### PR TITLE
Warn users before they can leave multi-part forms

### DIFF
--- a/coldfront/core/project/templates/project/project_renewal/new_project_details.html
+++ b/coldfront/core/project/templates/project/project_renewal/new_project_details.html
@@ -14,6 +14,7 @@ Project Renewal - New Project Details
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <h1>New Project Details</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_renewal/new_project_survey.html
+++ b/coldfront/core/project/templates/project/project_renewal/new_project_survey.html
@@ -14,6 +14,7 @@ Project Renewal - New Project Survey
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
 <link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
 

--- a/coldfront/core/project/templates/project/project_renewal/pi_selection.html
+++ b/coldfront/core/project/templates/project/project_renewal/pi_selection.html
@@ -14,6 +14,7 @@ Project Renewal - PI Selection
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
 <link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
 

--- a/coldfront/core/project/templates/project/project_renewal/pooling_preference.html
+++ b/coldfront/core/project/templates/project/project_renewal/pooling_preference.html
@@ -14,6 +14,7 @@ Project Renewal - Pooling Preference
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <h1>Update Pooling Preference</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_renewal/project_selection.html
+++ b/coldfront/core/project/templates/project/project_renewal/project_selection.html
@@ -14,6 +14,7 @@ Project Renewal - Project Selection
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <h1>Select a Project</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_renewal/review_and_submit.html
+++ b/coldfront/core/project/templates/project/project_renewal/review_and_submit.html
@@ -14,6 +14,7 @@ Project Renewal - Review and Submit
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <h1>Review and Submit</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_request/savio/project_allocation_type.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_allocation_type.html
@@ -14,6 +14,8 @@ Savio Project Request - Allocation Type
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
+
 <h1>Savio: Allocation Type</h1><hr>
 
 <p>Select the project's allocation type.</p>

--- a/coldfront/core/project/templates/project/project_request/savio/project_details.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_details.html
@@ -14,6 +14,8 @@ Savio Project Request - Project Details
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
+
 <h1>Savio: New Project Details</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_request/savio/project_existing_pi.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_existing_pi.html
@@ -14,6 +14,7 @@ Savio Project Request - Existing PI
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
 <link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
 

--- a/coldfront/core/project/templates/project/project_request/savio/project_ica_extra_fields.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_ica_extra_fields.html
@@ -14,6 +14,7 @@ Savio Project Request - Instructional Compute Allowance Details
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <h1>Savio: Instructional Compute Allowance Details</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_request/savio/project_new_pi.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_new_pi.html
@@ -13,6 +13,7 @@ Savio Project Request - New PI
 {% endblock %}
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <h1>Savio: Principal Investigator</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_request/savio/project_pool_allocations.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_pool_allocations.html
@@ -14,6 +14,7 @@ Savio Project Request - Allocation Pooling
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <h1>Savio: Allocation Pooling</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_request/savio/project_pooled_project_selection.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_pooled_project_selection.html
@@ -14,6 +14,7 @@ Savio Project Request - Allocation Pooling
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
 <link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
 

--- a/coldfront/core/project/templates/project/project_request/savio/project_recharge_extra_fields.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_recharge_extra_fields.html
@@ -14,6 +14,7 @@ Savio Project Request - Recharge Details
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <h1>Savio: Recharge Details</h1><hr>
 
 <ol class="breadcrumb">

--- a/coldfront/core/project/templates/project/project_request/savio/project_survey.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_survey.html
@@ -14,6 +14,7 @@ Savio Project Request - Survey
 
 
 {% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
 <script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
 <link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
 

--- a/coldfront/static/common/js/leave_form_alert.js
+++ b/coldfront/static/common/js/leave_form_alert.js
@@ -1,0 +1,8 @@
+/**
+ * If any form was modified, raise a warning before the user may leave.
+ */
+$(document).ready(function() {
+    $('form').each(function() {
+        $(this).dirty({preventLeaving: true});
+    });
+});

--- a/coldfront/static/common/js/leave_form_alert.js
+++ b/coldfront/static/common/js/leave_form_alert.js
@@ -1,8 +1,27 @@
 /**
  * If any form was modified, raise a warning before the user may leave.
  */
+
+var submitted = false;
+var firstPage = false;
+
 $(document).ready(function() {
+    var bodyText = document.body.textContent || document.body.innerText;
+    if (bodyText.indexOf('Step 1 of') > -1) {
+        firstPage = true;
+    }
+
     $('form').each(function() {
         $(this).dirty({preventLeaving: true});
     });
+
+    $("form").submit(function() {
+        submitted = true;
+    });
+
+    window.onbeforeunload = function (e) {
+        if (!firstPage && !submitted) {
+            return true;
+        }
+    }
 });

--- a/coldfront/templates/common/base.html
+++ b/coldfront/templates/common/base.html
@@ -40,6 +40,9 @@
   <script src="https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min.js"></script>
   <script src="https://cdn.datatables.net/1.10.19/js/dataTables.bootstrap4.min.js"></script>
 
+  <!-- jquery.dirty -->
+  <script src="https://cdn.jsdelivr.net/npm/jquery.dirty@0.8.3"></script>
+
    <!-- Custom -->
   <link rel="stylesheet" href="{% static 'common/css/common.css' %}">
 


### PR DESCRIPTION
Fixes #190

Based on work by @jofeinstein and myself.

**Changes**
- Added JavaScript code to raise a warning when the user attempts to navigate away from/refresh/close a multi-part form.
    - In particular, raise a warning if the form was modified, or if it is not the first form, even if it was unmodified.
- Included `jquery.dirty@0.8.3` as a dependency via CDN.

**Notes**
- Run the management command `collectstatic` in order for changes to take effect.
- The user could navigate back to the first form using the "First Step" and "Previous Step" buttons. Leaving at this point would cause future progress to be lost, but this seems rare.