### PR TITLE
fixed one line that got added by accident somehow

### DIFF
--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -2510,8 +2510,6 @@ class SavioProjectRequestListView(LoginRequiredMixin, TemplateView):
             *args, **kwargs)
         context['request_filter'] = (
             'completed' if self.completed else 'pending')
-        context['savio_project_request_list'] = \
-            SavioProjectAllocationRequest.objects.filter(*args, **kwargs)
 
         return context
 


### PR DESCRIPTION
Fixes #284

**Changes**
- Removed a line that clobbered the value of a template variable, setting it to the incorrect queryset.
    - The line was introduced when incorrectly resolving a merge conflict [here](https://github.com/ucb-rit/coldfront/pull/274/files#diff-cdebbdec350c291247bbd79c8fb68bd6f2b6318c10b9abc8374072378be7c14eR2513).

**How to Test**
- Manual Testing
    - Create some pending requests.
    - Navigate to the list of pending requests.
    - Ensure that sorting on individual columns behaves as expected.