### PR TITLE
Permanently redirect HTTP to HTTPS

### DIFF
--- a/bootstrap/ansible/cf_mybrc_wsgi_conf_ssl.tmpl
+++ b/bootstrap/ansible/cf_mybrc_wsgi_conf_ssl.tmpl
@@ -45,6 +45,6 @@ WSGIPassAuthorization On
 <VirtualHost {{ host_ip }}:80>
 
     ServerName {{ hostname }}
-    Redirect "/" "{{ full_host_path }}"
+    Redirect permanent "/" "{{ full_host_path }}"
 
 </VirtualHost>


### PR DESCRIPTION
Refs #230

**Changes**
- Added the `permanent` keyword to the `Redirect` directive in the Ansible template for the Apache HTTPS configuration file.
    - This causes a 301 redirect, which should get cached in the browser.