### PR TITLE
Add support for ABC cluster/project

### DIFF
--- a/coldfront/core/portal/templates/portal/authorized_home.html
+++ b/coldfront/core/portal/templates/portal/authorized_home.html
@@ -201,6 +201,36 @@
           {% endif %}
         </div>
       </div>
+      <div class="row">
+        <div class="col-lg-6 mt-2">
+          <h4>ABC</h4>
+          <hr>
+          {% if abc_projects %}
+            <ul class="list-group">
+              {% for project in project_list %}
+                {% if project.name in abc_projects %}
+                  <li class="list-group-item">
+                    <a href="{% url 'project-detail' project.pk %}">
+                      <i class="fa fa-folder fa-lg" aria-hidden="true"></i>
+                      {{ project.title }}
+                    </a>
+                    {% if project.needs_review %}
+                      <a href="{% url 'project-review' project.pk %}">
+                        <span class="badge badge-warning">Needs Review</span>
+                      </a>
+                    {% endif %}
+                  </li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          {% else %}
+            <div class="alert alert-info" role="alert">
+              <i class="fa fa-info-circle" aria-hidden="true"></i>
+              You are not part of any ABC projects at this time. Please click Join to join any of the existing projects.
+            </div>
+          {% endif %}
+        </div>
+      </div>
     {% else %}
       <div class="alert alert-info" role="alert">
         <i class="fa fa-info-circle" aria-hidden="true"></i>

--- a/coldfront/core/portal/views.py
+++ b/coldfront/core/portal/views.py
@@ -30,9 +30,11 @@ def home(request):
              Q(projectuser__status__name__in=['Active', ]))
         ).distinct().order_by('-created')
 
-        savio_projects, vector_projects = set(), set()
+        abc_projects, savio_projects, vector_projects = set(), set(), set()
         for project in project_list:
-            if project.name.startswith('vector_'):
+            if project.name == 'abc':
+                abc_projects.add(project.name)
+            elif project.name.startswith('vector_'):
                 vector_projects.add(project.name)
             else:
                 savio_projects.add(project.name)
@@ -46,6 +48,7 @@ def home(request):
            Q(allocationuser__status__name__in=['Active', ])
         ).distinct().order_by('-created')
         context['project_list'] = project_list
+        context['abc_projects'] = abc_projects
         context['savio_projects'] = savio_projects
         context['vector_projects'] = vector_projects
         context['allocation_list'] = allocation_list

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -30,6 +30,7 @@ class ProjectSearchForm(forms.Form):
 
     CLUSTER_NAME_CHOICES = [
         ('', '-----'),
+        ('ABC', 'ABC'),
         ('Savio', 'Savio'),
         ('Vector', 'Vector'),
     ]

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -40,12 +40,21 @@ def add_project_user_status_choices(apps, schema_editor):
         ProjectUserStatusChoice.objects.get_or_create(name=choice)
 
 
-def get_project_compute_allocation(project_obj):
-    """Return the given Project's Allocation to a Compute Resource."""
-    if project_obj.name.startswith('vector_'):
+def get_project_compute_resource_name(project_obj):
+    """Return the name of the Compute Resource that corresponds to the
+    given Project."""
+    if project_obj.name == 'abc':
+        resource_name = 'ABC Compute'
+    elif project_obj.name.startswith('vector_'):
         resource_name = 'Vector Compute'
     else:
         resource_name = 'Savio Compute'
+    return resource_name
+
+
+def get_project_compute_allocation(project_obj):
+    """Return the given Project's Allocation to a Compute Resource."""
+    resource_name = get_project_compute_resource_name(project_obj)
     return project_obj.allocation_set.get(resources__name=resource_name)
 
 

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -250,6 +250,7 @@ class ProjectListView(LoginRequiredMixin, ListView):
                     status__name__in=['New', 'Active', ]
                 ).annotate(
                     cluster_name=Case(
+                        When(name='abc', then=Value('ABC')),
                         When(name__startswith='vector_', then=Value('Vector')),
                         default=Value('Savio'),
                         output_field=CharField(),
@@ -262,6 +263,7 @@ class ProjectListView(LoginRequiredMixin, ListView):
                     Q(projectuser__status__name='Active')
                 ).annotate(
                     cluster_name=Case(
+                        When(name='abc', then=Value('ABC')),
                         When(name__startswith='vector_', then=Value('Vector')),
                         default=Value('Savio'),
                         output_field=CharField(),
@@ -311,6 +313,7 @@ class ProjectListView(LoginRequiredMixin, ListView):
                 Q(projectuser__status__name='Active')
             ).annotate(
                 cluster_name=Case(
+                    When(name='abc', then=Value('ABC')),
                     When(name__startswith='vector_', then=Value('Vector')),
                     default=Value('Savio'),
                     output_field=CharField(),
@@ -1573,6 +1576,7 @@ class ProjectJoinListView(ProjectListView, UserPassesTestMixin):
                 status__name__in=['New', 'Active', ]
         ).annotate(
             cluster_name=Case(
+                When(name='abc', then=Value('ABC')),
                 When(name__startswith='vector_', then=Value('Vector')),
                 default=Value('Savio'),
                 output_field=CharField(),

--- a/coldfront/core/utils/management/commands/add_brc_accounting_defaults.py
+++ b/coldfront/core/utils/management/commands/add_brc_accounting_defaults.py
@@ -21,6 +21,7 @@ class Command(BaseCommand):
         resources = [
             ('Savio Compute', 'Savio cluster compute access'),
             ('Vector Compute', 'Vector cluster compute access'),
+            ('ABC Compute', 'ABC cluster compute access'),
         ]
         for name, description in resources:
             # Allocations to a cluster must have the corresponding Resource.


### PR DESCRIPTION
Fixes #84

**Changes**
- Added handling to create the "ABC Compute" `Resource`.
- Added a step to create the "abc" `Project` with the PI manually set.
- Added a step to create allocation-related objects for the "abc" `Project`, and refactored relevant code.
- Added filtering on cluster ABC when listing projects.
- Included ABC projects (i.e., just `abc`) for display on the home page.

**How to Test**
- Manual Testing
    - Run the following commands in order:
        - `python manage.py add_brc_accounting_defaults` (creates "ABC Compute" `Resource`)
        - `python manage.py create_existing_brc_data` (creates "abc" `Project`)
        - `python manage.py load_brc_allocation_data` (sets up allocation-related objects for "abc" `Project`)
    - Navigate to the list view for joining a project. Ensure that the "ABC" cluster can be used to filter projects, and that the "abc" project exists.
    - Navigate to the home page.
        - There should be a new section for ABC.
        - Only the PI of the project should see the "abc" project listed.