### PR TITLE
Clarify requester-related logic with landing pages; send email to PI when different from requester

### DIFF
--- a/coldfront/core/project/templates/project/project_request/project_request.html
+++ b/coldfront/core/project/templates/project/project_request/project_request.html
@@ -19,8 +19,8 @@ Project Request
         class="form-control"
         onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
       <option value="">Select a cluster.</option>
-      <option value="{% url 'savio-project-request' %}">Savio</option>
-      <option value="{% url 'vector-project-request' %}">Vector</option>
+      <option value="{% url 'project-request-savio-landing' %}">Savio</option>
+      <option value="{% url 'project-request-vector-landing' %}">Vector</option>
     </select>
   </div>
 </div>

--- a/coldfront/core/project/templates/project/project_request/savio/project_request_landing.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_landing.html
@@ -1,0 +1,49 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+New Savio Project
+{% endblock %}
+
+
+{% block head %}
+{{ wizard.form.media }}
+{% endblock %}
+
+
+{% block content %}
+<h1>New Savio Project</h1><hr>
+
+<p>
+  Eligible users may request to create a new project on the Savio cluster, or
+  pool their allocations with those of existing projects. The following
+  allocation types are available:
+</p>
+<ul>
+  <li>Faculty Compute Allowance (FCA)</li>
+  <li>Condo Allowance</li>
+  <li>Partner Compute Allowance (PCA)</li>
+</ul>
+<p>
+  This form is intended for Principal Investigators (PIs) or users acting on
+  behalf of PIs. The user who fills it out will become a manager on the
+  project: the user will receive access to the project on the cluster, will
+  have permissions to manage the project and its users, and cannot opt out of
+  email notifications (unless at least one other user becomes a manager). If
+  this does not sound like your role on the project, please ask the appropriate
+  user to fill it out.
+</p>
+<p>
+  If you are filling out the form on behalf of another PI, that PI will be
+  notified by email that a request is being made by you.
+</p>
+<a class="btn btn-primary" href="{% url 'savio-project-request' %}">
+  Continue
+</a>
+<a class="btn btn-secondary" href="{% url 'project-request' %}">
+  Back
+</a>
+
+{% endblock %}

--- a/coldfront/core/project/templates/project/project_request/vector/project_request_landing.html
+++ b/coldfront/core/project/templates/project/project_request/vector/project_request_landing.html
@@ -1,0 +1,42 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+New Vector Project
+{% endblock %}
+
+
+{% block head %}
+{{ wizard.form.media }}
+{% endblock %}
+
+
+{% block content %}
+<h1>New Vector Project</h1><hr>
+
+<p>
+  Eligible users may request to create a new project on the Vector cluster.
+</p>
+<p>
+  This form is intended to be filled out by the project lead, although the
+  Principal Investigator will be set to a pre-defined user. The user who fills
+  it out will become a manager on the project: the user will receive access to
+  the project on the cluster, will have permissions to manage the project and
+  its users, and cannot opt out of email notifications (unless at least one
+  other user becomes a manager). If this does not sound like your role on the
+  project, please ask the appropriate user to fill it out.
+</p>
+<p>
+  After approval, you will also automatically gain access to the Savio cluster
+  under the co_rosalind project.
+</p>
+<a class="btn btn-primary" href="{% url 'vector-project-request' %}">
+  Continue
+</a>
+<a class="btn btn-secondary" href="{% url 'project-request' %}">
+  Back
+</a>
+
+{% endblock %}

--- a/coldfront/core/project/urls.py
+++ b/coldfront/core/project/urls.py
@@ -47,18 +47,25 @@ from coldfront.core.project.views import VectorProjectRequestListView
 from coldfront.core.project.views import VectorProjectRequestView
 from coldfront.core.project.views import VectorProjectReviewEligibilityView
 from coldfront.core.project.views import VectorProjectReviewSetupView
+from django.views.generic import TemplateView
 
 
 urlpatterns += [
     path('project-request/',
          ProjectRequestView.as_view(),
          name='project-request'),
+    path('project-request-savio-landing/',
+         TemplateView.as_view(
+             template_name=(
+                 'project/project_request/savio/project_request_landing.html')
+         ),
+         name='project-request-savio-landing'),
     path('savio-project-request/', SavioProjectRequestWizard.as_view(
-        condition_dict={
-            '2': show_new_pi_form_condition,
-            '4': show_pooled_project_selection_form_condition,
-            '5': show_details_form_condition,
-            }),
+         condition_dict={
+             '2': show_new_pi_form_condition,
+             '4': show_pooled_project_selection_form_condition,
+             '5': show_details_form_condition,
+         }),
          name='savio-project-request'),
     path('savio-project-pending-request-list/',
          SavioProjectRequestListView.as_view(completed=False),
@@ -81,6 +88,12 @@ urlpatterns += [
     path('savio-project-request/<int:pk>/deny/',
          SavioProjectReviewDenyView.as_view(),
          name='savio-project-request-review-deny'),
+    path('project-request-vector-landing/',
+         TemplateView.as_view(
+             template_name=(
+                 'project/project_request/vector/project_request_landing.html')
+         ),
+         name='project-request-vector-landing'),
     path('vector-project-request/',
          VectorProjectRequestView.as_view(),
          name='vector-project-request'),

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -2004,7 +2004,8 @@ from coldfront.core.project.forms import VectorProjectReviewSetupForm
 from coldfront.core.project.models import SavioProjectAllocationRequest
 from coldfront.core.project.models import VectorProjectAllocationRequest
 from coldfront.core.project.utils import savio_request_state_status
-from coldfront.core.project.utils import send_new_project_request_notification_email
+from coldfront.core.project.utils import send_new_project_request_admin_notification_email
+from coldfront.core.project.utils import send_new_project_request_pi_notification_email
 from coldfront.core.project.utils import vector_request_state_status
 from coldfront.core.user.models import UserProfile
 from formtools.wizard.views import SessionWizardView
@@ -2159,11 +2160,19 @@ class SavioProjectRequestWizard(UserPassesTestMixin, SessionWizardView):
 
             # Send a notification email to admins.
             try:
-                send_new_project_request_notification_email(request)
+                send_new_project_request_admin_notification_email(request)
             except Exception as e:
                 self.logger.error(
                     'Failed to send notification email. Details:\n')
                 self.logger.exception(e)
+            # Send a notification email to the PI if the requester differs.
+            if request.requester != request.pi:
+                try:
+                    send_new_project_request_pi_notification_email(request)
+                except Exception as e:
+                    self.logger.error(
+                        'Failed to send notification email. Details:\n')
+                    self.logger.exception(e)
         except Exception as e:
             self.logger.exception(e)
             message = 'Unexpected failure. Please contact an administrator.'
@@ -2887,7 +2896,7 @@ class VectorProjectRequestView(LoginRequiredMixin, UserPassesTestMixin,
 
             # Send a notification email to admins.
             try:
-                send_new_project_request_notification_email(request)
+                send_new_project_request_admin_notification_email(request)
             except Exception as e:
                 self.logger.error(
                     'Failed to send notification email. Details:\n')

--- a/coldfront/templates/email/project_request/pi_new_project_request.txt
+++ b/coldfront/templates/email/project_request/pi_new_project_request.txt
@@ -1,0 +1,12 @@
+Dear {{ pi_str }},
+
+A user ({{ requester_str }}) has made a {% if pooling %}pooled {% endif %}project request with you as the Principal Investigator (PI) via the MyBRC User Portal.
+
+You may view the details of the request here: {{ review_url }}.
+
+If approved, you will become a PI on the project. The requesting user will become a manager and gain cluster access under the project's allowance.
+
+If you would like to prevent this, or have any questions, please contact us at {{ support_email }}.
+
+Thank you,
+{{ signature }}


### PR DESCRIPTION
Fixes #133

**Changes**
- Added a landing page for the new Savio project request form containing additional information.
- Added a landing page for the new Vector project request form containing additional information.
- Added logic to send an email to the PI for new Savio project requests when the requesting user is not the PI.