### PR TITLE
Issue 282: Modifying Staff and Admin Dropdown menus

### DIFF
--- a/coldfront/templates/common/authorized_navbar.html
+++ b/coldfront/templates/common/authorized_navbar.html
@@ -49,3 +49,25 @@
     </div>
   </div>
 </nav>
+
+<style>
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu a::after {
+        transform: rotate(-90deg);
+        position: absolute;
+        right: 6px;
+        top: .8em;
+    }
+
+    .dropdown-submenu .dropdown-menu {
+        top: 0;
+        left: 100%;
+        margin-left: -.1rem;
+        margin-right: -.1rem;
+    }
+
+    .dropdown-submenu:hover>.dropdown-menu{display:block;}
+</style>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -1,22 +1,20 @@
 <li id="navbar-admin" class="nav-item dropdown">
   <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin</a>
   <div class="dropdown-menu">
-    <a class="dropdown-item" href="/admin">MyBRC Administration</a>
-    <a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a>
-    <a class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a>
-    <a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a>
-    <a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a>
-    <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
-<!--    <a id="navbar-allocation-requests" class="dropdown-item" href="{% url 'allocation-request-list' %}">-->
-<!--      Allocation Requests</a>-->
-    <a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
-      Cluster Account Requests
-    </a>
-    <a id="navbar-project-savio-project-requests" class="dropdown-item" href="{% url 'savio-project-pending-request-list' %}">
-      Savio Project Requests
-    </a>
-    <a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
-      Vector Project Requests
-    </a>
+      <a class="dropdown-item" href="/admin">MyBRC Administration</a>
+      <a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a>
+      <a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a>
+      <a class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a>
+      <a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
+          Cluster Account Requests
+      </a>
+      <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
+      <a id="navbar-project-savio-project-requests" class="dropdown-item" href="{% url 'savio-project-pending-request-list' %}">
+          Savio Project Requests
+      </a>
+      <a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a>
+      <a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
+          Vector Project Requests
+      </a>
   </div>
 </li>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -25,25 +25,3 @@
         </li>
     </ul>
 </li>
-
-<style>
-    .dropdown-submenu {
-        position: relative;
-    }
-
-    .dropdown-submenu a::after {
-        transform: rotate(-90deg);
-        position: absolute;
-        right: 6px;
-        top: .8em;
-    }
-
-    .dropdown-submenu .dropdown-menu {
-        top: 0;
-        left: 100%;
-        margin-left: -.1rem;
-        margin-right: -.1rem;
-    }
-
-    .dropdown-submenu:hover>.dropdown-menu{display:block;}
-</style>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -1,20 +1,49 @@
 <li id="navbar-admin" class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin</a>
-  <div class="dropdown-menu">
-      <a class="dropdown-item" href="/admin">MyBRC Administration</a>
-      <a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a>
-      <a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a>
-      <a class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a>
-      <a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
-          Cluster Account Requests
-      </a>
-      <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
-      <a id="navbar-project-savio-project-requests" class="dropdown-item" href="{% url 'savio-project-pending-request-list' %}">
-          Savio Project Requests
-      </a>
-      <a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a>
-      <a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
-          Vector Project Requests
-      </a>
-  </div>
+    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin</a>
+    <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+        <li><a class="dropdown-item" href="/admin">MyBRC Administration</a></li>
+        <li><a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a></li>
+        <li><a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a></li>
+        <li><a class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a></li>
+        <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
+        <li><a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a></li>
+
+
+        <li><div class="dropdown-divider"></div></li>
+        <li class="dropdown-submenu"><a class="dropdown-item dropdown-toggle" href="#">Requests</a>
+            <ul class="dropdown-menu">
+                <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
+                    Cluster Account Requests
+                </a></li>
+                <li><a id="navbar-project-savio-project-requests" class="dropdown-item" href="{% url 'savio-project-pending-request-list' %}">
+                    Savio Project Requests
+                </a></li>
+                <li><a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
+                    Vector Project Requests
+                </a></li>
+            </ul>
+        </li>
+    </ul>
 </li>
+
+<style>
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu a::after {
+        transform: rotate(-90deg);
+        position: absolute;
+        right: 6px;
+        top: .8em;
+    }
+
+    .dropdown-submenu .dropdown-menu {
+        top: 0;
+        left: 100%;
+        margin-left: -.1rem;
+        margin-right: -.1rem;
+    }
+
+    .dropdown-submenu:hover>.dropdown-menu{display:block;}
+</style>

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -6,30 +6,30 @@
   <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Staff</a>
   <div class="dropdown-menu">
     {# all staff can perform a user search #}
-    <a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a>
+      {% if perms.allocation.can_view_all_allocations %}
+          <a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a>
+      {% endif %}
+      {% if perms.project.can_view_all_projects %}
+          <a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a>
+      {% endif %}
       <a id="navbar-user-list" class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a>
-    {% if perms.project.can_view_all_projects %}
-    <a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a>
-    {% endif %}
-    {% if perms.allocation.can_view_all_allocations %}
-    <a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a>
-    {% endif %}
-    {% if perms.project.can_review_pending_project_reviews %}
-    <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
-    {% endif %}
-    {% if perms.allocation.can_review_cluster_account_requests %}
-    <a id="navbar-cluster-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}">
-        Cluster Account Requests</a>
-    {% endif %}
+      {% if perms.allocation.can_review_cluster_account_requests %}
+          <a id="navbar-cluster-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}">
+              Cluster Account Requests</a>
+      {% endif %}
+      {% if perms.project.can_review_pending_project_reviews %}
+          <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
+      {% endif %}
       {% if perms.project.view_savioprojectallocationrequest %}
-      <a id="navbar-project-savio-project-requests" class="dropdown-item" href="{% url 'savio-project-pending-request-list' %}">
-          Savio Project Requests
-      </a>
-    {% endif %}
-    {% if perms.project.view_vectorprojectallocationrequest %}
-      <a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
-          Vector Project Requests
-      </a>
-    {% endif %}
+          <a id="navbar-project-savio-project-requests" class="dropdown-item" href="{% url 'savio-project-pending-request-list' %}">
+              Savio Project Requests
+          </a>
+      {% endif %}
+      <a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a>
+      {% if perms.project.view_vectorprojectallocationrequest %}
+          <a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
+              Vector Project Requests
+          </a>
+      {% endif %}
   </div>
 </li>

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -3,33 +3,50 @@
   since existing templates use javascript to target it by ID
 {% endcomment %}
 <li id="navbar-admin" class="nav-item dropdown">
-  <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Staff</a>
-  <div class="dropdown-menu">
+    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Staff</a>
+    <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
     {# all staff can perform a user search #}
-      {% if perms.allocation.can_view_all_allocations %}
-          <a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a>
-      {% endif %}
-      {% if perms.project.can_view_all_projects %}
-          <a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a>
-      {% endif %}
-      <a id="navbar-user-list" class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a>
-      {% if perms.allocation.can_review_cluster_account_requests %}
-          <a id="navbar-cluster-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}">
-              Cluster Account Requests</a>
-      {% endif %}
-      {% if perms.project.can_review_pending_project_reviews %}
-          <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
-      {% endif %}
-      {% if perms.project.view_savioprojectallocationrequest %}
-          <a id="navbar-project-savio-project-requests" class="dropdown-item" href="{% url 'savio-project-pending-request-list' %}">
-              Savio Project Requests
-          </a>
-      {% endif %}
-      <a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a>
-      {% if perms.project.view_vectorprojectallocationrequest %}
-          <a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
-              Vector Project Requests
-          </a>
-      {% endif %}
-  </div>
+        <li><a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a></li>
+        <li><a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a></li>
+        <li><a id="navbar-user-list" class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a></li>
+        <li><a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a></li>
+        <li><a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a></li>
+
+        <li><div class="dropdown-divider"></div></li>
+        <li class="dropdown-submenu"><a class="dropdown-item dropdown-toggle" href="#">Requests</a>
+            <ul class="dropdown-menu">
+                <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
+                    Cluster Account Requests
+                </a></li>
+                <li><a id="navbar-project-savio-project-requests" class="dropdown-item" href="{% url 'savio-project-pending-request-list' %}">
+                    Savio Project Requests
+                </a></li>
+                <li><a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
+                    Vector Project Requests
+                </a></li>
+            </ul>
+        </li>
+    </ul>
 </li>
+
+<style>
+    .dropdown-submenu {
+        position: relative;
+    }
+
+    .dropdown-submenu a::after {
+        transform: rotate(-90deg);
+        position: absolute;
+        right: 6px;
+        top: .8em;
+    }
+
+    .dropdown-submenu .dropdown-menu {
+        top: 0;
+        left: 100%;
+        margin-left: -.1rem;
+        margin-right: -.1rem;
+    }
+
+    .dropdown-submenu:hover>.dropdown-menu{display:block;}
+</style>

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -28,25 +28,3 @@
         </li>
     </ul>
 </li>
-
-<style>
-    .dropdown-submenu {
-        position: relative;
-    }
-
-    .dropdown-submenu a::after {
-        transform: rotate(-90deg);
-        position: absolute;
-        right: 6px;
-        top: .8em;
-    }
-
-    .dropdown-submenu .dropdown-menu {
-        top: 0;
-        left: 100%;
-        margin-left: -.1rem;
-        margin-right: -.1rem;
-    }
-
-    .dropdown-submenu:hover>.dropdown-menu{display:block;}
-</style>


### PR DESCRIPTION
- Staff and admin drop down menus both now contain a submenu titled "Requests"
   - Cluster Account Requests, Savio Project Requests, and Vector Project Requests are in the new submenu
   - submenu is at the bottom of the original dropdown menu, separated by a divider
   - is opened by hovering over "Requests"
 
- Other menu items were placed in alphabetical order above Requests
   - "MyBRC Administration" Item in admin menu was kept at the top