### PR TITLE
Hide registration button if first/last name match

### DIFF
--- a/coldfront/core/user/templates/user/registration_form.html
+++ b/coldfront/core/user/templates/user/registration_form.html
@@ -17,5 +17,15 @@
   {{ form.phone_number|as_crispy_field }}
   {{ form.password1|as_crispy_field }}
   {{ form.password2|as_crispy_field }}
-  <button type="submit" class="btn btn-primary btn-block">Register</button>
+  <div class="form-check" id="new-user-acknowledgement-form">
+    <input class="form-check-input" type="checkbox" id="new-user-acknowledgement">
+    <label class="form-check-label" for="new-user-acknowledgement">
+      I acknowledge that I am a new user and have not previously used a BRC
+      cluster. The Register button will be unavailable until this check box is
+      selected.
+    </label>
+  </div>
+  <button type="submit" class="btn btn-primary btn-block" id="register-button">
+    Register
+  </button>
 </form>

--- a/coldfront/static/core/user/css/registration.css
+++ b/coldfront/static/core/user/css/registration.css
@@ -5,3 +5,10 @@
   font-weight: bold;
   color: #dc3545;
 }
+
+#new-user-acknowledgement-form {
+  display: none;
+  margin-bottom: 1.00rem;
+  color: #dc3545;
+  font-weight: bold;
+}

--- a/coldfront/static/core/user/js/registration.js
+++ b/coldfront/static/core/user/js/registration.js
@@ -34,6 +34,21 @@ $(document).ready(function() {
     clearTimeout(emailTypingTimer);
   });
 
+
+  // When the acknowledgement check box changes, conditionally display the
+  // registration button.
+  let ackDivId = 'new-user-acknowledgement';
+  $(`#${ackDivId}`).change(function() {
+    let registerButton = document.getElementById('register-button');
+    var display;
+    if (this.checked) {
+      display = 'block';
+    } else {
+      display = 'none';
+    }
+    registerButton.style.display = display;
+  });
+
 });
 
 
@@ -77,6 +92,10 @@ function checkNameExists() {
   let isLastNameValid = lastName.length > 0 && pattern.test(lastName);
 
   let alertDiv = document.getElementById('nameExists');
+  let ackDiv = document.getElementById('new-user-acknowledgement-form');
+  let ackInput = document.getElementById('new-user-acknowledgement');
+  let registerButton = document.getElementById('register-button');
+
   if (isFirstNameValid && isLastNameValid) {
     let url = `` +
       `/user/user-name-exists?first_name=${firstName}&last_name=${lastName}`;
@@ -92,11 +111,18 @@ function checkNameExists() {
             passwordResetTag + ' using the existing address to gain access. ' +
             'You may then associate additional email addresses with your ' +
             'account. If you need any assistance, please contact us.';
+          ackDiv.style.display = 'block';
+          registerButton.style.display = 'none';
         } else {
           alertDiv.innerHTML = '';
+          ackDiv.style.display = 'none';
+          registerButton.style.display = 'block';
         }
       });
   } else {
     alertDiv.innerHTML = '';
+    ackDiv.style.display = 'none';
+    registerButton.style.display = 'block';
   }
+  ackInput.checked = false;
 };


### PR DESCRIPTION
Fixes #169

**Changes**
- Added logic to hide the registration button if the user's provided first and last name match those of an existing user. The user must then select a check box to acknowledge that they are a new user before the button re-appears.

**How to Test**
- Run `python manage.py collectstatic` to update static files.
- Hard refresh any existing browser session.