### PR TITLE
Enhance filtering in Job List view #350

### DIFF
--- a/coldfront/core/statistics/forms.py
+++ b/coldfront/core/statistics/forms.py
@@ -48,7 +48,10 @@ class JobSearchForm(forms.Form):
 
     partition = forms.CharField(label='Partition', max_length=100, required=False)
 
-    amount = forms.FloatField(label='Service Units', required=False)
+    amount = forms.FloatField(label='Service Units',
+                              required=False,
+                              widget=forms.NumberInput(
+                                  attrs={'placeholder': 'Number of Service Units'}))
 
     amount_modifier = forms.ChoiceField(
         choices=AMOUNT_MODIFIER,

--- a/coldfront/core/statistics/forms.py
+++ b/coldfront/core/statistics/forms.py
@@ -143,11 +143,11 @@ class JobSearchForm(forms.Form):
 
                 self.fields.pop('show_all_jobs')
 
-                set = ProjectUser.objects.filter(user=user,
+                active_projects = ProjectUser.objects.filter(user=user,
                                                  status__name='Active').\
                     distinct('project').values_list('project__name')
                 queryset = \
-                    Project.objects.filter(name__in=set)
+                    Project.objects.filter(name__in=active_projects)
 
         self.fields['submitdate'].label = ''
         self.fields['submit_modifier'].label = ''
@@ -159,4 +159,4 @@ class JobSearchForm(forms.Form):
         self.fields['amount_modifier'].label = ''
 
         self.fields['project_name'].widget.choices = \
-            [('', '-----')] + [(project.name, project.name) for project in queryset]
+            [('', '-----')] + [(project.name, project.name) for project in queryset.iterator()]

--- a/coldfront/core/statistics/forms.py
+++ b/coldfront/core/statistics/forms.py
@@ -124,12 +124,16 @@ class JobSearchForm(forms.Form):
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user', None)
+        is_pi = kwargs.pop('is_pi', None)
         super(JobSearchForm, self).__init__(*args, **kwargs)
 
         if user:
             if not (user.is_superuser or
                     user.has_perm('statistics.view_job')):
                 self.fields.pop('show_all_jobs')
+
+                if not is_pi:
+                    self.fields.pop('username')
 
         self.fields['submitdate'].label = ''
         self.fields['submit_modifier'].label = ''

--- a/coldfront/core/statistics/templates/job_list.html
+++ b/coldfront/core/statistics/templates/job_list.html
@@ -62,7 +62,9 @@
                             <div>{{ job_search_form.status|as_crispy_field }}</div>
                             <div>{{ job_search_form.jobslurmid|as_crispy_field }}</div>
                             <div>{{ job_search_form.project_name|as_crispy_field }}</div>
-                            <div>{{ job_search_form.username|as_crispy_field }}</div>
+                            {% if is_pi %}
+                              <div>{{ job_search_form.username|as_crispy_field }}</div>
+                            {% endif %}
                             <div>{{ job_search_form.partition|as_crispy_field }}</div>
                             <div class="row">
                               <div class="col-sm-2 ">Service Units {% include 'service_unit_popover.html' %}</div>

--- a/coldfront/core/statistics/templates/job_list.html
+++ b/coldfront/core/statistics/templates/job_list.html
@@ -246,30 +246,39 @@
         </div>
     {% endif %}
 
-    <script>
-        $("#navbar-main > ul > li.active").removeClass("active");
-        $("#navbar-project-menu").addClass("active");
-        $("#navbar-jobs-list").addClass("active");
+  <script>
+      $("#navbar-main > ul > li.active").removeClass("active");
+      $("#navbar-project-menu").addClass("active");
+      $("#navbar-jobs-list").addClass("active");
 
-        $(document).on('click', '#form_reset_button', function () {
-            resetForm($('#filter_form'));
-        });
+      $(document).on('click', '#form_reset_button', function () {
+          resetForm($('#filter_form'));
+      });
 
-        $(".datepicker").datepicker();
+      $(".datepicker").datepicker();
 
-        function resetForm($form) {
-            $form.find('input:text, input:password, input:file, select, textarea').val('');
-            $form.find("input[type='number']").val('');
-        }
+      function resetForm($form) {
+          $form.find('input:text, input:password, input:file, select, textarea').val('');
+          $form.find("input[type='number']").val('');
+      }
 
-        $("#expand_button").click(function () {
+      $("#expand_button").click(function () {
 
-            $('#collapseOne').collapse();
-            icon = $("#plus_minus");
-            icon.toggleClass("fa-plus fa-minus");
+          $('#collapseOne').collapse();
+          icon = $("#plus_minus");
+          icon.toggleClass("fa-plus fa-minus");
 
-        });
-    </script>
+      });
+  </script>
+  <script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
+  <link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
+
+  <script>
+      $('select').selectize({
+          create: true,
+          sortField: 'text'
+      })
+  </script>
 
 {% endblock %}
 {% endtimezone %}

--- a/coldfront/core/statistics/templates/job_list.html
+++ b/coldfront/core/statistics/templates/job_list.html
@@ -250,6 +250,11 @@
     {% endif %}
 
   <script>
+      $('select').selectize({
+          create: true,
+          sortField: 'text'
+      })
+
       $("#navbar-main > ul > li.active").removeClass("active");
       $("#navbar-project-menu").addClass("active");
       $("#navbar-jobs-list").addClass("active");
@@ -263,6 +268,8 @@
       function resetForm($form) {
           $form.find('input:text, input:password, input:file, select, textarea').val('');
           $form.find("input[type='number']").val('');
+
+          for (let i = 0; i < 6; i++) {$('select')[i].selectize.clear();}
       }
 
       $("#expand_button").click(function () {
@@ -272,13 +279,6 @@
           icon.toggleClass("fa-plus fa-minus");
 
       });
-  </script>
-
-  <script>
-      $('select').selectize({
-          create: true,
-          sortField: 'text'
-      })
   </script>
 
 {% endblock %}

--- a/coldfront/core/statistics/templates/job_list.html
+++ b/coldfront/core/statistics/templates/job_list.html
@@ -65,7 +65,7 @@
                             <div>{{ job_search_form.status|as_crispy_field }}</div>
                             <div>{{ job_search_form.jobslurmid|as_crispy_field }}</div>
                             <div>{{ job_search_form.project_name|as_crispy_field }}</div>
-                            {% if is_pi %}
+                            {% if show_username %}
                               <div>{{ job_search_form.username|as_crispy_field }}</div>
                             {% endif %}
                             <div>{{ job_search_form.partition|as_crispy_field }}</div>

--- a/coldfront/core/statistics/templates/job_list.html
+++ b/coldfront/core/statistics/templates/job_list.html
@@ -11,6 +11,9 @@
 
 
 {% block content %}
+  <script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
+  <link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
+
   <h1>Job List</h1>
 
   <div class="table-responsive">
@@ -270,8 +273,6 @@
 
       });
   </script>
-  <script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
-  <link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
 
   <script>
       $('select').selectize({

--- a/coldfront/core/statistics/tests/test_job_views.py
+++ b/coldfront/core/statistics/tests/test_job_views.py
@@ -205,12 +205,14 @@ class TestSlurmJobListView(TestJobBase):
         self.assertContains(response, '<span class="badge badge-success">COMPLETED</span>')
         self.assertNotContains(response, '<span class="badge badge-success">COMPLETING</span>')
         self.assertNotContains(response, 'Show All Jobs')
+        self.assertNotContains(response, 'div_id_username')
 
         # user2 should not be able to see job2
         response = self.get_response(self.user2, url)
         self.assertNotContains(response, self.job1.jobslurmid)
         self.assertNotContains(response, self.job2.jobslurmid)
         self.assertNotContains(response, 'Show All Jobs')
+        self.assertNotContains(response, 'Username')
 
     def test_pi_manager_list_view_content(self):
         """Testing content when users access SlurmJobListView"""
@@ -218,11 +220,13 @@ class TestSlurmJobListView(TestJobBase):
 
         response = self.get_response(self.pi, url)
         self.assertContains(response, self.job1.jobslurmid)
+        self.assertContains(response, 'div_id_username')
         self.assertNotContains(response, self.job2.jobslurmid)
         self.assertNotContains(response, 'Show All Jobs')
 
         response = self.get_response(self.manager, url)
         self.assertContains(response, self.job1.jobslurmid)
+        self.assertContains(response, 'div_id_username')
         self.assertNotContains(response, self.job2.jobslurmid)
         self.assertNotContains(response, 'Show All Jobs')
 
@@ -241,6 +245,7 @@ class TestSlurmJobListView(TestJobBase):
             self.assertNotContains(response, self.job2.jobslurmid)
             self.assertContains(response, 'Show All Jobs')
             self.assertContains(response, 'Viewing only jobs belonging to')
+            self.assertContains(response, 'div_id_username')
             self.assertNotContains(response, 'Viewing all jobs.')
             self.assertNotContains(response, 'Viewing your jobs and the jobs')
 
@@ -249,6 +254,7 @@ class TestSlurmJobListView(TestJobBase):
             self.assertContains(response, self.job2.jobslurmid)
             self.assertContains(response, 'Show All Jobs')
             self.assertContains(response, 'Show All Jobs')
+            self.assertContains(response, 'div_id_username')
             self.assertNotContains(response, 'Viewing only jobs belonging to')
             self.assertContains(response, 'Viewing all jobs.')
             self.assertNotContains(response, 'Viewing your jobs and the jobs')

--- a/coldfront/core/statistics/views.py
+++ b/coldfront/core/statistics/views.py
@@ -55,7 +55,7 @@ class SlurmJobListView(LoginRequiredMixin,
 
         is_pi = ProjectUser.objects.filter(
             role__name__in=['Manager', 'Principal Investigator'],
-            user=self.request.user)
+            user=self.request.user).exists()
         job_search_form = JobSearchForm(self.request.GET,
                                         user=self.request.user,
                                         is_pi=is_pi)
@@ -92,7 +92,7 @@ class SlurmJobListView(LoginRequiredMixin,
 
         is_pi = ProjectUser.objects.filter(
             role__name__in=['Manager', 'Principal Investigator'],
-            user=self.request.user)
+            user=self.request.user).exists()
         job_search_form = JobSearchForm(self.request.GET,
                                         user=self.request.user,
                                         is_pi=is_pi)
@@ -156,7 +156,7 @@ class SlurmJobListView(LoginRequiredMixin,
             self.request.user.is_superuser or \
             self.request.user.has_perm('statistics.view_job')
 
-        context['is_pi'] = not (self.request.user.is_superuser or self.request.user.has_perm('statistics.view_job')) and is_pi
+        context['show_username'] = (self.request.user.is_superuser or self.request.user.has_perm('statistics.view_job')) or is_pi
 
         return context
 


### PR DESCRIPTION
- Username search field only appears for PI/manager/staff/admin
- Now have a drop down select menu for Projects
- only projects that the user is an active member of appear
- can search incomplete project names such as "fc_" or click on project name in dropdown
- added to reset function to clear selectize values
- added tests to ensure username search field was properly popped