### PR TITLE
Allow REST API to be disabled

### DIFF
--- a/coldfront/config/local_settings.py.sample
+++ b/coldfront/config/local_settings.py.sample
@@ -320,6 +320,34 @@ LOCAL_SETTINGS_EXPORT += [
 
 # XDMOD_API_URL = 'http://localhost'
 
+# ------------------------------------------------------------------------------
+# Enable myBRC REST API
+# ------------------------------------------------------------------------------
+# EXTRA_APPS += [
+#     'rest_framework',
+#     'django_filters',
+#     'drf_yasg',
+#     'coldfront.api',
+# ]
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'coldfront.api.user.authentication.ExpiringTokenAuthentication',
+    ],
+    'DEFAULT_PAGINATION_CLASS': (
+        'rest_framework.pagination.PageNumberPagination'),
+    'PAGE_SIZE': 100,
+    'DEFAULT_FILTER_BACKENDS': (
+        'django_filters.rest_framework.DjangoFilterBackend',),
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.IsAuthenticated',
+    ],
+}
+
+# The number of hours for which a newly created authentication token will be
+# valid.
+TOKEN_EXPIRATION_HOURS = 24
+
 #------------------------------------------------------------------------------
 # Multiple Email Address settings
 #------------------------------------------------------------------------------

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -56,14 +56,6 @@ INSTALLED_APPS += [
     'coldfront.core.statistics',
 ]
 
-# REST API
-INSTALLED_APPS += [
-    'rest_framework',
-    'django_filters',
-    'drf_yasg',
-    'coldfront.api',
-]
-
 # Savio-specific Additional Apps
 INSTALLED_APPS += [
     'formtools',
@@ -189,28 +181,6 @@ SU_LOGOUT_REDIRECT_URL = "/admin/auth/user/"
 
 
 SETTINGS_EXPORT = []
-
-# ------------------------------------------------------------------------------
-# REST API settings
-# ------------------------------------------------------------------------------
-
-REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-        'coldfront.api.user.authentication.ExpiringTokenAuthentication',
-    ],
-    'DEFAULT_PAGINATION_CLASS': (
-        'rest_framework.pagination.PageNumberPagination'),
-    'PAGE_SIZE': 100,
-    'DEFAULT_FILTER_BACKENDS': (
-        'django_filters.rest_framework.DjangoFilterBackend',),
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
-    ],
-}
-
-# The number of hours for which a newly created authentication token will be
-# valid.
-TOKEN_EXPIRATION_HOURS = 24
 
 # ------------------------------------------------------------------------------
 # Accounting settings

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -27,7 +27,7 @@ urlpatterns = [
 ]
 
 
-if 'coldfront.api' in settings.INSTALLED_APPS:
+if 'coldfront.api' in settings.EXTRA_APPS:
     urlpatterns.append(path('api/', include('coldfront.api.urls')))
 
 if 'coldfront.plugins.iquota' in settings.EXTRA_APPS:


### PR DESCRIPTION
Fixes #155

**Changes**
- Moved REST API-related apps to the `EXTRA_APPS` variable in `local_settings.py` so that they can be enabled on a deployment-by-deployment basis.
    - By default, it is disabled.