### PR TITLE
Automatically request cluster access on approval of join request

### DIFF
--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -1,4 +1,6 @@
 
+
+
 def add_project_status_choices(apps, schema_editor):
     ProjectStatusChoice = apps.get_model('project', 'ProjectStatusChoice')
 

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -1,6 +1,4 @@
 
-
-
 def add_project_status_choices(apps, schema_editor):
     ProjectStatusChoice = apps.get_model('project', 'ProjectStatusChoice')
 


### PR DESCRIPTION
Fixes #71

**Changes**
- Added method for requesting cluster access for a user under a specific compute allocation for a project.
- Added logic to generate cluster access requests when:
    - A user requests to join a project that does not require join approval,
    - A manager of a project that requires join approval approves a request,
    - A manager of a project changes the setting to no longer require join approvals, causing pending requests to be auto-approved.