### PR TITLE
Issue 258 - Management command to deactivate expired ICA projects

### DIFF
--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -62,8 +62,8 @@ class Command(BaseCommand):
 
     def deactivate_project(self, project, allocation, dry_run):
         """
-        Sets project status to Inactive and corresponding compute Allocation to
-        expired. Sets allocation start date to the current date and removes
+        Sets project status to Inactive and corresponding compute allocation to
+        Expired. Sets allocation start date to the current date and removes
         the end date.
 
         If dry_run is True, write to stdout without changing object fields.
@@ -177,6 +177,8 @@ class Command(BaseCommand):
         """
         Send emails to managers/PIs of the project that have notifications
         enabled about the project deactivation.
+
+        If dry_run is True, write the emails to stdout instead.
         """
 
         if settings.EMAIL_ENABLED:

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -1,0 +1,233 @@
+from decimal import Decimal
+
+from django.template.loader import render_to_string
+
+from coldfront.api.statistics.utils import get_accounting_allocation_objects, \
+    set_project_allocation_value, set_project_user_allocation_value
+from coldfront.config import settings
+from coldfront.core.allocation.models import AllocationAttributeType
+from coldfront.core.allocation.models import AllocationStatusChoice
+from coldfront.core.allocation.utils import get_project_compute_allocation
+from coldfront.core.project.models import Project
+from coldfront.core.project.models import ProjectStatusChoice
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+import logging
+
+from coldfront.core.statistics.models import ProjectTransaction, \
+    ProjectUserTransaction
+from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.mail import send_email_template
+
+"""An admin command that sets expired ICA Projects to 'Inactive' and
+their corresponding compute Allocations to 'Expired'."""
+
+
+class Command(BaseCommand):
+
+    help = (
+        'Set expired ICA Projects to \'Inactive\' and their corresponding '
+        'compute Allocations to \'Expired\'.')
+    logger = logging.getLogger(__name__)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry_run',
+            action='store_true',
+            help='Display updates without performing them.')
+        parser.add_argument(
+            '--send-emails',
+            action='store_true',
+            default=False,
+            help='Send emails to PIs/managers about project deactivation.')
+
+    def handle(self, *args, **options):
+        """For each expired ICA Project, set its status to 'Inactive' and its
+        compute Allocation's status to 'Expired'. Zero out Service Units for
+        the Allocation and AllocationUsers.
+        """
+        current_date = utc_now_offset_aware()
+        ica_projects = Project.objects.filter(name__icontains='ic_')
+
+        for project in ica_projects:
+            allocation = get_project_compute_allocation(project)
+            expiry_date = allocation.end_date
+
+            if allocation.end_date < current_date:
+                self.deactivate_project(project, allocation, options['dry_run'])
+                self.reset_service_units(project, options['dry_run'])
+
+                if options['send_emails']:
+                    self.send_emails(project, expiry_date, options['dry_run'])
+
+    def deactivate_project(self, project, allocation, dry_run):
+        """
+        Sets project status to Inactive and corresponding compute Allocation to
+        expired. Sets allocation start date to the current date and removes
+        the end date.
+
+        If dry_run is True, write to stdout without changing object fields.
+        """
+        project_status = ProjectStatusChoice.objects.get(name='Inactive')
+        allocation_status = AllocationStatusChoice.objects.get(name='Expired')
+        current_date = utc_now_offset_aware()
+
+        if dry_run:
+            message = (
+                f'Would update Project {project.name} ({project.pk})\'s '
+                f'status to {project_status.name} and Allocation '
+                f'{allocation.pk}\'s status to {allocation_status.name}.')
+
+            self.stdout.write(self.style.WARNING(message))
+        else:
+            project.status = project_status
+            project.save()
+            allocation.status = allocation_status
+            allocation.start_date = current_date
+            allocation.end_date = None
+            allocation.save()
+
+            message = (
+                f'Updated Project {project.name} ({project.pk})\'s status to '
+                f'{project_status.name} and Allocation {allocation.pk}\'s '
+                f'status to {allocation_status.name}.')
+
+            self.logger.info(message)
+            self.stdout.write(self.style.SUCCESS(message))
+
+    def reset_service_units(self, project, dry_run):
+        """
+        Resets service units for a project and its users to 0.00. Creates
+        the relevant transaction objects to record the change. Updates the
+        relevant historical objects with the reason for the SU change.
+
+        If dry_run is True, write to stdout without changing object fields.
+        """
+        allocation_objects = get_accounting_allocation_objects(project)
+        current_allocation = Decimal(allocation_objects.allocation_attribute.value)
+        current_date = utc_now_offset_aware()
+        reason = 'Resetting SUs while deactivating expired ICA project.'
+        updated_su = Decimal('0.00')
+
+        if dry_run:
+            message = f'Would reset {project.name} and its users\'s SUs from ' \
+                      f'{current_allocation} to {updated_su}. The reason ' \
+                      f'would be: "Resetting SUs while deactivating expired ' \
+                      f'ICA project."'
+
+            self.stdout.write(self.style.WARNING(message))
+
+        else:
+            # Set the value for the Project.
+            set_project_allocation_value(project, updated_su)
+
+            # Create a transaction to record the change.
+            ProjectTransaction.objects.create(
+                project=project,
+                date_time=current_date,
+                allocation=updated_su)
+
+            # Set the reason for the change in the newly-created historical object.
+            allocation_objects.allocation_attribute.refresh_from_db()
+            historical_allocation_attribute = \
+                allocation_objects.allocation_attribute.history.latest("id")
+            historical_allocation_attribute.history_change_reason = reason
+            historical_allocation_attribute.save()
+
+            # Do the same for each ProjectUser.
+            allocation_attribute_type = AllocationAttributeType.objects.get(
+                name="Service Units")
+            for project_user in project.projectuser_set.all():
+                user = project_user.user
+                # Attempt to set the value for the ProjectUser. The method returns whether
+                # it succeeded; it may not because not every ProjectUser has a
+                # corresponding AllocationUser (e.g., PIs). Only proceed with further steps
+                # if an update occurred.
+                allocation_updated = set_project_user_allocation_value(
+                    user, project, updated_su)
+                if allocation_updated:
+                    # Create a transaction to record the change.
+                    ProjectUserTransaction.objects.create(
+                        project_user=project_user,
+                        date_time=current_date,
+                        allocation=updated_su)
+                    # Set the reason for the change in the newly-created historical object.
+                    allocation_user = \
+                        allocation_objects.allocation.allocationuser_set.get(user=user)
+                    allocation_user_attribute = \
+                        allocation_user.allocationuserattribute_set.get(
+                            allocation_attribute_type=allocation_attribute_type,
+                            allocation=allocation_objects.allocation)
+                    historical_allocation_user_attribute = \
+                        allocation_user_attribute.history.latest("id")
+                    historical_allocation_user_attribute.history_change_reason = reason
+                    historical_allocation_user_attribute.save()
+
+            message = f'Successfully reset SUs for {project.name} ' \
+                      f'and its users, updating {project.name}\'s SUs from ' \
+                      f'{current_allocation} to {updated_su}. The reason ' \
+                      f'was: "{reason}".'
+
+            self.logger.info(message)
+            self.stdout.write(self.style.SUCCESS(message))
+
+        return current_allocation
+
+    def send_emails(self, project, expiry_date, dry_run):
+        """
+        Send emails to managers/PIs of the project that have notifications
+        enabled about the project deactivation.
+        """
+
+        if settings.EMAIL_ENABLED:
+            context = {
+                'project_name': project.name,
+                'expiry_date': expiry_date,
+                'signature': settings.EMAIL_SIGNATURE,
+            }
+
+            pi_condition = Q(
+                role__name='Principal Investigator', status__name='Active',
+                enable_notifications=True)
+            manager_condition = Q(role__name='Manager', status__name='Active')
+
+            recipients = list(
+                project.projectuser_set.filter(
+                    pi_condition | manager_condition
+                ).values_list(
+                    'user__email', flat=True
+                ))
+
+            if dry_run:
+                msg_plain = \
+                    render_to_string('email/expired_ica_project.txt',
+                                     context)
+
+                message = f'Would send the following email to ' \
+                          f'{len(recipients)} users:'
+                self.stdout.write(self.style.WARNING(message))
+                self.stdout.write(self.style.WARNING(msg_plain))
+
+            else:
+                try:
+                    send_email_template(
+                        'Expired ICA Project Deactivation',
+                        'email/expired_ica_project.txt',
+                        context,
+                        settings.EMAIL_SENDER,
+                        recipients)
+
+                    message = f'Sent deactivation notification email to ' \
+                              f'{len(recipients)} users.'
+                    self.stdout.write(self.style.SUCCESS(message))
+
+                except Exception as e:
+                    message = 'Failed to send notification email. Details:'
+                    self.stderr.write(self.style.ERROR(message))
+                    self.stderr.write(self.style.ERROR(str(e)))
+                    self.logger.error(message)
+                    self.logger.exception(e)
+        else:
+            message = 'settings.EMAIL_ENABLED set to False. ' \
+                      'No emails will be sent.'
+            self.stderr.write(self.style.ERROR(message))

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -188,8 +188,7 @@ class Command(BaseCommand):
                 'signature': settings.EMAIL_SIGNATURE,
             }
 
-            recipients = list(project.managers_and_pis_with_notifications()
-                              .values_list('user__email', flat=True))
+            recipients = project.managers_and_pis_emails()
 
             if dry_run:
                 msg_plain = \

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             action='store_true',
             help='Display updates without performing them.')
         parser.add_argument(
-            '--send-emails',
+            '--send_emails',
             action='store_true',
             default=False,
             help='Send emails to PIs/managers about project deactivation.')
@@ -53,9 +53,9 @@ class Command(BaseCommand):
             allocation = get_project_compute_allocation(project)
             expiry_date = allocation.end_date
 
-            if allocation.end_date < current_date:
-                self.deactivate_project(project, allocation, options['dry_run'])
+            if expiry_date < current_date.date():
                 self.reset_service_units(project, options['dry_run'])
+                self.deactivate_project(project, allocation, options['dry_run'])
 
                 if options['send_emails']:
                     self.send_emails(project, expiry_date, options['dry_run'])

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -183,6 +183,7 @@ class Command(BaseCommand):
             context = {
                 'project_name': project.name,
                 'expiry_date': expiry_date,
+                'support_email': settings.CENTER_HELP_EMAIL,
                 'signature': settings.EMAIL_SIGNATURE,
             }
 

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -182,7 +182,7 @@ class Command(BaseCommand):
         if settings.EMAIL_ENABLED:
             context = {
                 'project_name': project.name,
-                'expiry_date': expiry_date,
+                'expiry_date': expiry_date.strftime('%m-%d-%Y'),
                 'support_email': settings.CENTER_HELP_EMAIL,
                 'signature': settings.EMAIL_SIGNATURE,
             }

--- a/coldfront/core/project/management/commands/pending_join_request_reminder.py
+++ b/coldfront/core/project/management/commands/pending_join_request_reminder.py
@@ -60,16 +60,8 @@ class Command(BaseCommand):
                     'review_url': review_project_join_requests_url(project),
                     'signature': settings.EMAIL_SIGNATURE,
                 }
-                pi_condition = Q(
-                    role__name='Principal Investigator', status__name='Active',
-                    enable_notifications=True)
-                manager_condition = Q(role__name='Manager', status__name='Active')
-                recipients = list(
-                    project.projectuser_set.filter(
-                        pi_condition | manager_condition
-                    ).values_list(
-                        'user__email', flat=True
-                    ))
+
+                recipients = project.managers_and_pis_emails()
                 try:
                     msg_plain = \
                         render_to_string('email/project_join_request/pending_project_join_requests.txt',

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.validators import MinLengthValidator
 from django.db import models
+from django.db.models import Q
 from model_utils.models import TimeStampedModel
 from simple_history.models import HistoricalRecords
 
@@ -176,6 +177,15 @@ We do not have information about your research. Please provide a detailed descri
         pi_role = ProjectUserRoleChoice.objects.get(
             name='Principal Investigator')
         return self.projectuser_set.filter(role=pi_role).count() > 1
+
+    def managers_and_pis_with_notifications(self):
+        """Return a queryset of ProjectUsers that are active managers and PIs
+        with enable_notifications=True."""
+        pi_condition = Q(
+            role__name='Principal Investigator', status__name='Active',
+            enable_notifications=True)
+        manager_condition = Q(role__name='Manager', status__name='Active')
+        return self.projectuser_set.filter(pi_condition | manager_condition)
 
     def __str__(self):
         return self.name

--- a/coldfront/core/project/models.py
+++ b/coldfront/core/project/models.py
@@ -178,14 +178,18 @@ We do not have information about your research. Please provide a detailed descri
             name='Principal Investigator')
         return self.projectuser_set.filter(role=pi_role).count() > 1
 
-    def managers_and_pis_with_notifications(self):
-        """Return a queryset of ProjectUsers that are active managers and PIs
-        with enable_notifications=True."""
+    def managers_and_pis_emails(self):
+        """Return a list of emails belonging to active managers and PIs that
+        have enable_notifications=True."""
         pi_condition = Q(
             role__name='Principal Investigator', status__name='Active',
             enable_notifications=True)
         manager_condition = Q(role__name='Manager', status__name='Active')
-        return self.projectuser_set.filter(pi_condition | manager_condition)
+
+        return list(
+            self.projectuser_set.filter(
+                pi_condition | manager_condition
+            ).distinct().values_list('user__email', flat=True))
 
     def __str__(self):
         return self.name

--- a/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
@@ -388,8 +388,7 @@ class TestDeactivateICAProjects(TestBase):
         # run command
         output, error = self.call_deactivate_command('--send_emails')
 
-        recipients = list(project.managers_and_pis_with_notifications()
-                          .values_list('user__email', flat=True))
+        recipients = project.managers_and_pis_emails()
 
         # Testing that the correct text is output to stdout
         message = f'Sent deactivation notification email to ' \

--- a/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
@@ -1,0 +1,452 @@
+import datetime
+from decimal import Decimal
+from io import StringIO
+import sys
+
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.management import call_command
+from django.db.models import Q
+
+from coldfront.api.statistics.utils import create_project_allocation, \
+    create_user_project_allocation, AccountingAllocationObjects
+from coldfront.config import settings
+from coldfront.core.allocation.models import Allocation, \
+    AllocationAttributeType, AllocationAttribute, \
+    AllocationAttributeUsage, AllocationUserStatusChoice, AllocationUser, \
+    AllocationUserAttribute, AllocationUserAttributeUsage
+from coldfront.core.project.models import Project, ProjectStatusChoice, \
+    ProjectUserStatusChoice, ProjectUserRoleChoice, ProjectUser
+from coldfront.core.project.utils import get_project_compute_allocation
+from coldfront.core.statistics.models import ProjectTransaction, ProjectUserTransaction
+from coldfront.core.user.models import UserProfile
+from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.tests.test_base import TestBase
+
+
+class TestDeactivateICAProject(TestBase):
+    """Class for testing the management command deactivate_ica_projects"""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+
+        # Create a PI.
+        self.pi = User.objects.create(
+            username='pi0', email='pi0@nonexistent.com')
+        user_profile = UserProfile.objects.get(user=self.pi)
+        user_profile.is_pi = True
+        user_profile.save()
+
+        # Create two Users.
+        for i in range(2):
+            user = User.objects.create(
+                username=f'user{i}', email=f'user{i}@nonexistent.com')
+            user_profile = UserProfile.objects.get(user=user)
+            user_profile.cluster_uid = f'{i}'
+            user_profile.save()
+            setattr(self, f'user{i}', user)
+            setattr(self, f'user_profile{i}', user_profile)
+
+        # Create Projects and associate Users with them.
+        project_status = ProjectStatusChoice.objects.get(name='Active')
+        project_user_status = ProjectUserStatusChoice.objects.get(
+            name='Active')
+        user_role = ProjectUserRoleChoice.objects.get(name='User')
+        manager_role = ProjectUserRoleChoice.objects.get(name='Manager')
+        current_date = utc_now_offset_aware()
+
+        for i in range(2):
+            # Create an ICA Project and ProjectUsers.
+            project = Project.objects.create(
+                name=f'ic_project{i}', status=project_status)
+            setattr(self, f'ic_project{i}', project)
+            for j in range(2):
+                ProjectUser.objects.create(
+                    user=getattr(self, f'user{j}'), project=project,
+                    role=user_role, status=project_user_status)
+            ProjectUser.objects.create(
+                user=self.pi, project=project, role=manager_role,
+                status=project_user_status)
+
+            # Create a compute allocation for the Project.
+            allocation = Decimal(f'{i + 1}000.00')
+            create_project_allocation(project, allocation)
+
+            # Set start and end dates for allocations
+            allocation_object = get_project_compute_allocation(project)
+            allocation_object.start_date = \
+                current_date - datetime.timedelta(days=(i+1)*5)
+            allocation_object.end_date = \
+                current_date + datetime.timedelta(days=(i+1)*5)
+            allocation_object.save()
+
+            # Create a compute allocation for each User on the Project.
+            for j in range(2):
+                create_user_project_allocation(
+                    getattr(self, f'user{j}'), project, allocation / 2)
+
+        # Clear the mail outbox.
+        mail.outbox = []
+
+    def get_accounting_allocation_objects(self, project, user=None):
+        """Return a namedtuple of database objects related to accounting and
+        allocation for the given project and optional user.
+
+        Parameters:
+            - project (Project): an instance of the Project model
+            - user (User): an instance of the User model
+
+        Returns:
+            - AccountingAllocationObjects instance
+
+        Raises:
+            - MultipleObjectsReturned, if a database retrieval returns more
+            than one object
+            - ObjectDoesNotExist, if a database retrieval returns less than
+            one object
+            - TypeError, if one or more inputs has the wrong type
+
+        NOTE: this function was taken from coldfront.core.statistics.utils.
+        This version does not check that the allocation status is Active
+        """
+        if not isinstance(project, Project):
+            raise TypeError(f'Project {project} is not a Project object.')
+
+        objects = AccountingAllocationObjects()
+
+        allocation = Allocation.objects.get(
+            project=project, resources__name='Savio Compute')
+
+        # Check that the allocation has an attribute for Service Units and
+        # an associated usage.
+        allocation_attribute_type = AllocationAttributeType.objects.get(
+            name='Service Units')
+        allocation_attribute = AllocationAttribute.objects.get(
+            allocation_attribute_type=allocation_attribute_type,
+            allocation=allocation)
+        allocation_attribute_usage = AllocationAttributeUsage.objects.get(
+            allocation_attribute=allocation_attribute)
+
+        objects.allocation = allocation
+        objects.allocation_attribute = allocation_attribute
+        objects.allocation_attribute_usage = allocation_attribute_usage
+
+        if user is None:
+            return objects
+
+        if not isinstance(user, User):
+            raise TypeError(f'User {user} is not a User object.')
+
+        # Check that there is an active association between the user and project.
+        active_status = ProjectUserStatusChoice.objects.get(name='Active')
+        ProjectUser.objects.get(user=user, project=project, status=active_status)
+
+        # Check that the user is an active member of the allocation.
+        active_status = AllocationUserStatusChoice.objects.get(name='Active')
+        allocation_user = AllocationUser.objects.get(
+            allocation=allocation, user=user, status=active_status)
+
+        # Check that the allocation user has an attribute for Service Units
+        # and an associated usage.
+        allocation_user_attribute = AllocationUserAttribute.objects.get(
+            allocation_attribute_type=allocation_attribute_type,
+            allocation=allocation, allocation_user=allocation_user)
+        allocation_user_attribute_usage = AllocationUserAttributeUsage.objects.get(
+            allocation_user_attribute=allocation_user_attribute)
+
+        objects.allocation_user = allocation_user
+        objects.allocation_user_attribute = allocation_user_attribute
+        objects.allocation_user_attribute_usage = allocation_user_attribute_usage
+
+        return objects
+
+    def create_expired_project(self, project_name):
+        """Change the end date of ic_project0 to be expired"""
+        project = Project.objects.get(name=project_name)
+        allocation = get_project_compute_allocation(project)
+        current_date = utc_now_offset_aware()
+        expired_date = (current_date - datetime.timedelta(days=4)).date()
+
+        allocation.end_date = expired_date
+        allocation.save()
+        allocation.refresh_from_db()
+        self.assertEqual(allocation.end_date, expired_date)
+
+    def record_historical_objects_len(self, project):
+        """ Records the lengths of all relevant historical objects to a dict"""
+        length_dict = {}
+        allocation_objects = self.get_accounting_allocation_objects(project)
+        historical_allocation_attribute = \
+            allocation_objects.allocation_attribute.history.all()
+
+        length_dict['historical_allocation_attribute'] = \
+            len(historical_allocation_attribute)
+
+        allocation_attribute_type = AllocationAttributeType.objects.get(
+            name="Service Units")
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            allocation_user = \
+                allocation_objects.allocation.allocationuser_set.get(
+                    user=project_user.user)
+            allocation_user_attribute = \
+                allocation_user.allocationuserattribute_set.get(
+                    allocation_attribute_type=allocation_attribute_type,
+                    allocation=allocation_objects.allocation)
+            historical_allocation_user_attribute = \
+                allocation_user_attribute.history.all()
+
+            key = 'historical_allocation_user_attribute_' + project_user.user.username
+            length_dict[key] = len(historical_allocation_user_attribute)
+
+        return length_dict
+
+    def allocation_values_test(self, project, value, user_value):
+        """
+        Tests that the allocation user values are correct
+        """
+        allocation_objects = self.get_accounting_allocation_objects(project)
+        self.assertEqual(allocation_objects.allocation_attribute.value, value)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+            allocation_objects = self.get_accounting_allocation_objects(
+                project, user=project_user.user)
+
+            self.assertEqual(allocation_objects.allocation_user_attribute.value,
+                             user_value)
+
+    def transactions_created(self, project, pre_time, post_time, amount):
+        """
+        Tests that transactions were created for the zeroing of SUs
+        """
+        proj_transaction = ProjectTransaction.objects.get(project=project,
+                                                          allocation=amount)
+
+        self.assertTrue(pre_time <= proj_transaction.date_time <= post_time)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            proj_user_transaction = ProjectUserTransaction.objects.get(
+                project_user=project_user,
+                allocation=amount)
+
+            self.assertTrue(pre_time <= proj_user_transaction.date_time <= post_time)
+
+    def historical_objects_created(self, pre_length_dict, post_length_dict):
+        """Test that historical objects were created"""
+        for k, v in pre_length_dict.items():
+            self.assertEqual(v + 1, post_length_dict[k])
+
+    def historical_objects_updated(self, project):
+        """
+        Tests that the relevant historical objects have the correct reason
+        """
+        reason = 'Resetting SUs while deactivating expired ICA project.'
+        allocation_objects = self.get_accounting_allocation_objects(project)
+        historical_allocation_attribute = \
+            allocation_objects.allocation_attribute.history.latest("id")
+        historical_reason = historical_allocation_attribute.history_change_reason
+
+        self.assertEqual(historical_reason, reason)
+
+        allocation_attribute_type = AllocationAttributeType.objects.get(
+            name="Service Units")
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            allocation_user = \
+                allocation_objects.allocation.allocationuser_set.get(
+                    user=project_user.user)
+            allocation_user_attribute = \
+                allocation_user.allocationuserattribute_set.get(
+                    allocation_attribute_type=allocation_attribute_type,
+                    allocation=allocation_objects.allocation)
+            historical_allocation_user_attribute = \
+                allocation_user_attribute.history.latest("id")
+            historical_reason = \
+                historical_allocation_user_attribute.history_change_reason
+            self.assertEqual(historical_reason, reason)
+
+    def project_allocation_updates(self, project, allocation, pre_time, post_time):
+        """Tests that the project and allocation were correctly updated"""
+        self.assertEqual(project.status.name, 'Inactive')
+        self.assertEqual(allocation.status.name, 'Expired')
+        self.assertTrue(pre_time.date() <= allocation.start_date <= post_time.date())
+        self.assertTrue(allocation.end_date is None)
+
+    def test_dry_run_no_expired_projects(self):
+        """Testing a dry run in which no ICA projects are expired"""
+        out, err = StringIO(''), StringIO('')
+        call_command('deactivate_ica_projects',
+                     '--dry_run',
+                     '--send_emails',
+                     stdout=out,
+                     stderr=err)
+        sys.stdout = sys.__stdout__
+        out.seek(0)
+
+        self.assertIn(out.read(), '')
+        err.seek(0)
+        self.assertEqual(err.read(), '')
+
+    def test_dry_run_with_expired_projects(self):
+        """Testing a dry run in which an ICA project is expired"""
+        self.create_expired_project('ic_project0')
+
+        out, err = StringIO(''), StringIO('')
+        call_command('deactivate_ica_projects',
+                     '--dry_run',
+                     '--send_emails',
+                     stdout=out,
+                     stderr=err)
+        sys.stdout = sys.__stdout__
+        out.seek(0)
+
+        console_output = out.read()
+
+        project = Project.objects.get(name='ic_project0')
+        allocation = get_project_compute_allocation(project)
+
+        # Messages that should be output to stdout during a dry run
+        messages = [f'Would update Project {project.name} ({project.pk})\'s '
+                    f'status to Inactive and Allocation '
+                    f'{allocation.pk}\'s status to Expired.',
+
+                    f'Would reset {project.name} and its users\'s SUs from '
+                    f'1000.00 to 0.00. The reason '
+                    f'would be: "Resetting SUs while deactivating expired '
+                    f'ICA project."',
+
+                    'Would send the following email to 1 users:',
+                    f'Dear managers of {project.name},',
+
+                    f'This is a notification that the project {project.name} '
+                    f'expired on {allocation.end_date.strftime("%m-%d-%Y")} '
+                    f'and has therefore been deactivated. '
+                    f'Accounts under this project will no longer be able '
+                    f'to access its compute resources.']
+
+        for message in messages:
+            self.assertIn(message, console_output)
+
+        err.seek(0)
+        self.assertEqual(err.read(), '')
+
+    def test_creates_and_updates_objects(self):
+        """Testing deactivate_ica_projects WITHOUT send_emails flag"""
+        self.create_expired_project('ic_project0')
+
+        project = Project.objects.get(name='ic_project0')
+        allocation = get_project_compute_allocation(project)
+
+        pre_time = utc_now_offset_aware()
+        pre_length_dict = self.record_historical_objects_len(project)
+
+        # test allocation values before command
+        self.allocation_values_test(project, '1000.00', '500.00')
+
+        # run command
+        out, err = StringIO(''), StringIO('')
+        call_command('deactivate_ica_projects',
+                     stdout=out,
+                     stderr=err)
+        sys.stdout = sys.__stdout__
+        out.seek(0)
+        console_output = out.read()
+
+        messages = [
+            f'Updated Project {project.name} ({project.pk})\'s status to '
+            f'Inactive and Allocation {allocation.pk}\'s '
+            f'status to Expired.',
+
+            f'Successfully reset SUs for {project.name} '
+            f'and its users, updating {project.name}\'s SUs from '
+            f'1000.00 to 0.00. The reason '
+            f'was: "Resetting SUs while deactivating expired ICA '
+            f'project.".']
+
+        for message in messages:
+            self.assertIn(message, console_output)
+        err.seek(0)
+        self.assertEqual(err.read(), '')
+
+        post_time = utc_now_offset_aware()
+        project.refresh_from_db()
+        allocation.refresh_from_db()
+
+        # test project and allocation statuses
+        self.project_allocation_updates(project, allocation, pre_time, post_time)
+
+        # test allocation values after command
+        self.allocation_values_test(project, '0.00', '0.00')
+
+        # test ProjectTransaction created
+        self.transactions_created(project, pre_time, post_time, 0.00)
+
+        # test historical objects created and updated
+        post_length_dict = self.record_historical_objects_len(project)
+        self.historical_objects_created(pre_length_dict, post_length_dict)
+        self.historical_objects_updated(project)
+
+    def test_emails_sent(self):
+        """
+        Tests that emails are sent correctly when there is an expired
+        ICA project
+        """
+
+        self.create_expired_project('ic_project0')
+
+        project = Project.objects.get(name='ic_project0')
+        allocation = get_project_compute_allocation(project)
+        old_end_date = allocation.end_date
+
+        # run command
+        out, err = StringIO(''), StringIO('')
+        call_command('deactivate_ica_projects',
+                     '--send_emails',
+                     stdout=out,
+                     stderr=err)
+        sys.stdout = sys.__stdout__
+        out.seek(0)
+
+        pi_condition = Q(
+            role__name='Principal Investigator', status__name='Active',
+            enable_notifications=True)
+        manager_condition = Q(role__name='Manager', status__name='Active')
+
+        recipients = list(
+            project.projectuser_set.filter(
+                pi_condition | manager_condition
+            ).values_list(
+                'user__email', flat=True
+            ))
+
+        # Testing that the correct text is output to stdout
+        message = f'Sent deactivation notification email to ' \
+                  f'{len(recipients)} users.'
+        self.assertIn(message, out.read())
+
+        # Testing that the correct number of emails were sent
+        self.assertEqual(len(mail.outbox), len(recipients))
+
+        email_body = [f'Dear managers of {project.name},',
+
+                      f'This is a notification that the project {project.name} '
+                      f'expired on {old_end_date.strftime("%m-%d-%Y")} '
+                      f'and has therefore been deactivated. '
+                      f'Accounts under this project will no longer be able '
+                      f'to access its compute resources.']
+
+        for email in mail.outbox:
+            for section in email_body:
+                self.assertIn(section, email.body)
+            self.assertIn(email.to[0], recipients)
+            self.assertEqual(settings.EMAIL_SENDER, email.from_email)

--- a/coldfront/core/project/tests/test_commands/test_pending_auto_request_reminder.py
+++ b/coldfront/core/project/tests/test_commands/test_pending_auto_request_reminder.py
@@ -149,16 +149,7 @@ class TestPendingJoinRequestReminderCommand(TestCase):
         call_command('pending_join_request_reminder', stdout=out, stderr=err)
         sys.stdout = sys.__stdout__
 
-        pi_condition = Q(
-            role__name='Principal Investigator', status__name='Active',
-            enable_notifications=True)
-        manager_condition = Q(role__name='Manager', status__name='Active')
-        manager_emails = list(
-            self.project1.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
+        manager_emails = self.project1.managers_and_pis_emails()
 
         for email in mail.outbox:
             for addr in email.to:
@@ -208,16 +199,7 @@ class TestPendingJoinRequestReminderCommand(TestCase):
         call_command('pending_join_request_reminder', stdout=out, stderr=err)
         sys.stdout = sys.__stdout__
 
-        pi_condition = Q(
-            role__name='Principal Investigator', status__name='Active',
-            enable_notifications=True)
-        manager_condition = Q(role__name='Manager', status__name='Active')
-        manager_emails = list(
-            self.project1.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
+        manager_emails = self.project1.managers_and_pis_emails()
 
         for email in mail.outbox:
             for addr in email.to:
@@ -297,23 +279,7 @@ class TestPendingJoinRequestReminderCommand(TestCase):
         call_command('pending_join_request_reminder', stdout=out, stderr=err)
         sys.stdout = sys.__stdout__
 
-        pi_condition = Q(
-            role__name='Principal Investigator', status__name='Active',
-            enable_notifications=True)
-        manager_condition = Q(role__name='Manager', status__name='Active')
-        manager_emails1 = list(
-            self.project1.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
-
-        manager_emails2 = list(
-            project2.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
+        manager_emails1 = self.project1.managers_and_pis_emails()
 
         for email in mail.outbox:
             for addr in email.to:
@@ -381,16 +347,7 @@ class TestPendingJoinRequestReminderCommand(TestCase):
         call_command('pending_join_request_reminder', stdout=out, stderr=err)
         sys.stdout = sys.__stdout__
 
-        pi_condition = Q(
-            role__name='Principal Investigator', status__name='Active',
-            enable_notifications=True)
-        manager_condition = Q(role__name='Manager', status__name='Active')
-        manager_emails = list(
-            self.project1.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
+        manager_emails = self.project1.managers_and_pis_emails()
 
         for email in mail.outbox:
             for addr in email.to:

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -128,16 +128,7 @@ def send_project_join_notification_email(project, project_user):
                'review_url': review_project_join_requests_url(project),
                'url': __project_detail_url(project)}
 
-    pi_condition = Q(
-        role__name='Principal Investigator', status__name='Active',
-        enable_notifications=True)
-    manager_condition = Q(role__name='Manager', status__name='Active')
-    receiver_list = list(
-        project.projectuser_set.filter(
-            pi_condition | manager_condition
-        ).values_list(
-            'user__email', flat=True
-        ))
+    receiver_list = project.managers_and_pis_emails()
 
     msg_plain = \
         render_to_string('email/new_project_join_request.txt',
@@ -438,18 +429,7 @@ def send_project_request_pooling_email(request):
     }
 
     sender = settings.EMAIL_SENDER
-
-    pi_condition = Q(
-        role__name='Principal Investigator', status__name='Active',
-        enable_notifications=True)
-    manager_condition = Q(role__name='Manager', status__name='Active')
-    receiver_list = list(
-        request.project.projectuser_set.filter(
-            pi_condition | manager_condition
-        ).values_list(
-            'user__email', flat=True
-        ))
-
+    receiver_list = request.project.managers_and_pis_emails()
     send_email_template(subject, template_name, context, sender, receiver_list)
 
 

--- a/coldfront/core/project/utils_/email_utils.py
+++ b/coldfront/core/project/utils_/email_utils.py
@@ -22,11 +22,4 @@ def project_email_receiver_list(project):
     """
     if not isinstance(project, Project):
         raise TypeError(f'{project} is not a Project object.')
-    pi_condition = Q(
-        role__name='Principal Investigator', status__name='Active',
-        enable_notifications=True)
-    manager_condition = Q(role__name='Manager', status__name='Active')
-    return list(
-        project.projectuser_set.filter(
-            pi_condition | manager_condition
-        ).distinct().values_list('user__email', flat=True))
+    return project.managers_and_pis_emails()

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -334,16 +334,7 @@ def send_new_allocation_renewal_request_pooling_notification_email(request):
     }
 
     sender = settings.EMAIL_SENDER
-    pi_condition = Q(
-        role__name='Principal Investigator', status__name='Active',
-        enable_notifications=True)
-    manager_condition = Q(role__name='Manager', status__name='Active')
-    receiver_list = list(
-        request.post_project.projectuser_set.filter(
-            pi_condition | manager_condition
-        ).values_list(
-            'user__email', flat=True
-        ))
+    receiver_list = request.post_project.managers_and_pis_emails()
 
     send_email_template(subject, template_name, context, sender, receiver_list)
 

--- a/coldfront/templates/email/expired_ica_project.txt
+++ b/coldfront/templates/email/expired_ica_project.txt
@@ -3,5 +3,7 @@ Dear managers of {{ project_name }},
 This is a notification that the project {{ project_name }} expired on {{ expiry_date }} and has therefore been
 deactivated. Accounts under this project will no longer be able to access its compute resources.
 
+If you believe this is a mistake, please contact us at {{ support_email }}.
+
 Thank you,
 {{ signature }}

--- a/coldfront/templates/email/expired_ica_project.txt
+++ b/coldfront/templates/email/expired_ica_project.txt
@@ -1,0 +1,7 @@
+Dear managers of {{ project_name }},
+
+This is a notification that the project {{ project_name }} expired on {{ expiry_date }} and has therefore been
+deactivated. Accounts under this project will no longer be able to access its compute resources.
+
+Thank you,
+{{ signature }}

--- a/coldfront/templates/email/expired_ica_project.txt
+++ b/coldfront/templates/email/expired_ica_project.txt
@@ -1,7 +1,6 @@
 Dear managers of {{ project_name }},
 
-This is a notification that the project {{ project_name }} expired on {{ expiry_date }} and has therefore been
-deactivated. Accounts under this project will no longer be able to access its compute resources.
+This is a notification that the project {{ project_name }} expired on {{ expiry_date }} and has therefore been deactivated. Accounts under this project will no longer be able to access its compute resources.
 
 If you believe this is a mistake, please contact us at {{ support_email }}.
 


### PR DESCRIPTION
- created new management command `coldfront/core/project/management/commands/deactivate_ica_projects.py`
- added tests in `coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py`
- all tests pass on my setup

- Much of the code in `test_deactivate_ica_projects.py` is the same as code for `test_add_service_units_to_project.py` from [PR 355](https://github.com/ucb-rit/coldfront/pull/355). If we merge these branches, I can either create a new base class for both testing classes to inherit or have one of the testing classes inherit the other