### PR TITLE
Enhance "Link Your Personal Account" section of User Profile

### DIFF
--- a/coldfront/core/user/templates/user/user_profile.html
+++ b/coldfront/core/user/templates/user/user_profile.html
@@ -235,7 +235,7 @@ User Profile{% if not user == viewed_user %}: {{ viewed_user.username }}{% endif
       <i class="far fa-user-circle"></i>
       Link Your Personal Account
       <div class="float-right">
-        {% if linking_request and linking_request.status.name == 'Pending' %}
+        {% if not has_cluster_access or linking_request and linking_request.status.name == 'Pending' %}
           <a class="btn btn-secondary float-right disabled" id="request-linking-email-button">
             <i class="fas fa-paper-plane"></i>
             Request Linking Email
@@ -253,10 +253,16 @@ User Profile{% if not user == viewed_user %}: {{ viewed_user.username }}{% endif
     </div>
     <div class="card-body">
       <p>
-        You may request a new invitation to link an external identity (e.g.,
-        your personal email account or CalNet account) to your cluster account.
-        Once requested, you will receive an email containing instructions on
-        how to link your accounts.
+        If you have an active cluster account, you may request a new invitation
+        to link an external identity (e.g., your personal email account or
+        CalNet account) to it, allowing you to manage one-time password (OTP)
+        tokens. Once requested, you will receive an email containing
+        instructions on how to link your accounts.
+      </p>
+      <p>
+        If you have an LBL account, you do not need to link an external
+        identity. Instead, you can manage OTP tokens by logging into LBL
+        <a href="https://identity.lbl.gov/otptokens/hpccluster">here</a>.
       </p>
       <p>
         Emails are sent periodically. If you have not received the email after

--- a/coldfront/core/user/tests/utils.py
+++ b/coldfront/core/user/tests/utils.py
@@ -1,7 +1,48 @@
+from coldfront.api.statistics.utils import create_project_allocation
+from coldfront.api.statistics.utils import create_user_project_allocation
+from coldfront.core.allocation.models import AllocationAttributeType
+from coldfront.core.allocation.models import AllocationUserAttribute
+from coldfront.core.project.models import Project
+from coldfront.core.project.models import ProjectStatusChoice
+from coldfront.core.project.models import ProjectUser
+from coldfront.core.project.models import ProjectUserRoleChoice
+from coldfront.core.project.models import ProjectUserStatusChoice
+from decimal import Decimal
 from django.core.management import call_command
 from django.test import TestCase
 import os
 import sys
+
+
+def grant_user_cluster_access_under_test_project(user):
+    """For the given User, Create a Project named 'test_project', a
+    ProjectUser, an associated Allocation and AllocationUser, and an
+    AllocationUserAttribute of type 'Cluster Account Status' and value
+    'Active'. Return this last object."""
+    project_name = 'test_project'
+    project = Project.objects.create(
+        name=project_name,
+        status=ProjectStatusChoice.objects.get(name='Active'),
+        title=project_name,
+        description=f'Description of {project_name}.')
+    ProjectUser.objects.create(
+        project=project,
+        user=user,
+        role=ProjectUserRoleChoice.objects.get(name='User'),
+        status=ProjectUserStatusChoice.objects.get(name='Active'))
+    num_service_units = Decimal('0.00')
+    create_project_allocation(project, num_service_units)
+    objects = create_user_project_allocation(
+        user, project, num_service_units)
+    allocation = objects.allocation
+    allocation_user = objects.allocation_user
+    allocation_attribute_type = AllocationAttributeType.objects.get(
+        name='Cluster Account Status')
+    return AllocationUserAttribute.objects.create(
+        allocation_attribute_type=allocation_attribute_type,
+        allocation=allocation,
+        allocation_user=allocation_user,
+        value='Active')
 
 
 class TestUserBase(TestCase):


### PR DESCRIPTION
Fixes #306

**Changes**
- Added text directing LBL users, who do not need to link an external identity, elsewhere.
- Disabled the button to request a linking email, and disabled access to the view, if the requesting user does not have active cluster access.
- Updated tests.

**How to Test**
- Review the code changes and add comments as needed.
- Ensure that the following test suites pass:
    ```
    python manage.py test coldfront.api.user.tests
    python manage.py test coldfront.core.user.tests
    ```
- Manual Testing
    - Ensure that the request button is disabled for a user without cluster access (i.e., any user whose username is an email address).
    - Ensure that the request button is not disabled for a user with cluster access.
    - Ensure that the new text makes sense.