### PR TITLE
Only redirect port 80 to HTTPS if accessed via the external IP address

### DIFF
--- a/bootstrap/ansible/cf_mybrc_wsgi_conf_ssl.tmpl
+++ b/bootstrap/ansible/cf_mybrc_wsgi_conf_ssl.tmpl
@@ -36,3 +36,10 @@ WSGIPassAuthorization On
     CustomLog /var/log/httpd/cf_brc.custom.log combined
 
 </VirtualHost>
+
+<VirtualHost {{ host_ip }}:80>
+
+    ServerName {{ hostname }}
+    Redirect "/" "{{ full_host_path }}"
+
+</VirtualHost>

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -58,7 +58,7 @@ google_sheets_credentials: '/tmp/credentials.json'
 #debug: False
 #git_prefix: /var/www/coldfront_app/
 #hostname: mybrc.brc.berkeley.edu
-#host_ip: 10.0.0.40
+#host_ip: 136.152.224.34
 #app_port: 8000
 #full_host_path: https://mybrc.brc.berkeley.edu
 


### PR DESCRIPTION
**Changes**
- Filled in the production IP address in the sample `main.yml` file.
- Added redirection only when accessing port 80 via the external IP address, so that other services using the internal IP address are unaffected.