### PR TITLE
Issue 14

### DIFF
--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -140,7 +140,10 @@ Project Detail
             <th>Role <a href="#" data-toggle="popover" title="Role" data-trigger="hover" data-content="Manager role grants user access to add/remove users, and allocations to the project."><i class="fas fa-info-circle"></i></a></th>
             <th>Cluster Username</th>
             <th>Project Access on Cluster</th>
-            <th>Actions</th>
+
+            {% if is_allowed_to_update_project %}
+              <th>Actions</th>
+            {% endif %}
           </tr>
         </thead>
         <tbody>
@@ -173,11 +176,11 @@ Project Detail
                 </span>
               {% endif %}
             </td>
-            <td>
-              {% if is_allowed_to_update_project %}
-                <a href="{% url 'project-user-detail' project.pk user.id %}"><i class="fas fa-user-edit"></i></a>
-              {% endif %}
-            </td>
+            {% if is_allowed_to_update_project %}
+              <td>
+                  <a href="{% url 'project-user-detail' project.pk user.id %}"><i class="fas fa-user-edit"></i></a>
+              </td>
+            {% endif %}
           </tr>
           {% endfor %}
         </tbody>

--- a/coldfront/core/project/templates/project/project_user_detail.html
+++ b/coldfront/core/project/templates/project/project_user_detail.html
@@ -38,6 +38,10 @@ Project User Detail
             <th scope="row">Role:</th>
             <td>{{project_user_obj.role}}</td>
           </tr>
+          <tr>
+            <th scope="row">Enable Notifications:</th>
+            <td>{{project_user_update_form.enable_notifications}}</td>
+          </tr>
         {% else %}
           <tr>
             <th scope="row">Role:</th>
@@ -59,9 +63,7 @@ Project User Detail
     </div>
   </div>
   <div class="card-footer">
-    {% if project_user_obj.user not in project_user_obj.project.pis %}
-      <button type="submit" class="btn btn-primary">Update</button>
-    {% endif %}
+    <button type="submit" class="btn btn-primary">Update</button>
     <a class="btn btn-secondary" href="{% url 'project-detail' project_obj.pk %}" role="button">Back to Project</a><br>
   </div>
 </div>

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1076,7 +1076,7 @@ class ProjectUserDetail(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
 
         if project_obj.status.name not in ['Active', 'New', ]:
             messages.error(request, 'You cannot update a user in an archived project.')
-            return HttpResponseRedirect(reverse('project-user-detail', kwargs={'pk': project_obj.pk}))
+            return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_obj.pk}))
 
         if project_obj.projectuser_set.filter(id=project_user_pk).exists():
             project_user_obj = project_obj.projectuser_set.get(pk=project_user_pk)

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -99,17 +99,17 @@ class ProjectDetailView(LoginRequiredMixin, UserPassesTestMixin, DetailView):
             context['is_allowed_to_archive_project'] = False
 
         # Can the user update the project?
+        context['is_allowed_to_update_project'] = False
+
         if self.request.user.is_superuser:
             context['is_allowed_to_update_project'] = True
+
         elif self.object.projectuser_set.filter(user=self.request.user).exists():
             project_user = self.object.projectuser_set.get(user=self.request.user)
-            if project_user.role.name in ('Principal Investigator', 'Manager'):
-                context['is_allowed_to_update_project'] = True
+
+            if project_user.role.name in ['Principal Investigator', 'Manager']:
                 context['username'] = project_user.user.username
-            else:
-                context['is_allowed_to_update_project'] = False
-        else:
-            context['is_allowed_to_update_project'] = False
+                context['is_allowed_to_update_project'] = True
 
         # Retrieve cluster access statuses.
         cluster_access_statuses = {}
@@ -1075,57 +1075,84 @@ class ProjectUserDetail(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
         project_user_pk = self.kwargs.get('project_user_pk')
 
         if project_obj.status.name not in ['Active', 'New', ]:
-            messages.error(
-                request, 'You cannot update a user in an archived project.')
-            return HttpResponseRedirect(reverse('project-user-detail', kwargs={'pk': project_user_pk}))
+            messages.error(request, 'You cannot update a user in an archived project.')
+            return HttpResponseRedirect(reverse('project-user-detail', kwargs={'pk': project_obj.pk}))
 
         if project_obj.projectuser_set.filter(id=project_user_pk).exists():
-            project_user_obj = project_obj.projectuser_set.get(
-                pk=project_user_pk)
-
-            pi_role = ProjectUserRoleChoice.objects.get(
-                name='Principal Investigator')
-            if project_user_obj.role == pi_role:
-                messages.error(
-                    request, 'PI role and email notification option cannot be changed.')
-                return HttpResponseRedirect(reverse('project-user-detail', kwargs={'pk': project_user_pk}))
+            project_user_obj = project_obj.projectuser_set.get(pk=project_user_pk)
+            managers = project_obj.projectuser_set.filter(role__name='Manager', status__name='Active')
+            project_pis = project_obj.projectuser_set.filter(role__name='Principal Investigator', status__name='Active')
 
             project_user_update_form = ProjectUserUpdateForm(request.POST,
                                                              initial={'role': project_user_obj.role.name,
                                                                       'enable_notifications': project_user_obj.enable_notifications})
 
+            is_request_by_superuser = project_obj.projectuser_set.filter(user=self.request.user,
+                                                                         role__name__in=['Manager',
+                                                                                         'Principal Investigator'],
+                                                                         status__name='Active').exists() or self.request.user.is_superuser
+
+            if project_user_obj.role.name == 'Principal Investigator':
+                enable_notifications = project_user_update_form.data.get('enable_notifications', 'off') == 'on'
+
+                # cannot disable when no manager(s) exists
+                if not managers.exists() and not enable_notifications:
+                    messages.error(request, 'PIs can disable notifications when at least one manager exists.')
+                else:
+                    project_user_obj.enable_notifications = enable_notifications
+                    project_user_obj.save()
+                    messages.success(request, 'User details updated.')
+
+                return HttpResponseRedirect(reverse('project-user-detail', kwargs={'pk': project_obj.pk, 'project_user_pk': project_user_obj.pk}))
+
             if project_user_update_form.is_valid():
                 form_data = project_user_update_form.cleaned_data
-                project_user_obj.enable_notifications = form_data.get('enable_notifications')
+                enable_notifications = form_data.get('enable_notifications')
 
                 old_role = project_user_obj.role
                 new_role = ProjectUserRoleChoice.objects.get(name=form_data.get('role'))
-                only_manager = not project_obj.projectuser_set.filter(~Q(pk=project_user_pk),
-                                                                      role__name='Manager').exists()
+                demotion = False
 
-                if old_role.name == 'Manager' and only_manager:
-                    if new_role.name == 'User':
-                        project_pis = project_obj.projectuser_set.filter(role__name='Principal Investigator')
+                # demote manager to user role
+                if old_role.name == 'Manager' and new_role.name == 'User':
+                    if not managers.filter(~Q(pk=project_user_pk)).exists():
 
+                        # no pis exist, cannot demote
                         if not project_pis.exists():
-                            # no pis exist, cannot demote
                             new_role = old_role
                             messages.error(
                                 request, 'The project must have at least one PI or manager with notifications enabled.')
+
+                        # enable all PI notifications, demote to user role
                         else:
-                            messages.warning(request, 'User {} is no longer a manager. All PIs will now receive notifications.'
-                                             .format(project_user_obj.user.username))
                             for pi in project_pis:
                                 pi.enable_notifications = True
                                 pi.save()
 
-                    elif new_role.name == 'Principal Investigator':
-                        project_user_obj.enable_notifications = True
+                            # users have notifications disabled by default
+                            enable_notifications = False
+                            demotion = True
 
+                            messages.warning(request, 'User {} is no longer a manager. All PIs will now receive notifications.'.format(
+                                project_user_obj.user.username))
+                            messages.success(request, 'User details updated.')
+
+                    else:
+                        demotion = True
+                        messages.success(request, 'User details updated.')
+
+                # promote user to manager role (notifications always active)
+                elif old_role.name == 'User' and new_role.name == 'Manager':
+                    enable_notifications = True
+                    messages.success(request, 'User details updated.')
+
+                project_user_obj.enable_notifications = enable_notifications
                 project_user_obj.role = new_role
                 project_user_obj.save()
 
-                messages.success(request, 'User details updated.')
+                if demotion and not is_request_by_superuser:
+                    return HttpResponseRedirect(reverse('project-detail', kwargs={'pk': project_obj.pk}))
+
                 return HttpResponseRedirect(reverse('project-user-detail', kwargs={'pk': project_obj.pk, 'project_user_pk': project_user_obj.pk}))
 
 


### PR DESCRIPTION
fixes #14 

### added features:
- Manager cannot turn off notifications
- Users cannot update notification settings themself
- PI(s) can disable notifications when manager(s) exist
- When promoting a user to Manager role, notifications are turned on by default
- When demoting a Manager to user role, notifications are turned off by default

### bug fixes:
- removed the empty `Actions` column for visitors with User role
- fixed `POST` request redirect errors in `/project/{id}/user-details/{user-id}` [`ProjectUserDetail` view]

### how to test
- updating notification settings/role of a User or Manager in a project should behave as expected