### PR TITLE
Send notification email to managers when user joins

### DIFF
--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -3,9 +3,15 @@ from coldfront.core.allocation.utils import request_project_cluster_access
 from coldfront.core.project.models import ProjectUser
 from coldfront.core.project.models import ProjectUserJoinRequest
 from coldfront.core.project.models import ProjectUserStatusChoice
+from coldfront.core.utils.common import import_from_settings
+from coldfront.core.utils.mail import send_email_template
 from collections import namedtuple
 from datetime import datetime
+from datetime import timedelta
 from django.conf import settings
+from django.db.models import Q
+from django.urls import reverse
+from urllib.parse import urljoin
 import logging
 import pytz
 
@@ -127,3 +133,49 @@ def auto_approve_project_join_requests():
                     JoinAutoApprovalResult(success=False, message=message))
 
     return results
+
+
+def __project_detail_url(project):
+    domain = import_from_settings('CENTER_BASE_URL')
+    view = reverse('project-detail', kwargs={'pk': project.pk})
+    return urljoin(domain, view)
+
+
+def __review_project_join_requests_url(project):
+    domain = import_from_settings('CENTER_BASE_URL')
+    view = reverse('project-review-join-requests', kwargs={'pk': project.pk})
+    return urljoin(domain, view)
+
+
+def send_project_join_notification_email(project, project_user):
+    """Send a notification email to the users of the given Project who
+    have email notifications enabled that the given ProjectUser has
+    requested to join it."""
+    email_enabled = import_from_settings('EMAIL_ENABLED', False)
+    if not email_enabled:
+        return
+
+    user = project_user.user
+
+    subject = f'New request to join Project {project.name}'
+    context = {
+        'project_name': project.name,
+        'user_string': f'{user.first_name} {user.last_name} ({user.email})',
+        'signature': import_from_settings('EMAIL_SIGNATURE', ''),
+    }
+
+    delay = project.joins_auto_approval_delay
+    if delay != timedelta():
+        template_name = 'email/new_project_join_request_delay.txt'
+        context['url'] = __review_project_join_requests_url(project)
+        context['delay'] = str(delay)
+    else:
+        template_name = 'email/new_project_join_request_no_delay.txt'
+        context['url'] = __project_detail_url(project)
+
+    sender = settings.EMAIL_SENDER
+    receiver_list = list(project.projectuser_set.filter(
+        Q(role__name='Principal Investigator', enable_notifications=True) |
+        Q(role__name='Manager')).values_list('user__email', flat=True))
+
+    send_email_template(subject, template_name, context, sender, receiver_list)

--- a/coldfront/core/user/utils.py
+++ b/coldfront/core/user/utils.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.db.models import Q
@@ -136,6 +137,8 @@ def __account_activation_url(user):
 
 
 def send_account_activation_email(user):
+    """Send an activation email to the given User, who has just created
+    an account, providing a link to activate the account."""
     email_enabled = import_from_settings('EMAIL_ENABLED', False)
     if not email_enabled:
         return
@@ -147,7 +150,10 @@ def send_account_activation_email(user):
         'activation_url': __account_activation_url(user),
         'signature': import_from_settings('EMAIL_SIGNATURE', ''),
     }
-    sender = import_from_settings('EMAIL_SENDER', ''),
+
+    # Using import_from_settings for EMAIL_SENDER returns a tuple, leading to
+    # an error.
+    sender = settings.EMAIL_SENDER
     receiver_list = [user.email, ]
 
     send_email_template(subject, template_name, context, sender, receiver_list)

--- a/coldfront/templates/email/new_project_join_request_delay.txt
+++ b/coldfront/templates/email/new_project_join_request_delay.txt
@@ -1,0 +1,8 @@
+Dear managers of {{ project_name }},
+
+User {{ user_string }} has requested to join your project.
+
+The request will automatically be approved after a delay of {{ delay }} hours. You may approve or deny it manually at {{ url }}.
+
+Thank you,
+{{ signature }}

--- a/coldfront/templates/email/new_project_join_request_no_delay.txt
+++ b/coldfront/templates/email/new_project_join_request_no_delay.txt
@@ -1,0 +1,8 @@
+Dear managers of {{ project_name }},
+
+User {{ user_string }} has requested to join your project.
+
+The request was automatically approved because the project is configured to approve join requests without delay. You may manage users and update settings at {{ url }}.
+
+Thank you,
+{{ signature }}


### PR DESCRIPTION
Refs #49

**Changes**
- Added logic to send an email to project managers, and PIs (who have notifications enabled), when a user requests to join.
    - The email text differs based on whether the project has an auto-approval delay for joins.
- Fixed bug causing account activation email to fail.