### PR TITLE
Add clarifying help text about usernames, passwords, and projects

### DIFF
--- a/coldfront/core/portal/templates/portal/authorized_home.html
+++ b/coldfront/core/portal/templates/portal/authorized_home.html
@@ -6,7 +6,7 @@
     <hr>
 
     <p>If you would like to set up or update your access to a cluster, please complete the following steps.</p>
-    <p>First Review and Sign the cluster user agreement. Only then you can Join a cluster project and gain access to the cluster.</p>
+    <p>First review and sign the cluster user agreement. Only then you can join a cluster project and gain access to the cluster.</p>
     <table class="table">
       <thead>
         <tr>
@@ -46,7 +46,17 @@
           {% endif %}
         </tr>
         <tr>
-          <td>2. Create or join a project.</td>
+          <td>
+            2. Create or join a project.
+            <i
+              class="fas fa-question-circle"
+              aria-hidden="true"
+              data-toggle="tooltip"
+              data-placement="top"
+              title="A project corresponds to an allowance (e.g., FCA, Condo, etc.) and provides access to a Slurm account on the cluster.">
+            </i>
+          </td>
+
           {% if user.userprofile.access_agreement_signed_date is not None %}
             <td>
               {% if project_list %}
@@ -341,4 +351,11 @@
   $("#navbar-main > ul > li.active").removeClass("active");
   $("#navbar-home").addClass("active");
 </script>
+
+<script>
+  $(function () {
+    $('[data-toggle="tooltip"]').tooltip()
+  })
+</script>
+
 {% endblock %}

--- a/coldfront/core/project/templates/project/project_join_list.html
+++ b/coldfront/core/project/templates/project/project_join_list.html
@@ -11,7 +11,7 @@ Project List
 <h1>Join a Project</h1><hr>
 <h5>Pending Join Requests</h5>
   {% if user.userprofile.access_agreement_signed_date is None %}
-    <p>First Review and Sign the cluster user agreement. Only then you can Join a cluster project and gain access to the cluster.</p>
+    <p>First review and sign the cluster user agreement. Only then you can join a cluster project and gain access to the cluster.</p>
   {% elif not join_requests %}
     <div class="alert alert-info" role="alert">
       <i class="fa fa-info-circle" aria-hidden="true"></i>

--- a/coldfront/core/project/templates/project/project_request/project_request.html
+++ b/coldfront/core/project/templates/project/project_request/project_request.html
@@ -14,6 +14,12 @@ Project Request
 <hr>
 
 <div class="row">
+  <div class="col-lg-12 mt-2">
+    <p>Request to create a new project (Slurm account) on the Savio or Vector cluster. You may also request to <a href="{% url 'project-join-list' %}">join</a> an existing project.</p>
+  </div>
+</div>
+
+<div class="row">
   <div class="col-lg-6 mt-2">
     <select
         class="form-control"

--- a/coldfront/core/user/forms.py
+++ b/coldfront/core/user/forms.py
@@ -53,7 +53,7 @@ class UserRegistrationForm(UserCreationForm):
     password1 = forms.CharField(
         help_text=(
             'This password is unique to this portal, and is separate from the '
-            'OTP and PIN used to access the cluster.'),
+            'PIN and OTP used to access the cluster.'),
         label='Enter Password', widget=forms.PasswordInput())
     password2 = forms.CharField(
         label='Confirm Password', widget=forms.PasswordInput())
@@ -124,7 +124,7 @@ class UserLoginForm(AuthenticationForm):
             'CalNet username.')
         self.fields['password'].help_text = (
             'This password is unique to this portal, and is neither your '
-            'CalNet password nor the OTP and PIN used to access the BRC '
+            'CalNet password nor the PIN and OTP used to access the BRC '
             'cluster.')
 
     def clean_username(self):

--- a/coldfront/core/user/forms.py
+++ b/coldfront/core/user/forms.py
@@ -33,11 +33,11 @@ class UserRegistrationForm(UserCreationForm):
     email = forms.EmailField(
         label='Email Address', widget=forms.EmailInput(),
         help_text=(
-            'If the individual has an @berkeley.edu email address, please '
-            'provide that to avoid delays in processing. All communication is '
-            'sent to this email. Please provide a valid address. If this '
-            'communication address changes, it is the user\'s responsibility '
-            'to give us his/her new email address.'))
+            'If you have an @berkeley.edu email address, please provide it to '
+            'avoid delays in processing. All communication is sent to this '
+            'email. Please provide a valid address. If this communication '
+            'address changes, it is your responsibility to update it in this '
+            'portal.'))
 
     first_name = forms.CharField(
         label='First Name',
@@ -51,6 +51,9 @@ class UserRegistrationForm(UserCreationForm):
         help_text='The number must be in E.164 format (e.g. +12125552368).',
         label='Phone Number', required=False)
     password1 = forms.CharField(
+        help_text=(
+            'This password is unique to this portal, and is separate from the '
+            'OTP and PIN used to access the cluster.'),
         label='Enter Password', widget=forms.PasswordInput())
     password2 = forms.CharField(
         label='Confirm Password', widget=forms.PasswordInput())
@@ -112,6 +115,17 @@ class UserLoginForm(AuthenticationForm):
             'Please enter a correct username or verified email address, and '
             'password. Note that both fields may be case-sensitive.'),
     }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['username'].help_text = (
+            'This is your BRC cluster account username if you have one, or '
+            'any of the verified email addresses associated with it, not your '
+            'CalNet username.')
+        self.fields['password'].help_text = (
+            'This password is unique to this portal, and is neither your '
+            'CalNet password nor the OTP and PIN used to access the BRC '
+            'cluster.')
 
     def clean_username(self):
         cleaned_data = super().clean()

--- a/coldfront/core/user/templates/user/login.html
+++ b/coldfront/core/user/templates/user/login.html
@@ -28,10 +28,7 @@ Log In
     </div>
     <div class="card-body">
       <p>
-        You may authenticate using your cluster username or any of the <i>verified</i> email addresses associated with your account.
-      </p>
-      <p>
-        If this is your first time visting the portal, please <a href="{% url 'password-reset' %}">set your password</a> to activate your account.
+        If you are an existing BRC cluster user and this is your first time visiting the portal, please <a href="{% url 'password-reset' %}">set your password</a> to activate your account.
       </p>
       <hr>
       {% include "user/login_form.html" %} 

--- a/coldfront/core/user/templates/user/passwords/password_change_form.html
+++ b/coldfront/core/user/templates/user/passwords/password_change_form.html
@@ -19,7 +19,7 @@ Change Password
       <h5>Change Password</h5>
     </div>
     <div class="card-body">
-      <p>Change your portal password. Note that this does not change the OTP and PIN used to access the BRC cluster.</p>
+      <p>Change your portal password. Note that this does not change the PIN and OTP used to access the BRC cluster.</p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}

--- a/coldfront/core/user/templates/user/passwords/password_change_form.html
+++ b/coldfront/core/user/templates/user/passwords/password_change_form.html
@@ -19,6 +19,7 @@ Change Password
       <h5>Change Password</h5>
     </div>
     <div class="card-body">
+      <p>Change your portal password. Note that this does not change the OTP and PIN used to access the BRC cluster.</p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}

--- a/coldfront/core/user/templates/user/passwords/password_reset_complete.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_complete.html
@@ -19,7 +19,7 @@ Password Set
       <h5>Password Set</h5>
     </div>
     <div class="card-body">
-      <p>Your portal password has been set. Note that you still need to use your OTP and PIN to access the cluster.</p>
+      <p>Your portal password has been set. Note that you still need to use your PIN and OTP to access the cluster.</p>
       <a href="{% url 'login' %}" class="btn btn-primary btn-block">
         <i class="fas fa-sign-in-alt" aria-hidden="true"></i> Log In
       </a>

--- a/coldfront/core/user/templates/user/passwords/password_reset_complete.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_complete.html
@@ -19,7 +19,7 @@ Password Set
       <h5>Password Set</h5>
     </div>
     <div class="card-body">
-      <p>Your password has been set.</p>
+      <p>Your portal password has been set. Note that you still need to use your OTP and PIN to access the cluster.</p>
       <a href="{% url 'login' %}" class="btn btn-primary btn-block">
         <i class="fas fa-sign-in-alt" aria-hidden="true"></i> Log In
       </a>

--- a/coldfront/core/user/templates/user/passwords/password_reset_confirm.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_confirm.html
@@ -19,7 +19,7 @@ Set Password
       <h5>Set Password</h5>
     </div>
     <div class="card-body">
-      <p>Set your portal password. Note that this does not change the OTP and PIN used to access the BRC cluster.</p>
+      <p>Set your portal password. Note that this does not change the PIN and OTP used to access the BRC cluster.</p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}

--- a/coldfront/core/user/templates/user/passwords/password_reset_confirm.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_confirm.html
@@ -19,6 +19,7 @@ Set Password
       <h5>Set Password</h5>
     </div>
     <div class="card-body">
+      <p>Set your portal password. Note that this does not change the OTP and PIN used to access the BRC cluster.</p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}

--- a/coldfront/core/user/templates/user/passwords/password_reset_done.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_done.html
@@ -20,7 +20,7 @@ Password Reset Sent
     </div>
     <div class="card-body">
       <p>
-        If the email address you entered is associated with an active account, please check the address for instructions to reset your password.
+        If the email address you entered is associated with an active account and was previously verified by you, please check the address for instructions to reset your portal password.
       </p>
       <p>
         If you don't receive an email, please double check the address you entered and check your spam folder.

--- a/coldfront/core/user/templates/user/passwords/password_reset_email.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_email.html
@@ -4,6 +4,8 @@
 
 {% blocktrans %}You're receiving this email because you requested a password reset for your MyBRC portal account at {{ site_name }}.{% endblocktrans %}
 
+{% blocktrans %}As a reminder, this password is unique to the portal, and does not change the OTP and PIN used to access the BRC cluster.{% endblocktrans %}
+
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}
 {{ protocol }}://{{ domain }}{% url 'password-reset-confirm' uidb64=uid token=token %}

--- a/coldfront/core/user/templates/user/passwords/password_reset_email.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_email.html
@@ -4,7 +4,7 @@
 
 {% blocktrans %}You're receiving this email because you requested a password reset for your MyBRC portal account at {{ site_name }}.{% endblocktrans %}
 
-{% blocktrans %}As a reminder, this password is unique to the portal, and does not change the OTP and PIN used to access the BRC cluster.{% endblocktrans %}
+{% blocktrans %}As a reminder, this password is unique to the portal, and does not change the PIN and OTP used to access the BRC cluster.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}

--- a/coldfront/core/user/templates/user/passwords/password_reset_form.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_form.html
@@ -19,6 +19,7 @@ Reset Password
       <h5>Reset Password</h5>
     </div>
     <div class="card-body">
+      <p>Reset your portal password by providing a verified email address associated with your account. Note that this does not change the OTP and PIN used to access the BRC cluster.</p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}

--- a/coldfront/core/user/templates/user/passwords/password_reset_form.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_form.html
@@ -19,7 +19,7 @@ Reset Password
       <h5>Reset Password</h5>
     </div>
     <div class="card-body">
-      <p>Reset your portal password by providing a verified email address associated with your account. Note that this does not change the OTP and PIN used to access the BRC cluster.</p>
+      <p>Reset your portal password by providing a verified email address associated with your account. Note that this does not change the PIN and OTP used to access the BRC cluster.</p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}

--- a/coldfront/core/user/views.py
+++ b/coldfront/core/user/views.py
@@ -360,7 +360,10 @@ class CustomPasswordChangeView(PasswordChangeView):
     success_url = reverse_lazy('user-profile')
 
     def form_valid(self, form):
-        messages.success(self.request, 'Your password has been changed.')
+        message = (
+            'Your portal password has been changed. Note that you still need '
+            'to use your OTP and PIN to access the cluster.')
+        messages.success(self.request, message)
         return super().form_valid(form)
 
 

--- a/coldfront/core/user/views.py
+++ b/coldfront/core/user/views.py
@@ -362,7 +362,7 @@ class CustomPasswordChangeView(PasswordChangeView):
     def form_valid(self, form):
         message = (
             'Your portal password has been changed. Note that you still need '
-            'to use your OTP and PIN to access the cluster.')
+            'to use your PIN and OTP to access the cluster.')
         messages.success(self.request, message)
         return super().form_valid(form)
 


### PR DESCRIPTION
Refs #127

**Changes**
- Added help text that the username is not the CalNet username, and that the password is not the CalNet password or the PIN + OTP combination.
- Added minimal help text explaining the relationship between projects and Slurm accounts.