### PR TITLE
Issue 254

### DIFF
--- a/coldfront/core/portal/views.py
+++ b/coldfront/core/portal/views.py
@@ -48,12 +48,6 @@ def home(request):
             if project.display_status is not None and 'Active' in project.display_status:
                 context['cluster_username'] = request.user.username
 
-            # crashed on login if part of a project and the name was None
-            if project.name is None:
-                project.name = 'temp_test'
-                project.save()
-                print('saved project w new name')
-
             if project.name == 'abc':
                 abc_projects.add(project.name)
             elif project.name.startswith('vector_'):

--- a/coldfront/core/portal/views.py
+++ b/coldfront/core/portal/views.py
@@ -25,7 +25,6 @@ def home(request):
     context = {}
     if request.user.is_authenticated:
         template_name = 'portal/authorized_home.html'
-
         project_list = Project.objects.filter(
             (Q(status__name__in=['New', 'Active', ]) &
              Q(projectuser__user=request.user) &
@@ -35,7 +34,6 @@ def home(request):
 
         cluster_access_attributes = AllocationUserAttribute.objects.filter(allocation_attribute_type__name='Cluster Account Status',
                                                                        allocation_user__user=request.user)
-
         access_states = {}
         for attribute in cluster_access_attributes:
             project = attribute.allocation.project
@@ -43,11 +41,18 @@ def home(request):
             access_states[project] = status
 
         abc_projects, savio_projects, vector_projects = set(), set(), set()
+
         for project in project_list:
             project.display_status = access_states.get(project, None)
 
             if project.display_status is not None and 'Active' in project.display_status:
                 context['cluster_username'] = request.user.username
+
+            # crashed on login if part of a project and the name was None
+            if project.name is None:
+                project.name = 'temp_test'
+                project.save()
+                print('saved project w new name')
 
             if project.name == 'abc':
                 abc_projects.add(project.name)

--- a/coldfront/core/project/forms.py
+++ b/coldfront/core/project/forms.py
@@ -57,6 +57,7 @@ class ProjectAddUserForm(forms.Form):
         queryset=ProjectUserRoleChoice.objects.all().filter(~Q(name='Principal Investigator')),
         empty_label=None)
     selected = forms.BooleanField(initial=False, required=False)
+    user_access_agreement = forms.CharField(max_length=16, required=False, disabled=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/coldfront/core/project/templates/project/add_user_search_results.html
+++ b/coldfront/core/project/templates/project/add_user_search_results.html
@@ -54,7 +54,12 @@
             <td>{{ form.first_name.value }}</td>
             <td>{{ form.last_name.value }}</td>
             <td>{{ form.email.value }}</td>
-              <td><span class="badge badge-success">{{ form.user_access_agreement.value }}</span></td>
+              <td>
+                  <span class="badge badge-success">
+                  <i class="fas fa-check"></i>
+                  {{ form.user_access_agreement.value }}
+              </span>
+              </td>
             <td>{{ form.role }}</td>
 
           {% else %}
@@ -63,7 +68,14 @@
             <td><div class="text-muted">{{ form.first_name.value }}</div></td>
             <td><div class="text-muted">{{ form.last_name.value }}</div></td>
             <td><div class="text-muted">{{ form.email.value }}</div></td>
-              <td><div><span class="badge badge-danger">{{ form.user_access_agreement.value }}</span></div></td>
+              <td>
+                  <div>
+                  <span class="badge badge-danger">
+                      <i class="fas fa-times"></i>
+                      {{ form.user_access_agreement.value }}
+                  </span>
+              </div>
+              </td>
 
             {% comment %} NOTE: cannot remove this, so hide it {% endcomment %}
             <td><div class="d-none">{{ form.role }}</div></td>

--- a/coldfront/core/project/templates/project/add_user_search_results.html
+++ b/coldfront/core/project/templates/project/add_user_search_results.html
@@ -38,7 +38,9 @@
           <th scope="col">First Name</th>
           <th scope="col">Last Name</th>
           <th scope="col">Email</th>
+          <th scope="col">User Access Agreement</th>
           <th scope="col">Role</th>
+
         </tr>
       </thead>
       <tbody>
@@ -52,13 +54,16 @@
             <td>{{ form.first_name.value }}</td>
             <td>{{ form.last_name.value }}</td>
             <td>{{ form.email.value }}</td>
+              <td><span class="badge badge-success">{{ form.user_access_agreement.value }}</span></td>
             <td>{{ form.role }}</td>
+
           {% else %}
             <td><div class="text-muted">{{ form.counter }}</div></td>
             <td><div class="text-muted">{{ form.username.value }}</div></td>
             <td><div class="text-muted">{{ form.first_name.value }}</div></td>
             <td><div class="text-muted">{{ form.last_name.value }}</div></td>
             <td><div class="text-muted">{{ form.email.value }}</div></td>
+              <td><div><span class="badge badge-danger">{{ form.user_access_agreement.value }}</span></div></td>
 
             {% comment %} NOTE: cannot remove this, so hide it {% endcomment %}
             <td><div class="d-none">{{ form.role }}</div></td>

--- a/coldfront/core/project/templates/project/project_add_users.html
+++ b/coldfront/core/project/templates/project/project_add_users.html
@@ -29,7 +29,9 @@ Add Users to Project
 <div class="col" id="search_results" >
     <div class="card border-light">
       <div class="card-body">
-        <p>You may only add users who have signed the access agreement (no check box will appear below for those who have not signed). In addition, users who have requests to join this project appear <a href="{% url 'project-review-join-requests' project.pk %}">here</a>.</p>
+          <div class="alert alert-warning" role="alert">
+              <p>You may only add users who have signed the access agreement (no check box will appear below for those who have not signed). In addition, users who have requests to join this project appear <a href="{% url 'project-review-join-requests' project.pk %}">here</a>.</p>
+          </div>
         <div id="search_results_inner"></div>
       </div>
     </div>

--- a/coldfront/core/project/templates/project/project_add_users.html
+++ b/coldfront/core/project/templates/project/project_add_users.html
@@ -30,7 +30,7 @@ Add Users to Project
     <div class="card border-light">
       <div class="card-body">
           <div class="alert alert-warning" role="alert">
-              <p>You may only add users who have signed the access agreement (no check box will appear below for those who have not signed). In addition, users who have requests to join this project appear <a href="{% url 'project-review-join-requests' project.pk %}">here</a>.</p>
+              You may only add users who have signed the access agreement (no check box will appear below for those who have not signed). In addition, users who have requests to join this project appear <a href="{% url 'project-review-join-requests' project.pk %}">here</a>.
           </div>
         <div id="search_results_inner"></div>
       </div>

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -881,15 +881,18 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                 allocation_form_data.remove('__select_all__')
 
             unsigned_users = []
+            added_users = []
             for form in formset:
                 user_form_data = form.cleaned_data
-
+                print(user_form_data['username'])
                 # recording users with unsigned user access agreements
                 if user_form_data['user_access_agreement'] == 'Unsigned':
                     unsigned_users.append(user_form_data['username'])
+                    continue
 
                 if user_form_data['selected']:
                     added_users_count += 1
+                    added_users.append(user_form_data['username'])
 
                     # Will create local copy of user if not already present in local database
                     user_obj, _ = User.objects.get_or_create(
@@ -974,8 +977,9 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                 messages.error(request, message)
 
             if added_users_count != 0:
+                added_users_string = ", ".join(added_users)
                 messages.success(
-                    request, 'Added {} users to project.'.format(added_users_count))
+                    request, 'Added [{}] to project.'.format(added_users_string))
 
                 message = (
                     f'Requested cluster access under project for '

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -884,7 +884,7 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
             added_users = []
             for form in formset:
                 user_form_data = form.cleaned_data
-                print(user_form_data['username'])
+
                 # recording users with unsigned user access agreements
                 if user_form_data['user_access_agreement'] == 'Unsigned':
                     unsigned_users.append(user_form_data['username'])

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -958,17 +958,8 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                             self.logger.error(message)
                             self.logger.exception(e)
 
-            if added_users_count != 0:
-                messages.success(
-                    request, 'Added {} users to project.'.format(added_users_count))
-
-                message = (
-                    f'Requested cluster access under project for '
-                    f'{cluster_access_requests_count} users.')
-                messages.success(request, message)
-
             # checking if there were any users with unsigned user access agreements in the form
-            elif unsigned_users:
+            if unsigned_users:
                 unsigned_users_string = ", ".join(unsigned_users)
 
                 # changing grammar for one vs multiple users
@@ -981,6 +972,16 @@ class ProjectAddUsersView(LoginRequiredMixin, UserPassesTestMixin, View):
                               f'a signed User Access Agreement and were ' \
                               f'therefore not added to the project.'
                 messages.error(request, message)
+
+            if added_users_count != 0:
+                messages.success(
+                    request, 'Added {} users to project.'.format(added_users_count))
+
+                message = (
+                    f'Requested cluster access under project for '
+                    f'{cluster_access_requests_count} users.')
+                messages.success(request, message)
+
             else:
                 messages.info(request, 'No users selected to add.')
 


### PR DESCRIPTION
-Added new field in ProjectAddUserForm for user_access_agreement
-added column in search table with signed/unsigned status
-made warning on /project/id/add-users-search more visible
-added error messages if PI uses "select all" checkbox to add users and some of the users have not signed access agreement

-also ran into an issue where PIs could not login if the project.name = None
-added logic in /core/portal/views.py line 52 to avoid this. sets a temporary project name.