### PR TITLE
remove weird "Name" on project_list.html

### DIFF
--- a/coldfront/core/project/templates/project/project_list.html
+++ b/coldfront/core/project/templates/project/project_list.html
@@ -1,9 +1,4 @@
 {% extends "common/base.html" %} {% load common_tags %} {% load crispy_forms_tags %} {% load static %} {% block title %} Project List {% endblock %} {% block content %}
-        <th scope="col" class="text-nowrap">
-          Name
-        </th>
-
-
 
 <div class="card mb-3 bg-light">
   <div class="card-body">


### PR DESCRIPTION
remove that weird "Name" `<tr>` from `project_list`
<img width="1343" alt="temp" src="https://user-images.githubusercontent.com/16427330/113598988-96bb9c00-965b-11eb-812b-5c59fba280d5.png">

cant figure out how/when this got past us

