### PR TITLE
Display timestamps in America/Los_Angeles

### DIFF
--- a/coldfront/core/project/templates/project/project_join_list.html
+++ b/coldfront/core/project/templates/project/project_join_list.html
@@ -26,7 +26,7 @@ Project List
           <th scope="col" class="text-nowrap">PIs</th>
           <th scope="col">Title</th>
           <th scope="col">Cluster</th>
-          <th scope="col" class="text-nowrap">Auto-Approval Time (UTC)</th>
+          <th scope="col" class="text-nowrap">Auto-Approval Time</th>
         </tr>
       </thead>
       <tbody>

--- a/coldfront/core/project/templates/project/project_request/savio/project_request_detail.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_detail.html
@@ -2,6 +2,7 @@
 {% load crispy_forms_tags %}
 {% load common_tags %}
 {% load static %}
+{% load iso8601_to_datetime %}
 
 
 {% block title %}
@@ -61,7 +62,7 @@ Savio Project Request Detail
                   </p>
                   <p>
                     <strong>Timestamp:</strong>
-                    {{ denial_reason.timestamp }}
+                    {{ denial_reason.timestamp|iso8601_to_datetime }}
                   </p>
                   <p>If you have any questions or concerns, please contact us at {{ support_email }}.</p>
                 {% endif %}
@@ -108,11 +109,11 @@ Savio Project Request Detail
                     </span>
                   {% elif eligibility.status == 'Approved' %}
                     <span class="badge badge-success">
-                      {{ eligibility.status }} {{ eligibility.timestamp }}
+                      {{ eligibility.status }} {{ eligibility.timestamp|iso8601_to_datetime }}
                     </span>
                   {% else %}
                     <span class="badge badge-danger">
-                      {{ eligibility.status }} {{ eligibility.timestamp }}
+                      {{ eligibility.status }} {{ eligibility.timestamp|iso8601_to_datetime }}
                     </span>
                   {% endif %}
                 </td>
@@ -135,11 +136,11 @@ Savio Project Request Detail
                     </span>
                   {% elif readiness.status == 'Approved' %}
                     <span class="badge badge-success">
-                      {{ readiness.status }} {{ readiness.timestamp }}
+                      {{ readiness.status }} {{ readiness.timestamp|iso8601_to_datetime }}
                     </span>
                   {% else %}
                     <span class="badge badge-danger">
-                      {{ readiness.status }} {{ readiness.timestamp }}
+                      {{ readiness.status }} {{ readiness.timestamp|iso8601_to_datetime }}
                     </span>
                   {% endif %}
                 </td>
@@ -168,7 +169,7 @@ Savio Project Request Detail
                     </span>
                   {% else %}
                     <span class="badge badge-success">
-                      {{ setup.status }} {{ setup.timestamp }}
+                      {{ setup.status }} {{ setup.timestamp|iso8601_to_datetime }}
                     </span>
                   {% endif %}
                 </td>

--- a/coldfront/core/project/templates/project/project_request/vector/project_request_detail.html
+++ b/coldfront/core/project/templates/project/project_request/vector/project_request_detail.html
@@ -2,6 +2,7 @@
 {% load crispy_forms_tags %}
 {% load common_tags %}
 {% load static %}
+{% load iso8601_to_datetime %}
 
 
 {% block title %}
@@ -61,7 +62,7 @@ Vector Project Request Detail
                   </p>
                   <p>
                     <strong>Timestamp:</strong>
-                    {{ denial_reason.timestamp }}
+                    {{ denial_reason.timestamp|iso8601_to_datetime }}
                   </p>
                   <p>If you have any questions or concerns, please contact us at {{ support_email }}.</p>
                 {% endif %}
@@ -108,11 +109,11 @@ Vector Project Request Detail
                   </span>
                 {% elif eligibility.status == 'Approved' %}
                   <span class="badge badge-success">
-                    {{ eligibility.status }} {{ eligibility.timestamp }}
+                    {{ eligibility.status }} {{ eligibility.timestamp|iso8601_to_datetime }}
                   </span>
                 {% else %}
                   <span class="badge badge-danger">
-                    {{ eligibility.status }} {{ eligibility.timestamp }}
+                    {{ eligibility.status }} {{ eligibility.timestamp|iso8601_to_datetime }}
                   </span>
                 {% endif %}
               </td>
@@ -135,7 +136,7 @@ Vector Project Request Detail
                   </span>
                 {% else %}
                   <span class="badge badge-success">
-                    {{ setup.status }} {{ setup.timestamp }}
+                    {{ setup.status }} {{ setup.timestamp|iso8601_to_datetime }}
                   </span>
                 {% endif %}
               </td>

--- a/coldfront/core/project/templates/project/project_review_join_requests.html
+++ b/coldfront/core/project/templates/project/project_review_join_requests.html
@@ -26,7 +26,7 @@
               <th scope="col">Last Name</th>
               <th scope="col">Email</th>
               <th scope="col">Role</th>
-              <th scope="col">Auto-Approval Time (UTC)</th>
+              <th scope="col">Auto-Approval Time</th>
             </tr>
           </thead>
           <tbody>

--- a/coldfront/core/project/templatetags/iso8601_to_datetime.py
+++ b/coldfront/core/project/templatetags/iso8601_to_datetime.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from django import template
+from django.template.defaultfilters import stringfilter
+
+
+register = template.Library()
+
+
+@register.filter
+@stringfilter
+def iso8601_to_datetime(s):
+    return datetime.fromisoformat(s)

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -22,6 +22,7 @@ from datetime import timedelta
 from decimal import Decimal
 from django.conf import settings
 from django.db.models import Q
+
 from django.urls import reverse
 from urllib.parse import urljoin
 import logging

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -2286,6 +2286,9 @@ class SavioProjectRequestDetailView(LoginRequiredMixin, UserPassesTestMixin,
                 savio_request_latest_update_timestamp(self.request_obj)
             if not latest_update_timestamp:
                 latest_update_timestamp = 'No updates yet.'
+            else:
+                latest_update_timestamp = datetime.datetime.fromisoformat(
+                    latest_update_timestamp)
         except Exception as e:
             self.logger.exception(e)
             messages.error(self.request, self.error_message)
@@ -2822,6 +2825,9 @@ class VectorProjectRequestDetailView(LoginRequiredMixin, UserPassesTestMixin,
                 vector_request_latest_update_timestamp(self.request_obj)
             if not latest_update_timestamp:
                 latest_update_timestamp = 'No updates yet.'
+            else:
+                latest_update_timestamp = datetime.datetime.fromisoformat(
+                    latest_update_timestamp)
         except Exception as e:
             self.logger.exception(e)
             messages.error(self.request, self.error_message)

--- a/coldfront/templates/common/base.html
+++ b/coldfront/templates/common/base.html
@@ -1,5 +1,8 @@
 {% load static %}
 
+{% load tz %}
+{% timezone "America/Los_Angeles" %}
+
 <!DOCTYPE html>
 <html lang="en">
 
@@ -66,3 +69,5 @@
 </body>
 
 </html>
+
+{% endtimezone %}


### PR DESCRIPTION
Fixes #93

**Changes**
- Specified timezone `America/Los_Angeles` in the base template, inherited by all other templates, so that all timestamps are displayed in that zone.
- Added a template tag that converts an ISO 8601-compliant string into a `datetime` object.