### PR TITLE
Handle edge cases with joining pending projects

### DIFF
--- a/coldfront/core/project/templates/project/project_add_users.html
+++ b/coldfront/core/project/templates/project/project_add_users.html
@@ -29,7 +29,7 @@ Add Users to Project
 <div class="col" id="search_results" >
     <div class="card border-light">
       <div class="card-body">
-        <p>You may only add users who have signed the access agreement.</p>
+        <p>You may only add users who have signed the access agreement. In addition, users who have requests to join this project appear <a href="{% url 'project-review-join-requests' project.pk %}">here</a>.</p>
         <div id="search_results_inner"></div>
       </div>
     </div>

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -73,16 +73,23 @@ def get_project_compute_allocation(project_obj):
 def auto_approve_project_join_requests():
     """Approve each request to join a Project that has completed its
     delay period. Return the results of each approval attempt, where
-    each result has a 'success' boolean and a string message."""
+    each result has a 'success' boolean and a string message.
+
+    Because users are allowed to join 'New' Projects, only requests that
+    are for 'Active' projects should be considered. Handling elsewhere
+    should replace all join requests for a Project when it goes from
+    'New' to 'Active'."""
     JoinAutoApprovalResult = namedtuple(
         'JoinAutoApprovalResult', 'success message')
 
     pending_status = ProjectUserStatusChoice.objects.get(
         name='Pending - Add')
     active_status = ProjectUserStatusChoice.objects.get(name='Active')
+    project_active_status = ProjectStatusChoice.objects.get(name='Active')
+
     project_user_objs = ProjectUser.objects.prefetch_related(
         'project', 'project__allocation_set', 'projectuserjoinrequest_set'
-    ).filter(status=pending_status)
+    ).filter(status=pending_status, project__status=project_active_status)
 
     now = utc_now_offset_aware()
     results = []


### PR DESCRIPTION
Fixes #120

**Changes**
- Prevented users who are requesters or PIs on pending `Savio/VectorProjectAllocationRequests` from joining the project in question.
- Added `Project.save` to update any pending `ProjectUserJoinRequests` when a `Project`'s status changes to "Active" or "Denied".
    - "Active": Only the latest join request is considered when auto-approving joins, so create a new object with the current time, so the delay begins now.
    - "Denied": Deny any pending join requests.
- Only auto-approve join requests for "Active" projects.