### PR TITLE
issue_248: searching allocations on username error

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -411,7 +411,7 @@ class AllocationListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
             # username
             if data.get('username'):
                 allocations = allocations.filter(
-                    Q(username__icontains=data.get('username')) &
+                    Q(allocationuser__user__username__icontains=data.get('username')) &
                     (Q(project__projectuser__role__name='Principal Investigator') |
                      Q(allocationuser__status__name='Active'))
                 )


### PR DESCRIPTION
I looked into this and got a different error than what you described. I got the error 
```FieldError at /allocation/ Cannot resolve keyword 'username' into field. Choices are: allocationadminnote, allocationattribute, allocationuser, ...```

It was due to this query on line 414 of core/allocation/views.py:

```Q(username__icontains=data.get('username'))```

I changed it to

```Q(allocationuser__user__username__icontains=data.get('username'))```

Searching via usernames seems to work now.