### PR TITLE
Automatically provide access to Savio for new Vector users

### DIFF
--- a/coldfront/config/local_settings.py.sample
+++ b/coldfront/config/local_settings.py.sample
@@ -36,6 +36,9 @@ SITE_ID = 1
 # The username of the user to set as the PI for all Vector projects.
 VECTOR_PI_USERNAME = "channsoden@berkeley.edu"
 
+# The name of the Savio project to which all Vector users are given access to.
+SAVIO_PROJECT_FOR_VECTOR_USERS = "co_rosalind"
+
 #------------------------------------------------------------------------------
 # General Center Information
 #------------------------------------------------------------------------------

--- a/coldfront/core/allocation/utils.py
+++ b/coldfront/core/allocation/utils.py
@@ -108,15 +108,6 @@ def get_allocation_user_cluster_access_status(allocation_obj, user_obj):
         value__in=['Pending - Add', 'Active'])
 
 
-def request_project_cluster_access(allocation_obj, user_obj):
-    # Get or create the AllocationUser, and set its status to 'Active'.
-    allocation_user_obj = get_or_create_active_allocation_user(
-        allocation_obj, user_obj)
-    # Set the user's 'Cluster Account Status' attribute, with pending value.
-    set_allocation_user_attribute_value(
-        allocation_user_obj, 'Cluster Account Status', 'Pending - Add')
-
-
 def prorated_allocation_amount(amount, dt):
     """Given a number of service units and a datetime, return the
     prorated number of service units that would be allocated in the

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -137,7 +137,6 @@ def auto_approve_project_join_requests():
                 message = error_message
                 logger.error(message)
                 logger.exception(e)
-
             else:
                 success = runner_result.success
                 if success:
@@ -163,6 +162,19 @@ def auto_approve_project_join_requests():
                     message = 'Failed to send notification email. Details:'
                     logger.error(message)
                     logger.exception(e)
+
+                # If the Project is a Vector project, automatically add the
+                # User to the designated Savio project for Vector users.
+                if project_obj.name.startswith('vector_'):
+                    try:
+                        add_vector_user_to_designated_savio_project(user_obj)
+                    except Exception as e:
+                        message = (
+                            f'Encountered unexpected exception when '
+                            f'automatically providing User {user_obj.pk} with '
+                            f'access to Savio. Details:')
+                        logger.error(message)
+                        logger.exception(e)
 
     return results
 

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -4,7 +4,6 @@ from coldfront.core.allocation.models import AllocationAttributeType
 from coldfront.core.allocation.models import AllocationStatusChoice
 from coldfront.core.allocation.models import AllocationUserAttribute
 from coldfront.core.allocation.utils import get_or_create_active_allocation_user
-from coldfront.core.allocation.utils import request_project_cluster_access
 from coldfront.core.allocation.utils import review_cluster_access_requests_url
 from coldfront.core.allocation.utils import set_allocation_user_attribute_value
 from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
@@ -22,6 +21,8 @@ from collections import namedtuple
 from datetime import timedelta
 from decimal import Decimal
 from django.conf import settings
+from django.core.exceptions import MultipleObjectsReturned
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 
 from django.urls import reverse
@@ -116,51 +117,43 @@ def auto_approve_project_join_requests():
         # approve the user and request cluster access.
         delay = project_obj.joins_auto_approval_delay
         if join_request.created + delay <= now:
-            # Retrieve the compute Allocation for the Project.
-            try:
-                allocation_obj = get_project_compute_allocation(
-                    project_obj)
-            except (Allocation.DoesNotExist,
-                    Allocation.MultipleObjectsReturned):
-                message = (
-                    f'Project {project_obj.name} has no compute '
-                    f'allocation.')
-                logger.error(message)
-                results.append(
-                    JoinAutoApprovalResult(success=False, message=message))
-                continue
-
             # Set the ProjectUser's status to 'Active'.
             project_user_obj.status = active_status
             project_user_obj.save()
 
-            # Request cluster access for the ProjectUser.
+            error_message = (
+                f'Failed to request cluster access for User '
+                f'{user_obj.username} under Project {project_obj.name}. '
+                f'Details:')
+
+            # Request cluster access.
+            success = False
             try:
-                request_project_cluster_access(allocation_obj, user_obj)
-                message = (
-                    f'Created a cluster access request for User '
-                    f'{user_obj.username} under Project '
-                    f'{project_obj.name}.')
-                logger.info(message)
-                results.append(
-                    JoinAutoApprovalResult(success=True, message=message))
-            except ValueError:
-                message = (
-                    f'User {user_obj.username} already has cluster access '
-                    f'under Project {project_obj.name}.')
-                logger.warning(message)
-                results.append(
-                    JoinAutoApprovalResult(success=False, message=message))
+                request_runner = ProjectClusterAccessRequestRunner(
+                    project_user_obj)
+                runner_result = request_runner.run()
             except Exception as e:
-                message = (
-                    f'Failed to request cluster access for User '
-                    f'{user_obj.username} under Project '
-                    f'{project_obj.name}. Details:')
+                message = error_message
                 logger.error(message)
                 logger.exception(e)
-                results.append(
-                    JoinAutoApprovalResult(success=False, message=message))
+
             else:
+                success = runner_result.success
+                if success:
+                    message = (
+                        f'Created a cluster access request for User '
+                        f'{user_obj.username} under Project '
+                        f'{project_obj.name}.')
+                    logger.info(message)
+                else:
+                    message = error_message
+                    logger.error(message)
+                    logger.exception(runner_result.error_message)
+
+            results.append(
+                JoinAutoApprovalResult(success=success, message=message))
+
+            if success:
                 # Send an email to the user.
                 try:
                     send_project_join_request_approval_email(
@@ -872,3 +865,222 @@ class ProjectDenialRunner(object):
         project.status = ProjectStatusChoice.objects.get(name='Denied')
         project.save()
         return project
+
+
+class ProjectClusterAccessRequestRunnerError(Exception):
+    """An exception class for the ProjectClusterAccessRequestRunner."""
+
+    pass
+
+
+class ProjectClusterAccessRequestRunner(object):
+    """An object that performs necessary database checks and updates
+    when access to a project on the cluster is requested for a given
+    user."""
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, project_user_obj):
+        """Verify that the given ProjectUser is a ProjectUser instance.
+
+        Parameters:
+            - project_user_obj (ProjectUser): an instance of ProjectUser
+        Returns: None
+        Raises:
+            - TypeError
+        """
+        if not isinstance(project_user_obj, ProjectUser):
+            raise TypeError(
+                f'ProjectUser {project_user_obj} has unexpected type '
+                f'{type(project_user_obj)}.')
+        self.project_user_obj = project_user_obj
+        self.project_obj = self.project_user_obj.project
+        self.user_obj = self.project_user_obj.user
+        self.allocation_obj = None
+        self.allocation_user_obj = None
+        self.allocation_user_attribute_obj = None
+
+    def run(self):
+        """Perform checks and updates. Return whether or not all steps
+        succeeded."""
+        RunnerResult = namedtuple('RunnerResult', 'success error_message')
+        server_error_message = (
+            'Unexpected server error. Please contact an administrator.')
+        success = False
+        try:
+            self.validate_project_user()
+            self.validate_project_has_active_allocation()
+            self.create_or_update_allocation_user()
+            self.validate_no_existing_cluster_access()
+            self.request_cluster_access()
+            self.send_notification_email_to_cluster_admins()
+        except (ObjectDoesNotExist, MultipleObjectsReturned) as e:
+            message = (
+                f'Found an unexpected number of objects (one was expected) '
+                f'during processing of request for cluster access by '
+                f'ProjectUser {self.project_user_obj.pk}. Details:')
+            self.logger.error(message)
+            self.logger.exception(e)
+            error_message = server_error_message
+        except ProjectClusterAccessRequestRunnerError as e:
+            # Do not log here because this is done by the individual methods.
+            error_message = str(e)
+        except Exception as e:
+            message = (
+                f'Encountered unexpected exception during processing of '
+                f'request for cluster access by ProjectUser '
+                f'{self.project_user_obj.pk}. Details: ')
+            self.logger.error(message)
+            self.logger.exception(e)
+            error_message = (
+                'Unexpected server error. Please contact an administrator.')
+        else:
+            message = (
+                f'Successfully processed request for cluster access by '
+                f'ProjectUser {self.project_user_obj.pk}.')
+            self.logger.info(message)
+            success = True
+            error_message = ''
+        return RunnerResult(success=success, error_message=error_message)
+
+    def validate_project_user(self):
+        """Ensure that the ProjectUser has 'Active' status.
+
+        Parameters: None
+        Returns: None
+        Raises:
+            - ProjectUserStatusChoice.DoesNotExist
+            - ProjectUserStatusChoice.MultipleObjectsReturned
+            - ValueError
+        """
+        status = ProjectUserStatusChoice.objects.get(name='Active')
+        if self.project_user_obj.status != status:
+            message = f'ProjectUser {self.project_user_obj.pk} is not active.'
+            self.logger.error(message)
+            raise ValueError(message)
+        message = f'Validated ProjectUser {self.project_user_obj.pk}.'
+        self.logger.info(message)
+
+    def validate_project_has_active_allocation(self):
+        """Retrieve the compute Allocation for the Project.
+
+        Parameters: None
+        Returns: None
+        Raises:
+            - AllocationStatusChoice.DoesNotExist
+            - Allocation.MultipleObjectsReturned
+            - AllocationStatusChoice.MultipleObjectsReturned
+            - ProjectClusterAccessRequestRunnerError
+        """
+        try:
+            self.allocation_obj = get_project_compute_allocation(
+                self.project_obj)
+        except Allocation.DoesNotExist:
+            message = f'Project {self.project_obj} has no compute Allocation.'
+            self.logger.error(message)
+            raise ProjectClusterAccessRequestRunnerError(message)
+
+        status = AllocationStatusChoice.objects.get(name='Active')
+        if self.allocation_obj.status != status:
+            message = f'Allocation {self.allocation_obj.pk} is not active.'
+            self.logger.error(message)
+            raise ProjectClusterAccessRequestRunnerError(message)
+
+        message = f'Validated Allocation {self.allocation_obj.pk}.'
+        self.logger.info(message)
+
+    def create_or_update_allocation_user(self):
+        """Create an AllocationUser between the Allocation and User if
+        one does not exist. Set its status to 'Active'.
+
+        Parameters: None
+        Returns: None
+        Raises:
+            - AllocationUserStatusChoice.DoesNotExist
+            - AllocationUserStatusChoice.MultipleObjectsReturned
+        """
+        self.allocation_user_obj = get_or_create_active_allocation_user(
+            self.allocation_obj, self.user_obj)
+        message = (
+            f'Created or updated AllocationUser {self.allocation_user_obj.pk} '
+            f'and set it to active.')
+        self.logger.info(message)
+
+    def validate_no_existing_cluster_access(self):
+        """Ensure that the User does not already have pending or active
+        access to the Project on the cluster.
+
+        Parameters: None
+        Returns: None
+        Raises:
+            - AllocationAttributeType.DoesNotExist
+            - AllocationAttributeType.MultipleObjectsReturned
+            - AllocationUserAttribute.MultipleObjectsReturned
+            - ProjectClusterAccessRequestRunnerError
+        """
+        queryset = self.allocation_user_obj.allocationuserattribute_set
+        kwargs = {
+            'allocation_attribute_type': AllocationAttributeType.objects.get(
+                name='Cluster Account Status'),
+            'value__in': ['Pending - Add', 'Active'],
+        }
+        try:
+            status = queryset.get(**kwargs)
+        except AllocationUserAttribute.DoesNotExist:
+            message = (
+                f'Validated that User {self.user_obj.pk} does not already '
+                f'have a pending or active "Cluster Access Status" attribute '
+                f'under Project {self.project_obj.pk}.')
+            self.logger.info(message)
+            return
+        except AllocationUserAttribute.MultipleObjectsReturned as e:
+            message = (
+                f'Unexpectedly found multiple "Cluster Access Status" '
+                f'attributes for User {self.user_obj.pk} under Project '
+                f'{self.project_obj.pk}.')
+            self.logger.error(message)
+            raise e
+        else:
+            message = (
+                f'User {self.user_obj.pk} already has a "Cluster Access '
+                f'Status" attribute with value "{status.value}" under Project '
+                f'{self.project_obj.pk}.')
+            self.logger.error(message)
+            raise ProjectClusterAccessRequestRunnerError(message)
+
+    def request_cluster_access(self):
+        """Create or update an AllocationUserAttribute with type
+        "Cluster Account Status" and value "Pending - Add" for the
+        AllocationUser.
+
+        Parameters: None
+        Returns: None
+        Raises:
+            - AllocationAttributeType.DoesNotExist
+            - AllocationAttributeType.MultipleObjectsReturned
+        """
+        type_name = 'Cluster Account Status'
+        value = 'Pending - Add'
+        self.allocation_user_attribute_obj = \
+            set_allocation_user_attribute_value(
+                self.allocation_user_obj, type_name, value)
+        message = (
+            f'Created or updated a "Cluster Account Status" to be pending for '
+            f'User {self.user_obj.pk} and Project {self.project_obj.pk}.')
+        self.logger.info(message)
+
+    def send_notification_email_to_cluster_admins(self):
+        """Send an email to cluster administrators notifying them of the
+        new request. If an error occurs, do not re-raise it.
+
+        Parameters: None
+        Returns: None
+        Raises: None
+        """
+        try:
+            send_new_cluster_access_request_notification_email(
+                self.project_obj, self.project_user_obj)
+        except Exception as e:
+            message = f'Failed to send notification email. Details:'
+            self.logger.error(message)
+            self.logger.exception(e)

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -29,8 +29,7 @@ from coldfront.core.allocation.models import (Allocation,
                                               AllocationUserAttribute,
                                               AllocationUserStatusChoice)
 from coldfront.core.allocation.utils import (get_allocation_user_cluster_access_status,
-                                             prorated_allocation_amount,
-                                             request_project_cluster_access)
+                                             prorated_allocation_amount)
 from coldfront.core.allocation.signals import (allocation_activate_user,
                                                allocation_remove_user)
 # from coldfront.core.grant.models import Grant
@@ -54,6 +53,7 @@ from coldfront.core.project.models import (Project, ProjectReview,
                                            ProjectUserStatusChoice)
 from coldfront.core.project.utils import (auto_approve_project_join_requests,
                                           get_project_compute_allocation,
+                                          ProjectClusterAccessRequestRunner,
                                           ProjectDenialRunner,
                                           SavioProjectApprovalRunner,
                                           savio_request_denial_reason,
@@ -657,47 +657,29 @@ class ProjectUpdateView(SuccessMessageMixin, LoginRequiredMixin, UserPassesTestM
             f'approved.')
 
         if project_user_objs.exists():
-
             error_message = (
                 'Unexpected server error. Please contact an administrator.')
-
-            try:
-                allocation_obj = get_project_compute_allocation(project_obj)
-            except (Allocation.DoesNotExist,
-                    Allocation.MultipleObjectsReturned):
-                messages.error(self.request, error_message)
-                return False
-
             for project_user_obj in project_user_objs:
-                user_obj = project_user_obj.user
+                # Request cluster access.
                 try:
-                    request_project_cluster_access(allocation_obj, user_obj)
-                except ValueError:
-                    message = (
-                        f'User {user_obj.username} already has cluster access '
-                        f'under Project {project_obj.name}.')
-                    messages.warning(self.request, message)
+                    request_runner = ProjectClusterAccessRequestRunner(
+                        project_user_obj)
+                    runner_result = request_runner.run()
                 except Exception:
                     messages.error(self.request, error_message)
                     return False
                 else:
-                    # Send an email to admins.
-                    try:
-                        send_new_cluster_access_request_notification_email(
-                            project_obj, project_user_obj)
-                    except Exception as e:
-                        message = 'Failed to send notification email. Details:'
-                        self.logger.error(message)
-                        self.logger.exception(e)
-                    # Send an email to the user.
-                    try:
-                        send_project_join_request_approval_email(
-                            project_obj, project_user_obj)
-                    except Exception as e:
-                        message = 'Failed to send notification email. Details:'
-                        self.logger.error(message)
-                        self.logger.exception(e)
-
+                    if not runner_result.success:
+                        messages.error(
+                            self.request, runner_result.error_message)
+                # Send an email to the user.
+                try:
+                    send_project_join_request_approval_email(
+                        project_obj, project_user_obj)
+                except Exception as e:
+                    message = 'Failed to send notification email. Details:'
+                    self.logger.error(message)
+                    self.logger.exception(e)
             message = message + (
                 ' BRC staff have been notified to set up cluster access for '
                 'each request.')
@@ -928,39 +910,18 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                         'Unexpected server error. Please contact an '
                         'administrator.')
                     try:
-                        allocation_obj = get_project_compute_allocation(
-                            project_obj)
-                    except (Allocation.DoesNotExist,
-                            Allocation.MultipleObjectsReturned):
-                        messages.error(self.request, error_message)
-                        continue
-
-                    try:
-                        request_project_cluster_access(
-                            allocation_obj, user_obj)
-                    except ValueError:
-                        message = (
-                            f'User {user_obj.username} already has cluster '
-                            f'access under Project {project_obj.name}.')
-                        messages.warning(self.request, message)
+                        request_runner = ProjectClusterAccessRequestRunner(
+                            project_user_obj)
+                        request_runner.run()
                     except Exception:
                         messages.error(self.request, error_message)
+                        continue
                     else:
                         cluster_access_requests_count += 1
 
                         # Notify the user that he/she has been added.
                         try:
                             self.__send_email_to_user(
-                                project_obj, project_user_obj)
-                        except Exception as e:
-                            message = (
-                                'Failed to send notification email. Details:')
-                            self.logger.error(message)
-                            self.logger.exception(e)
-
-                        # Notify admins of a new cluster access request.
-                        try:
-                            send_new_cluster_access_request_notification_email(
                                 project_obj, project_user_obj)
                         except Exception as e:
                             message = (
@@ -1588,49 +1549,35 @@ class ProjectJoinView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
             messages.success(self.request, message)
             next_view = reverse('project-join-list')
         else:
-            next_view = reverse(
-                'project-detail', kwargs={'pk': project_obj.pk})
-            error_message = (
-                'Unexpected server error. Please contact an administrator.')
-
-            try:
-                allocation_obj = get_project_compute_allocation(project_obj)
-            except (Allocation.DoesNotExist,
-                    Allocation.MultipleObjectsReturned):
-                messages.error(self.request, error_message)
-                return redirect(next_view)
-
+            # Activate the user.
             status = ProjectUserStatusChoice.objects.get(name='Active')
             project_user.status = status
             project_user.save()
 
+            error_message = (
+                'Unexpected server error. Please contact an administrator.')
+
+            # Request cluster access.
             try:
-                request_project_cluster_access(allocation_obj, user_obj)
-            except ValueError:
-                message = (
-                    f'User {user_obj.username} already has cluster access '
-                    f'under Project {project_obj.name}.')
-                messages.warning(self.request, message)
+                request_runner = ProjectClusterAccessRequestRunner(
+                    project_user)
+                runner_result = request_runner.run()
             except Exception:
                 messages.error(self.request, error_message)
             else:
-                message = (
-                    f'You have requested to join Project {project_obj.name}. '
-                    f'Your request has automatically been approved. BRC staff '
-                    f'have been notified to set up cluster access.')
-                messages.success(self.request, message)
+                if runner_result.success:
+                    message = (
+                        f'You have requested to join Project '
+                        f'{project_obj.name}. Your request has automatically '
+                        f'been approved. BRC staff have been notified to set '
+                        f'up cluster access.')
+                    messages.success(self.request, message)
+                    next_view = reverse(
+                        'project-detail', kwargs={'pk': project_obj.pk})
+                else:
+                    messages.error(self.request, runner_result.error_message)
 
-                try:
-                    send_new_cluster_access_request_notification_email(
-                        project_obj, project_user)
-                except Exception as e:
-                    message = 'Failed to send notification email. Details:'
-                    self.logger.error(message)
-                    self.logger.exception(e)
-
-            next_view = reverse(
-                'project-detail', kwargs={'pk': project_obj.pk})
-
+        # Send a notification to the project managers.
         try:
             send_project_join_notification_email(project_obj, project_user)
         except Exception as e:
@@ -1871,23 +1818,17 @@ class ProjectReviewJoinRequestsView(LoginRequiredMixin, UserPassesTestMixin,
             if decision == 'approve':
                 status_name = 'Active'
                 message_verb = 'Approved'
+                email_function = send_project_join_request_approval_email
             else:
                 status_name = 'Denied'
                 message_verb = 'Denied'
+                email_function = send_project_join_request_denial_email
 
             project_user_status_choice = \
                 ProjectUserStatusChoice.objects.get(name=status_name)
 
             error_message = (
                 'Unexpected server error. Please contact an administrator.')
-
-            try:
-                allocation_obj = get_project_compute_allocation(project_obj)
-            except (Allocation.DoesNotExist,
-                    Allocation.MultipleObjectsReturned):
-                messages.error(self.request, error_message)
-                return HttpResponseRedirect(
-                    reverse('project-detail', kwargs={'pk': pk}))
 
             for form in formset:
                 user_form_data = form.cleaned_data
@@ -1903,46 +1844,26 @@ class ProjectReviewJoinRequestsView(LoginRequiredMixin, UserPassesTestMixin,
                     if status_name == 'Active':
                         # Request cluster access.
                         try:
-                            request_project_cluster_access(
-                                allocation_obj, user_obj)
-                        except ValueError:
-                            message = (
-                                f'User {user_obj.username} already has '
-                                f'cluster access under Project '
-                                f'{project_obj.name}.')
-                            messages.warning(self.request, message)
+                            request_runner = ProjectClusterAccessRequestRunner(
+                                project_user_obj)
+                            runner_result = request_runner.run()
                         except Exception:
                             messages.error(self.request, error_message)
                             return HttpResponseRedirect(
                                 reverse('project-detail', kwargs={'pk': pk}))
-                        # Send an email to the user.
-                        try:
-                            send_project_join_request_approval_email(
-                                project_obj, project_user_obj)
-                        except Exception as e:
-                            message = (
-                                'Failed to send notification email. Details:')
-                            self.logger.error(message)
-                            self.logger.exception(e)
-                        # Send an email to admins.
-                        try:
-                            send_new_cluster_access_request_notification_email(
-                                project_obj, project_user_obj)
-                        except Exception as e:
-                            message = (
-                                'Failed to send notification email. Details:')
-                            self.logger.error(message)
-                            self.logger.exception(e)
-                    else:
-                        # Send an email to the user.
-                        try:
-                            send_project_join_request_denial_email(
-                                project_obj, project_user_obj)
-                        except Exception as e:
-                            message = (
-                                'Failed to send notification email. Details:')
-                            self.logger.error(message)
-                            self.logger.exception(e)
+                        else:
+                            if not runner_result.success:
+                                messages.error(
+                                    self.request, runner_result.error_message)
+
+                    # Send an email to the user.
+                    try:
+                        email_function(project_obj, project_user_obj)
+                    except Exception as e:
+                        message = (
+                            'Failed to send notification email. Details:')
+                        self.logger.error(message)
+                        self.logger.exception(e)
 
             message = (
                 f'{message_verb} {reviewed_users_count} user requests to join '


### PR DESCRIPTION
Fixes #117

**Changes**
- Added setting `SAVIO_PROJECT_FOR_VECTOR_USERS` with value `co_rosalind`. All Vector users are provided access to this project.
- Added logic to trigger: (a) adding a Vector user to the designated project, (b) requesting cluster access under it, and (c) sending an email to the user, when the following events occur:
    - A request to create a new Vector project is approved. The user who created the request is the target user.
    - A user's join request is approved (manually, via the cron job, when an admin manually checks for requests that have finished their delay period, and when a project's delay setting becomes 0).
    - A user is manually added to a project by a manager.
    - NOTE: If the user already has access to the Savio project, the logic is skipped.
- Refactored logic for requesting cluster access into a class for reuse.

**How to Test**
- Copy `local_settings.py.sample` to `local_settings.py`.