### PR TITLE
Disallow SSL v2 and v3 connections

### DIFF
--- a/bootstrap/ansible/cf_mybrc_wsgi_conf_ssl.tmpl
+++ b/bootstrap/ansible/cf_mybrc_wsgi_conf_ssl.tmpl
@@ -28,6 +28,7 @@ WSGIPassAuthorization On
     </Directory>
 
     SSLEngine on
+    SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile {{ ssl_certificate_file }}
     SSLCertificateKeyFile {{ ssl_certificate_key_file }}
     SSLCertificateChainFile {{ ssl_certificate_chain_file }}


### PR DESCRIPTION
**Changes**
- Added a line to the template for the SSL WSGI configuration file that disables SSL v2 and v3 connections, which have security vulnerabilities.