### PR TITLE
Add "View all projects and managers" button to home page

### DIFF
--- a/coldfront/core/portal/templates/portal/authorized_home.html
+++ b/coldfront/core/portal/templates/portal/authorized_home.html
@@ -293,6 +293,9 @@
         You are not part of any BRC cluster projects at this time. Please click Join to join any of the existing projects. You can also click Create to request setup of a new project.
       </div>
     {% endif %}
+    <a class="btn btn-primary" href="{% url 'user-projects-managers' %}">
+      View all projects and managers
+    </a>
   </div>
 
 


### PR DESCRIPTION
Based on work by @Leon-Goldner-Cohen-Tzedek, from pull request #311.

**Fixes**
- Added a button to the home page that redirects to the view that lists all of the user's projects and their managers.
    - The home page only lists active projects, while this view also includes inactive projects.