### PR TITLE
Issue 154, staff permissions

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1042,9 +1042,6 @@ class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, Templat
         if self.request.user.is_superuser:
             return True
 
-        if self.request.user.has_perm('allocation.can_review_allocation_requests'):
-            return True
-
         messages.error(
             self.request, 'You do not have permission to review allocation requests.')
 

--- a/coldfront/core/utils/management/commands/create_staff_group.py
+++ b/coldfront/core/utils/management/commands/create_staff_group.py
@@ -8,10 +8,12 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         new_group, created = Group.objects.get_or_create(name='staff_group')
 
+        if not created:
+            new_group.permissions.clear()
+
         perm_codename_lst = ['view_vectorprojectallocationrequest',
                              'view_savioprojectallocationrequest',
                              'can_review_cluster_account_requests',
-                             'can_review_allocation_requests',
                              'can_review_pending_project_reviews',
                              'can_view_all_allocations',
                              'can_view_all_projects',

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -17,10 +17,6 @@
     {% if perms.project.can_review_pending_project_reviews %}
     <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
     {% endif %}
-    {% if perms.allocation.can_review_allocation_requests %}
-    <a id="navbar-allocation-requests" class="dropdown-item" href="{% url 'allocation-request-list' %}">
-      Allocation Requests</a>
-    {% endif %}
     {% if perms.allocation.can_review_cluster_account_requests %}
     <a id="navbar-cluster-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}">
         Cluster Requests</a>


### PR DESCRIPTION
Staff can now have read access to
-all users + user detail view + projects associated with user
-all projects + pending join requests for project
-cluster access requests
-savio project requests
-vector project requests