### PR TITLE
Issue 341 - added set_password management command

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ application should be served.
     python manage.py sqlflush | python manage.py dbshell
     # Load from the dump file.
     sh bootstrap/development/load_database_backup.sh /absolute/path/to/dump.file
+    # Set user passwords.
+    python manage.py set_passwords --password <password>
     ```
 
 ### Miscellanea

--- a/coldfront/core/user/management/commands/set_passwords.py
+++ b/coldfront/core/user/management/commands/set_passwords.py
@@ -1,0 +1,32 @@
+import logging
+
+from tqdm import tqdm
+
+from django.contrib.auth.models import User
+from django.core.management import BaseCommand, CommandError
+from django.conf import settings
+
+
+class Command(BaseCommand):
+    help = 'Command to set a common password for users in the test database.'
+    logger = logging.getLogger(__name__)
+
+    def add_arguments(self, parser):
+        parser.add_argument('--password', help='Password to set for all '
+                                               'users in test database.',
+                            type=str, required=True)
+
+    def handle(self, *args, **options):
+        """ Set user password for all users in test database """
+
+        if settings.DEBUG:
+            password = options['password']
+            for user in tqdm(User.objects.all()):
+                user.set_password(password)
+                user.save()
+
+            message = f'Set "{password}" as password for ' \
+                      f'{User.objects.count()} users.'
+            self.stdout.write(self.style.SUCCESS(message))
+        else:
+            raise CommandError('Cannot set passwords if DEBUG == False.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,5 +40,6 @@ requests==2.22.0
 six==1.12.0
 sqlparse==0.3.0
 text-unidecode==1.3
+tqdm==4.62.3
 urllib3==1.24.2
 wcwidth==0.1.7


### PR DESCRIPTION
- added set_password management command in `core/user/management/commands/set_password.py`
- resolves [issue 341](https://github.com/ucb-rit/coldfront/issues/341)
- updated README.md. added additional step in "load database from dump file" section
- added tqdm to requirements.txt