### PR TITLE
float right for coherency in user profile

### DIFF
--- a/coldfront/core/user/templates/user/user_profile.html
+++ b/coldfront/core/user/templates/user/user_profile.html
@@ -103,7 +103,7 @@ User Profile{% if not user == viewed_user %}: {{ viewed_user.username }}{% endif
                 Unsigned
               </span>
               {% if user == viewed_user %}
-                <a href="{% url 'user-access-agreement' %}" class="btn btn-secondary">
+                <a href="{% url 'user-access-agreement' %}" class="btn btn-secondary float-right">
                   <i class="far fa-edit" aria-hidden="true"></i>
                   Review and Sign
                 </a>


### PR DESCRIPTION
make the `review and sign` button float right to better match the button styles on the page.

note:
- this will align with the phone number update button as well

new look:
<img width="752" alt="Untitled" src="https://user-images.githubusercontent.com/16427330/116099698-d8bf8700-a6c9-11eb-84c5-5bf688017e48.png">
