### PR TITLE
Support account reactivation outside of the normal registration flow

### DIFF
--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -15,6 +15,7 @@ from coldfront.core.project.models import ProjectUserRoleChoice
 from coldfront.core.project.models import ProjectUserStatusChoice
 from coldfront.core.project.models import SavioProjectAllocationRequest
 from coldfront.core.project.models import VectorProjectAllocationRequest
+from coldfront.core.user.utils import account_activation_url
 from coldfront.core.utils.common import import_from_settings
 from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.utils.mail import send_email_template
@@ -412,9 +413,12 @@ def send_new_project_request_pi_notification_email(request):
         detail_view_name = 'vector-project-request-detail'
     else:
         raise TypeError(f'Request has invalid type {type(request)}.')
+    center_base_url = settings.CENTER_BASE_URL
     review_url = urljoin(
-        settings.CENTER_BASE_URL,
-        reverse(detail_view_name, kwargs={'pk': request.pk}))
+        center_base_url, reverse(detail_view_name, kwargs={'pk': request.pk}))
+    login_url = urljoin(center_base_url, reverse('login'))
+    activation_url = account_activation_url(pi)
+    password_reset_url = urljoin(center_base_url, reverse('password-reset'))
 
     context = {
         'pooling': pooling,
@@ -423,6 +427,10 @@ def send_new_project_request_pi_notification_email(request):
         'pi_str': pi_str,
         'review_url': review_url,
         'support_email': settings.CENTER_HELP_EMAIL,
+        'pi_is_active': pi.is_active,
+        'login_url': login_url,
+        'activation_url': activation_url,
+        'password_reset_url': password_reset_url,
     }
 
     sender = settings.EMAIL_SENDER

--- a/coldfront/core/user/forms.py
+++ b/coldfront/core/user/forms.py
@@ -200,6 +200,11 @@ class EmailAddressAddForm(forms.Form):
         return email
 
 
+class UserReactivateForm(forms.Form):
+
+    email = forms.EmailField(max_length=100, required=True)
+
+
 class PrimaryEmailAddressSelectionForm(forms.Form):
 
     email_address = forms.ModelChoiceField(

--- a/coldfront/core/user/templates/user/login.html
+++ b/coldfront/core/user/templates/user/login.html
@@ -28,9 +28,18 @@ Log In
       <h5><i class="fas fa-lock" aria-hidden="true"></i> Log In </h5>
     </div>
     <div class="card-body">
-      <p>
-        If you are an existing BRC cluster user and this is your first time visiting the portal, please <a href="{% url 'password-reset' %}">set your password</a> to activate your account.
-      </p>
+      <div class="alert alert-info" role="alert">
+        <i class="fas fa-info-circle" aria-hidden="true"></i>
+        Hint: If you are an existing BRC cluster user and this is your first time
+        visiting the portal, please <a href="{% url 'password-reset' %}">set
+        your password</a>.
+      </div>
+      <div class="alert alert-info" role="alert">
+        <i class="fas fa-info-circle" aria-hidden="true"></i>
+        Hint: If you have lost your initial activation email, you may generate
+        another one by logging in below or by
+        <a href="{% url 'reactivate' %}">reactivating your account</a>.
+      </div>
       <hr>
       {% include "user/login_form.html" %}
       {% if 'mozilla_django_oidc' in EXTRA_APPS %}
@@ -43,6 +52,8 @@ Log In
       {% endif %}
     </div>
     <div class="text-center last-form-entry">
+      <a href="{% url 'reactivate' %}">Reactivate your account</a>
+      &nbsp;|&nbsp;
       <a href="{% url 'password-reset' %}">Forgot your password?</a>
     </div>
   </div>

--- a/coldfront/core/user/templates/user/passwords/password_reset_done.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_done.html
@@ -20,10 +20,22 @@ Password Reset Sent
     </div>
     <div class="card-body">
       <p>
-        If the email address you entered is associated with an active account and was previously verified by you, please check the address for instructions to reset your portal password.
+        If the email address you entered is associated with an active account
+        and was previously verified by you, please check the address for
+        instructions to reset your portal password.
       </p>
       <p>
-        If you don't receive an email, please double check the address you entered and check your spam folder.
+        If you don't receive an email:
+        <ul>
+          <li>
+            Please double check the address you entered and check your spam
+            folder.
+          </li>
+          <li>
+            Your account may be inactive. If so, activate it
+            <a href="{% url 'reactivate' %}">here</a>.
+          </li>
+        </ul>
       </p>
     </div>
   </div>

--- a/coldfront/core/user/templates/user/user_reactivate.html
+++ b/coldfront/core/user/templates/user/user_reactivate.html
@@ -1,0 +1,32 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+Reactivate Account
+{% endblock %}
+
+
+{% block content %}
+
+
+<div class="col-sm-6 offset-sm-3">
+  <div class="card border-primary">
+    <div class="card-header bg-primary text-white">
+      <h5>Reactivate Account</h5>
+    </div>
+    <div class="card-body">
+      <p>
+        Reactivate your account by providing the primary email address
+        associated with your account.
+      </p>
+      <form method="post">
+        {% csrf_token %}
+        {{ form|crispy }}
+        <button type="submit" class="btn btn-primary btn-block">Reactivate</button>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/coldfront/core/user/urls.py
+++ b/coldfront/core/user/urls.py
@@ -77,6 +77,9 @@ urlpatterns = [
          user_views.activate_user_account,
          name='activate',
          ),
+    path('reactivate/',
+         user_views.UserReactivateView.as_view(),
+         name='reactivate'),
 
     # Email views
     path('add-email-address',

--- a/coldfront/core/user/utils.py
+++ b/coldfront/core/user/utils.py
@@ -176,7 +176,7 @@ class ExpiringTokenGenerator(PasswordResetTokenGenerator):
         return True
 
 
-def __account_activation_url(user):
+def account_activation_url(user):
     domain = import_from_settings('CENTER_BASE_URL')
     uidb64 = urlsafe_base64_encode(force_bytes(user.id))
     token = PasswordResetTokenGenerator().make_token(user)
@@ -213,7 +213,7 @@ def send_account_activation_email(user):
     template_name = 'email/account_activation_required.txt'
     context = {
         'center_name': import_from_settings('CENTER_NAME', ''),
-        'activation_url': __account_activation_url(user),
+        'activation_url': account_activation_url(user),
         'signature': import_from_settings('EMAIL_SIGNATURE', ''),
     }
 

--- a/coldfront/core/user/utils.py
+++ b/coldfront/core/user/utils.py
@@ -227,6 +227,33 @@ def send_account_activation_email(user):
     send_email_template(subject, template_name, context, sender, receiver_list)
 
 
+def send_account_already_active_email(user):
+    """Send an email to the given user stating that their account is
+    already active."""
+    email_enabled = import_from_settings('EMAIL_ENABLED', False)
+    if not email_enabled:
+        return
+
+    subject = 'Account already active'
+    template_name = 'email/account_already_active.txt'
+
+    center_base_url = settings.CENTER_BASE_URL
+    login_url = urljoin(center_base_url, reverse('login'))
+    password_reset_url = urljoin(
+        center_base_url, reverse('password-reset'))
+
+    context = {
+        'login_url': login_url,
+        'password_reset_url': password_reset_url,
+    }
+
+    sender = settings.EMAIL_SENDER
+    receiver_list = [user.email]
+
+    send_email_template(
+        subject, template_name, context, sender, receiver_list)
+
+
 def send_email_verification_email(email_address):
     """Send a verification email to the given EmailAddress."""
     email_enabled = import_from_settings('EMAIL_ENABLED', False)

--- a/coldfront/templates/email/account_already_active.txt
+++ b/coldfront/templates/email/account_already_active.txt
@@ -1,0 +1,10 @@
+Dear MyBRC Portal user,
+
+You're receiving this email because you requested a portal account reactivation. However, your account is already active, so no action is required at this time.
+
+Please login here: {{ login_url }}
+
+If needed, you may reset your password here: {{ password_reset_url }}
+
+Thank you,
+{{ signature }}

--- a/coldfront/templates/email/project_request/pi_new_project_request.txt
+++ b/coldfront/templates/email/project_request/pi_new_project_request.txt
@@ -8,5 +8,9 @@ If approved, you will become a PI on the project. The requesting user will becom
 
 If you would like to prevent this, or have any questions, please contact us at {{ support_email }}.
 
+{% if pi_is_active %}You already have a portal account and may login here: {{ login_url }}{% else %}A portal account was automatically created on your behalf. Please complete the following steps:
+1. Click on the following link to complete registration and activate your account: {{ activation_url }}
+2. Set your password here: {{ password_reset_url }}{% endif %}
+
 Thank you,
 {{ signature }}


### PR DESCRIPTION
Fixes #193

**Changes**
- Included an account activation URL in the email notifying a newly-created PI user that someone has requested a new project under their name.
- Added a view where a user can provide their _primary_ email address to activate their portal account.
    - If the account is already active, the email will say so.
    - If not, an account activation URL will be included.
    - The page itself will not provide any indication of the account's status, so email addresses and statuses will not be leaked.
- Added references to account reactivation in the login view and in the password reset view.

**Notes**
- Below are some implications of this functionality:
    - Inactive users will always be able to make themselves active again. To prevent undesirable users from logging in, another setting (e.g., `no_login`) will need to be added.
    - Any user may trigger an account activation email for any valid primary email address in the system.
        - This was already true of password reset emails.