### PR TITLE
Issue 330 - direct users to portal in email alert about new join requests 

### DIFF
--- a/coldfront/templates/email/new_project_join_request.html
+++ b/coldfront/templates/email/new_project_join_request.html
@@ -1,6 +1,6 @@
 Dear managers of {{ project_name }},
 
-User {{ user_string }} has requested to join your project, {{ project_name }} via the MyBRC user portal.
+User {{ user_string }} has requested to join your project, {{ project_name }} via the MyBRC User Portal.
 
 Please approve/deny this request <a href="{{ review_url }}">here</a>.
 

--- a/coldfront/templates/email/new_project_join_request.html
+++ b/coldfront/templates/email/new_project_join_request.html
@@ -2,7 +2,7 @@ Dear managers of {{ project_name }},
 
 User {{ user_string }} has requested to join your project, {{ project_name }} via the MyBRC user portal.
 
-Please approve/deny this request here.
+Please approve/deny this request <a href="{{ review_url }}">here</a>.
 
 Thank you,
 {{ signature }}

--- a/coldfront/templates/email/new_project_join_request.txt
+++ b/coldfront/templates/email/new_project_join_request.txt
@@ -1,6 +1,6 @@
 Dear managers of {{ project_name }},
 
-User {{ user_string }} has requested to join your project, {{ project_name }} via the MyBRC user portal.
+User {{ user_string }} has requested to join your project, {{ project_name }} via the MyBRC User Portal.
 
 Please approve/deny this request here.
 

--- a/coldfront/templates/email/new_project_join_request.txt
+++ b/coldfront/templates/email/new_project_join_request.txt
@@ -2,7 +2,7 @@ Dear managers of {{ project_name }},
 
 User {{ user_string }} has requested to join your project, {{ project_name }} via the MyBRC User Portal.
 
-Please approve/deny this request here.
+Please approve/deny this request here: {{ review_url }}.
 
 Thank you,
 {{ signature }}


### PR DESCRIPTION
Added a link to the email sent to PIs/managers that contains a link to approve/deny join requests. Also changed the wording of the email from "via MyBRC user portal" to "via the MyBRC User Portal".