### PR TITLE
Hide main Allocation views

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -100,19 +100,22 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
         if self.request.user.has_perm('allocation.can_view_all_allocations'):
             return True
 
-        pk = self.kwargs.get('pk')
-        allocation_obj = get_object_or_404(Allocation, pk=pk)
-
-        user_can_access_project = allocation_obj.project.projectuser_set.filter(
-            user=self.request.user, status__name__in=['Active', 'New', ]).exists()
-
-        user_can_access_allocation = allocation_obj.allocationuser_set.filter(
-            user=self.request.user, status__name__in=['Active', ]).exists()
-
-        if user_can_access_project and user_can_access_allocation:
-            return True
-
+        # TODO: Remove this block when allocations should be displayed.
         return False
+
+        # pk = self.kwargs.get('pk')
+        # allocation_obj = get_object_or_404(Allocation, pk=pk)
+        #
+        # user_can_access_project = allocation_obj.project.projectuser_set.filter(
+        #     user=self.request.user, status__name__in=['Active', 'New', ]).exists()
+        #
+        # user_can_access_allocation = allocation_obj.allocationuser_set.filter(
+        #     user=self.request.user, status__name__in=['Active', ]).exists()
+        #
+        # if user_can_access_project and user_can_access_allocation:
+        #     return True
+        #
+        # return False
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -329,12 +332,17 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             return render(request, self.template_name, context)
 
 
-class AllocationListView(LoginRequiredMixin, ListView):
+class AllocationListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
     model = Allocation
     template_name = 'allocation/allocation_list.html'
     context_object_name = 'allocation_list'
     paginate_by = 25
+
+    def test_func(self):
+        """Temporary block: Only allow superusers access."""
+        # TODO: Remove this block when allocations should be displayed.
+        return self.request.user.is_superuser
 
     def get_queryset(self):
 

--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -204,58 +204,58 @@ Project Detail
 
 
 <!-- Start Project Allocations -->
-<div class="card mb-3">
-  <div class="card-header">
-  <h4 class="d-inline"><i class="fas fa-server"></i> Allocations </h4> <span class="badge badge-secondary">{{allocations.count}}</span>
-  </div>
-  <div class="card-body">
-    {% if allocations %}
-    <div class="table-responsive">
-      <table id="allocation_table" class="table table-hover">
-        <thead>
-          <tr>
-            <th>Resource Name</th>
-            <th>Resource Type</th>
-            <th>Information</th>
-            <th>Status</th>
-            <th>End Date</th>
-            <th class="nosort">More Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for allocation in allocations %}
-          <tr>
-            <td>{{ allocation.get_parent_resource.name }}</td>
-            <td>{{ allocation.get_parent_resource.resource_type.name }}</td>
-            <td class="text-nowrap">{{allocation.get_information}}</td>
-            {% if allocation.status.name == 'Active' %}
-              <td class="text-success">{{ allocation.status.name }}</td>
-            {% elif  allocation.status.name == 'Expired' or allocation.status.name == 'Denied' %}
-              <td class="text-danger">{{ allocation.status.name }}</td>
-            {% else %}
-              <td class="text-info">{{ allocation.status.name }}</td>
-            {% endif %}
-            <td>{{allocation.end_date|date:"Y-m-d"}}</td>
-            <td>
-              <a href="{% url 'allocation-detail' allocation.pk %}"><i class="far fa-folder-open"></i></a>
-              {% if is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}
-                <a href="{% url 'allocation-renew' allocation.pk %}">
-                <span class="badge badge-warning"><i class="fas fa-redo-alt"></i>
-                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew
-                </span>
-                </a>
-              {% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-    {% else %}
-     <div class="alert alert-info" role="alert"><i class="fas fa-info-circle" aria-hidden="true"></i> There are no allocations to display.</div>
-    {% endif %}
-  </div>
-</div>
+<!--<div class="card mb-3">-->
+<!--  <div class="card-header">-->
+<!--  <h4 class="d-inline"><i class="fas fa-server"></i> Allocations </h4> <span class="badge badge-secondary">{{allocations.count}}</span>-->
+<!--  </div>-->
+<!--  <div class="card-body">-->
+<!--    {% if allocations %}-->
+<!--    <div class="table-responsive">-->
+<!--      <table id="allocation_table" class="table table-hover">-->
+<!--        <thead>-->
+<!--          <tr>-->
+<!--            <th>Resource Name</th>-->
+<!--            <th>Resource Type</th>-->
+<!--            <th>Information</th>-->
+<!--            <th>Status</th>-->
+<!--            <th>End Date</th>-->
+<!--            <th class="nosort">More Details</th>-->
+<!--          </tr>-->
+<!--        </thead>-->
+<!--        <tbody>-->
+<!--          {% for allocation in allocations %}-->
+<!--          <tr>-->
+<!--            <td>{{ allocation.get_parent_resource.name }}</td>-->
+<!--            <td>{{ allocation.get_parent_resource.resource_type.name }}</td>-->
+<!--            <td class="text-nowrap">{{allocation.get_information}}</td>-->
+<!--            {% if allocation.status.name == 'Active' %}-->
+<!--              <td class="text-success">{{ allocation.status.name }}</td>-->
+<!--            {% elif  allocation.status.name == 'Expired' or allocation.status.name == 'Denied' %}-->
+<!--              <td class="text-danger">{{ allocation.status.name }}</td>-->
+<!--            {% else %}-->
+<!--              <td class="text-info">{{ allocation.status.name }}</td>-->
+<!--            {% endif %}-->
+<!--            <td>{{allocation.end_date|date:"Y-m-d"}}</td>-->
+<!--            <td>-->
+<!--              <a href="{% url 'allocation-detail' allocation.pk %}"><i class="far fa-folder-open"></i></a>-->
+<!--              {% if is_allowed_to_update_project and ALLOCATION_ENABLE_ALLOCATION_RENEWAL and allocation.status.name == 'Active' and allocation.expires_in <= 60 and allocation.expires_in >= 0 %}-->
+<!--                <a href="{% url 'allocation-renew' allocation.pk %}">-->
+<!--                <span class="badge badge-warning"><i class="fas fa-redo-alt"></i>-->
+<!--                Expires in {{allocation.expires_in}} day{{allocation.expires_in|pluralize}} <br> Click to renew-->
+<!--                </span>-->
+<!--                </a>-->
+<!--              {% endif %}-->
+<!--            </td>-->
+<!--          </tr>-->
+<!--          {% endfor %}-->
+<!--        </tbody>-->
+<!--      </table>-->
+<!--    </div>-->
+<!--    {% else %}-->
+<!--     <div class="alert alert-info" role="alert"><i class="fas fa-info-circle" aria-hidden="true"></i> There are no allocations to display.</div>-->
+<!--    {% endif %}-->
+<!--  </div>-->
+<!--</div>-->
 <!-- End Project Allocations -->
 
 <!-- Start Admin Messages -->

--- a/coldfront/templates/common/authorized_navbar.html
+++ b/coldfront/templates/common/authorized_navbar.html
@@ -18,13 +18,13 @@
           <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Project</a>
           <div class="dropdown-menu">
             <a id="navbar-project" class="dropdown-item" href="{% url 'project-list' %}">Projects</a>
-            <a id="navbar-allocation" class="dropdown-item" href="{% url 'allocation-list' %}">Allocations</a>
-            {% if settings.ALLOCATION_ACCOUNT_ENABLED  %}
-            <a class="dropdown-item" href="{% url 'allocation-account-list' %}">Allocation Accounts</a>
-            {% endif %}
-            {% if request.user.userprofile.is_pi  %}
-            <a id="navbar-user-allocation" class="dropdown-item" href="{% url 'user-list-allocations' %}">User Allocations</a>
-            {% endif %}
+<!--            <a id="navbar-allocation" class="dropdown-item" href="{% url 'allocation-list' %}">Allocations</a>-->
+<!--            {% if settings.ALLOCATION_ACCOUNT_ENABLED  %}-->
+<!--            <a class="dropdown-item" href="{% url 'allocation-account-list' %}">Allocation Accounts</a>-->
+<!--            {% endif %}-->
+<!--            {% if request.user.userprofile.is_pi  %}-->
+<!--            <a id="navbar-user-allocation" class="dropdown-item" href="{% url 'user-list-allocations' %}">User Allocations</a>-->
+<!--            {% endif %}-->
           </div>
         </li>
         {% if request.user.is_superuser %}


### PR DESCRIPTION
Fixes #165

**Changes**
- Removed the allocation-related section from the Project Detail view.
- Removed the "Allocations" and "User Allocations" links from the navigation bar.
- Limited access to the Allocation List and Detail views to superusers.