### PR TITLE
fix #36: Improve project filtering in forms

### DIFF
--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -17,15 +17,15 @@ EMAIL_DIRECTOR_EMAIL_ADDRESS = import_from_settings(
 class ProjectSearchForm(forms.Form):
     """ Search form for the Project list page.
     """
-    LAST_NAME = 'Last Name'
-    USERNAME = 'Username'
+    LAST_NAME = 'Last Name (PI)'
+    USERNAME = 'Username (PI)'
     FIELD_OF_SCIENCE = 'Field of Science'
+    PROJECT_TITLE = 'Project Title'
 
-    last_name = forms.CharField(
-        label=LAST_NAME, max_length=100, required=False)
+    last_name = forms.CharField(label=LAST_NAME, max_length=100, required=False)
     username = forms.CharField(label=USERNAME, max_length=100, required=False)
-    field_of_science = forms.CharField(
-        label=FIELD_OF_SCIENCE, max_length=100, required=False)
+    field_of_science = forms.CharField(label=FIELD_OF_SCIENCE, max_length=100, required=False)
+    project_title = forms.CharField(label=PROJECT_TITLE, max_length=100, required=False)
     show_all_projects = forms.BooleanField(initial=False, required=False)
 
 

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -21,11 +21,13 @@ class ProjectSearchForm(forms.Form):
     USERNAME = 'Username (PI)'
     FIELD_OF_SCIENCE = 'Field of Science'
     PROJECT_TITLE = 'Project Title'
+    PROJECT_NAME = 'Project Name'
 
     last_name = forms.CharField(label=LAST_NAME, max_length=100, required=False)
     username = forms.CharField(label=USERNAME, max_length=100, required=False)
     field_of_science = forms.CharField(label=FIELD_OF_SCIENCE, max_length=100, required=False)
     project_title = forms.CharField(label=PROJECT_TITLE, max_length=100, required=False)
+    project_name = forms.CharField(label=PROJECT_NAME, max_length=100, required=False)
     show_all_projects = forms.BooleanField(initial=False, required=False)
 
 

--- a/coldfront/core/project/templates/project/project_archived_list.html
+++ b/coldfront/core/project/templates/project/project_archived_list.html
@@ -15,7 +15,7 @@
 <div class="mb-3" id="accordion">
   <div class="card">
     <div class="card-header">
-      <a id="expand_button" role="button" class="card-link " data-toggle="collapse" href="#collapseOne"> 
+      <a id="expand_button" role="button" class="card-link " data-toggle="collapse" href="#collapseOne">
         <i class="fas fa-filter" aria-hidden="true"></i> Filter
         <i id="plus_minus" class="fas {{expand_accordion|get_icon}} float-right"></i>
       </a>
@@ -45,6 +45,9 @@
           <a href="?order_by=id&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down"></i></a>
         </th>
         <th scope="col" class="text-nowrap">
+          Name
+        </th>
+        <th scope="col" class="text-nowrap">
           PIs
         </th>
         <th scope="col">Title and Description</th>
@@ -64,6 +67,7 @@
       {% for project in project_list %}
       <tr>
         <td><a href="/project/{{project.id}}/">{{ project.id }}</a></td>
+        <td>{{ project.name }}</td>
         <td>
           {% for pi in project.pis %}
             {{ pi.username }}<br>

--- a/coldfront/core/project/templates/project/project_join_list.html
+++ b/coldfront/core/project/templates/project/project_join_list.html
@@ -43,6 +43,9 @@ Project List
           <a href="?order_by=id&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down"></i></a>
         </th>
         <th scope="col" class="text-nowrap">
+          Name
+        </th>
+        <th scope="col" class="text-nowrap">
           PIs
         </th>
         <th scope="col">Title</th>
@@ -65,6 +68,7 @@ Project List
       {% for project in project_list %}
       <tr>
         <td><a href="/project/{{project.id}}/">{{ project.id }}</a></td>
+        <td>{{ project.name }}</td>
         <td>
           {% for pi in project.pis %}
             {{ pi.username }}<br>

--- a/coldfront/core/project/templates/project/project_join_list.html
+++ b/coldfront/core/project/templates/project/project_join_list.html
@@ -13,9 +13,9 @@ Project List
 <div class="mb-3" id="accordion">
   <div class="card">
     <div class="card-header">
-      <a id="expand_button" role="button" class="card-link " data-toggle="collapse" href="#collapseOne"> 
+      <a id="expand_button" role="button" class="card-link " data-toggle="collapse" href="#collapseOne">
         <i class="fas fa-filter" aria-hidden="true"></i> Filter
-        <i id="plus_minus" class="fas {{expand_accordion|get_icon}} float-right"></i>  
+        <i id="plus_minus" class="fas {{expand_accordion|get_icon}} float-right"></i>
       </a>
     </div>
     <div id="collapseOne" class="collapse {{expand_accordion}}" data-parent="#accordion">

--- a/coldfront/core/project/templates/project/project_list.html
+++ b/coldfront/core/project/templates/project/project_list.html
@@ -1,4 +1,7 @@
 {% extends "common/base.html" %} {% load common_tags %} {% load crispy_forms_tags %} {% load static %} {% block title %} Project List {% endblock %} {% block content %}
+        <th scope="col" class="text-nowrap">
+          Name
+        </th>
 
 
 
@@ -21,10 +24,10 @@
 <div class="mb-3" id="accordion">
   <div class="card">
     <div class="card-header">
-      
-      <a id="expand_button" role="button" class="card-link " data-toggle="collapse" href="#collapseOne"> 
+
+      <a id="expand_button" role="button" class="card-link " data-toggle="collapse" href="#collapseOne">
         <i class="fas fa-filter" aria-hidden="true"></i> Filter
-        <i id="plus_minus" class="fas {{expand_accordion|get_icon}} float-right"></i>  
+        <i id="plus_minus" class="fas {{expand_accordion|get_icon}} float-right"></i>
       </a>
     </div>
     <div id="collapseOne" class="collapse {{expand_accordion}}" data-parent="#accordion">
@@ -52,6 +55,9 @@
           <a href="?order_by=id&direction=des&{{filter_parameters}}"><i class="fas fa-sort-down"></i></a>
         </th>
         <th scope="col" class="text-nowrap">
+          Name
+        </th>
+        <th scope="col" class="text-nowrap">
           PIs
         </th>
         <th scope="col">Title</th>
@@ -71,6 +77,7 @@
       {% for project in project_list %}
       <tr>
         <td><a href="/project/{{project.id}}/">{{ project.id }}</a></td>
+        <td>{{ project.name }}</td>
         <td>
           {% for pi in project.pis %}
             {{ pi.username }}<br>

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -325,6 +325,10 @@ class ProjectArchivedListView(LoginRequiredMixin, ListView):
                 projects = projects.filter(
                     field_of_science__description__icontains=data.get('field_of_science'))
 
+            # Project Title
+            if data.get('project_title'):
+                projects = projects.filter(title__icontains=data.get('project_title'))
+
         else:
             projects = Project.objects.prefetch_related('field_of_science', 'status',).filter(
                 Q(status__name__in=['Archived', ]) &

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -207,6 +207,10 @@ class ProjectListView(LoginRequiredMixin, ListView):
             if data.get('project_title'):
                 projects = projects.filter(title__icontains=data.get('project_title'))
 
+            # Project Name
+            if data.get('project_name'):
+                projects = projects.filter(name__icontains=data.get('project_name'))
+
         else:
             projects = Project.objects.prefetch_related('field_of_science', 'status',).filter(
                 Q(status__name__in=['New', 'Active', ]) &
@@ -328,6 +332,10 @@ class ProjectArchivedListView(LoginRequiredMixin, ListView):
             # Project Title
             if data.get('project_title'):
                 projects = projects.filter(title__icontains=data.get('project_title'))
+
+            # Project Name
+            if data.get('project_name'):
+                projects = projects.filter(name__icontains=data.get('project_name'))
 
         else:
             projects = Project.objects.prefetch_related('field_of_science', 'status',).filter(
@@ -1277,6 +1285,10 @@ class ProjectJoinListView(ProjectListView):
             # Project Title
             if data.get('project_title'):
                 projects = projects.filter(title__icontains=data.get('project_title'))
+
+            # Project Name
+            if data.get('project_name'):
+                projects = projects.filter(name__icontains=data.get('project_name'))
 
         return projects.distinct()
 

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1270,6 +1270,10 @@ class ProjectJoinListView(ProjectListView):
                     field_of_science__description__icontains=data.get(
                         'field_of_science'))
 
+            # Project Title
+            if data.get('project_title'):
+                projects = projects.filter(title__icontains=data.get('project_title'))
+
         return projects.distinct()
 
     def get_context_data(self, **kwargs):

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -203,6 +203,10 @@ class ProjectListView(LoginRequiredMixin, ListView):
                 projects = projects.filter(
                     field_of_science__description__icontains=data.get('field_of_science'))
 
+            # Project Title
+            if data.get('project_title'):
+                projects = projects.filter(title__icontains=data.get('project_title'))
+
         else:
             projects = Project.objects.prefetch_related('field_of_science', 'status',).filter(
                 Q(status__name__in=['New', 'Active', ]) &


### PR DESCRIPTION
#36 

### CHANGES:
- clarified the meaning of `Lastname` and `Username` filter options in all Project search forms
- added option for case insensitive search on `Project.title` field in all Project search forms

### DISCUSS:
- filtering on `Project.name` instead? (not displayed in list view)