### PR TITLE
Management command to deactivate expired ICA projects

### DIFF
--- a/coldfront/core/project/management/commands/add_service_units_to_project.py
+++ b/coldfront/core/project/management/commands/add_service_units_to_project.py
@@ -5,13 +5,8 @@ from django.core.management import BaseCommand, CommandError
 
 from coldfront.config import settings
 from coldfront.core.project.models import Project
-from coldfront.core.project.utils_.addition_utils import set_service_units
-from coldfront.core.statistics.models import ProjectTransaction
-from coldfront.core.statistics.models import ProjectUserTransaction
-from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.project.management.commands.utils import set_service_units
 from coldfront.api.statistics.utils import get_accounting_allocation_objects
-from coldfront.api.statistics.utils import set_project_allocation_value
-from coldfront.api.statistics.utils import set_project_user_allocation_value
 from coldfront.core.allocation.models import AllocationAttributeType, Allocation
 
 

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -1,0 +1,225 @@
+from decimal import Decimal
+
+from django.template.loader import render_to_string
+
+from coldfront.api.statistics.utils import get_accounting_allocation_objects, \
+    set_project_allocation_value, set_project_user_allocation_value, \
+    set_project_usage_value, set_project_user_usage_value
+from coldfront.config import settings
+from coldfront.core.allocation.models import AllocationStatusChoice
+from coldfront.core.allocation.utils import get_project_compute_allocation
+from coldfront.core.project.models import Project
+from coldfront.core.project.models import ProjectStatusChoice
+from django.core.management.base import BaseCommand
+import logging
+
+from coldfront.core.statistics.models import ProjectTransaction, \
+    ProjectUserTransaction
+from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.mail import send_email_template
+
+"""An admin command that sets expired ICA Projects to 'Inactive' and
+their corresponding compute Allocations to 'Expired'."""
+
+
+class Command(BaseCommand):
+
+    help = ('Expire ICA projects whose end dates have passed and optionally '
+            'notify project owners')
+    logger = logging.getLogger(__name__)
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry_run',
+            action='store_true',
+            help='Display updates without performing them.')
+        parser.add_argument(
+            '--send_emails',
+            action='store_true',
+            default=False,
+            help='Send emails to PIs/managers about project deactivation.')
+
+    def handle(self, *args, **options):
+        """For each expired ICA Project, set its status to 'Inactive' and its
+        compute Allocation's status to 'Expired'. Zero out Service Units for
+        the Allocation and AllocationUsers.
+        """
+        current_date = utc_now_offset_aware()
+        ica_projects = Project.objects.filter(name__startswith='ic_')
+
+        for project in ica_projects:
+            allocation = get_project_compute_allocation(project)
+            expiry_date = allocation.end_date
+
+            if expiry_date and expiry_date < current_date.date():
+                self.reset_service_units(project, options['dry_run'])
+                self.deactivate_project(project, allocation, options['dry_run'])
+
+                if options['send_emails']:
+                    self.send_emails(project, expiry_date, options['dry_run'])
+
+    def deactivate_project(self, project, allocation, dry_run):
+        """
+        Expire ICA projects whose end dates have passed and optionally
+        notify project owners
+
+        If dry_run is True, write to stdout without changing object fields.
+        """
+        project_status = ProjectStatusChoice.objects.get(name='Inactive')
+        allocation_status = AllocationStatusChoice.objects.get(name='Expired')
+        current_date = utc_now_offset_aware()
+
+        if dry_run:
+            message = (
+                f'Would update Project {project.name} ({project.pk})\'s '
+                f'status to {project_status.name} and Allocation '
+                f'{allocation.pk}\'s status to {allocation_status.name}.')
+
+            self.stdout.write(self.style.WARNING(message))
+        else:
+            project.status = project_status
+            project.save()
+            allocation.status = allocation_status
+            allocation.start_date = current_date
+            allocation.end_date = None
+            allocation.save()
+
+            message = (
+                f'Updated Project {project.name} ({project.pk})\'s status to '
+                f'{project_status.name} and Allocation {allocation.pk}\'s '
+                f'status to {allocation_status.name}.')
+
+            self.logger.info(message)
+            self.stdout.write(self.style.SUCCESS(message))
+
+    def set_historical_reason(self, obj, reason):
+        """Set the latest historical object reason"""
+        obj.refresh_from_db()
+        historical_obj = obj.history.latest('id')
+        historical_obj.history_change_reason = reason
+        historical_obj.save()
+
+    def reset_service_units(self, project, dry_run):
+        """
+        Resets service units for a project and its users to 0.00. Creates
+        the relevant transaction objects to record the change. Updates the
+        relevant historical objects with the reason for the SU change.
+
+        If dry_run is True, write to stdout without changing object fields.
+        """
+        allocation_objects = get_accounting_allocation_objects(project)
+        current_allocation = Decimal(allocation_objects.allocation_attribute.value)
+        current_date = utc_now_offset_aware()
+        reason = 'Resetting SUs while deactivating expired ICA project.'
+        updated_su = Decimal('0.00')
+
+        if dry_run:
+            message = f'Would reset {project.name} and its users\'s SUs from ' \
+                      f'{current_allocation} to {updated_su}. The reason ' \
+                      f'would be: "Resetting SUs while deactivating expired ' \
+                      f'ICA project."'
+
+            self.stdout.write(self.style.WARNING(message))
+
+        else:
+            # Set the value for the Project.
+            set_project_allocation_value(project, updated_su)
+            set_project_usage_value(project, updated_su)
+
+            # Create a transaction to record the change.
+            ProjectTransaction.objects.create(
+                project=project,
+                date_time=current_date,
+                allocation=updated_su)
+
+            # Set the reason for the change in the newly-created historical object.
+            self.set_historical_reason(
+                allocation_objects.allocation_attribute, reason)
+
+            # Do the same for each ProjectUser.
+            for project_user in project.projectuser_set.all():
+                user = project_user.user
+                # Attempt to set the value for the ProjectUser. The method returns whether
+                # it succeeded; it may not because not every ProjectUser has a
+                # corresponding AllocationUser (e.g., PIs). Only proceed with further steps
+                # if an update occurred.
+
+                allocation_updated = set_project_user_allocation_value(
+                    user, project, updated_su)
+                allocation_usage_updated = set_project_user_usage_value(
+                    user, project, updated_su)
+
+                if allocation_updated and allocation_usage_updated:
+                    # Create a transaction to record the change.
+                    ProjectUserTransaction.objects.create(
+                        project_user=project_user,
+                        date_time=current_date,
+                        allocation=updated_su)
+                    # Set the reason for the change in the newly-created historical object.
+
+                    allocation_user_obj = get_accounting_allocation_objects(
+                        project, user=user)
+                    self.set_historical_reason(
+                        allocation_user_obj.allocation_user_attribute, reason)
+
+            message = f'Successfully reset SUs for {project.name} ' \
+                      f'and its users, updating {project.name}\'s SUs from ' \
+                      f'{current_allocation} to {updated_su}. The reason ' \
+                      f'was: "{reason}".'
+
+            self.logger.info(message)
+            self.stdout.write(self.style.SUCCESS(message))
+
+        return current_allocation
+
+    def send_emails(self, project, expiry_date, dry_run):
+        """
+        Send emails to managers/PIs of the project that have notifications
+        enabled about the project deactivation.
+
+        If dry_run is True, write the emails to stdout instead.
+        """
+
+        if settings.EMAIL_ENABLED:
+            context = {
+                'project_name': project.name,
+                'expiry_date': expiry_date.strftime('%m-%d-%Y'),
+                'support_email': settings.CENTER_HELP_EMAIL,
+                'signature': settings.EMAIL_SIGNATURE,
+            }
+
+            recipients = project.managers_and_pis_emails()
+
+            if dry_run:
+                msg_plain = \
+                    render_to_string('email/expired_ica_project.txt',
+                                     context)
+
+                message = f'Would send the following email to ' \
+                          f'{len(recipients)} users:'
+                self.stdout.write(self.style.WARNING(message))
+                self.stdout.write(self.style.WARNING(msg_plain))
+
+            else:
+                try:
+                    send_email_template(
+                        'Expired ICA Project Deactivation',
+                        'email/expired_ica_project.txt',
+                        context,
+                        settings.EMAIL_SENDER,
+                        recipients)
+
+                    message = f'Sent deactivation notification email to ' \
+                              f'{len(recipients)} users.'
+                    self.stdout.write(self.style.SUCCESS(message))
+
+                except Exception as e:
+                    message = 'Failed to send notification email. Details:'
+                    self.stderr.write(self.style.ERROR(message))
+                    self.stderr.write(self.style.ERROR(str(e)))
+                    self.logger.error(message)
+                    self.logger.exception(e)
+        else:
+            message = 'settings.EMAIL_ENABLED set to False. ' \
+                      'No emails will be sent.'
+            self.stderr.write(self.style.ERROR(message))

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -13,9 +13,7 @@ from coldfront.core.project.models import ProjectStatusChoice
 from django.core.management.base import BaseCommand
 import logging
 
-from coldfront.core.project.utils_.addition_utils import set_service_units
-from coldfront.core.statistics.models import ProjectTransaction, \
-    ProjectUserTransaction
+from coldfront.core.project.management.commands.utils import set_service_units
 from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.utils.mail import send_email_template
 
@@ -107,7 +105,7 @@ class Command(BaseCommand):
         updated_su = Decimal('0.00')
 
         if dry_run:
-            message = f'Would reset {project.name} and its users\'s SUs from ' \
+            message = f'Would reset {project.name} and its users\' SUs from ' \
                       f'{current_allocation} to {updated_su}. The reason ' \
                       f'would be: "Resetting SUs while deactivating expired ' \
                       f'ICA project."'

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -155,8 +155,8 @@ class Command(BaseCommand):
                         project_user=project_user,
                         date_time=current_date,
                         allocation=updated_su)
-                    # Set the reason for the change in the newly-created historical object.
 
+                    # Set the reason for the change in the newly-created historical object.
                     allocation_user_obj = get_accounting_allocation_objects(
                         project, user=user)
                     self.set_historical_reason(
@@ -169,8 +169,6 @@ class Command(BaseCommand):
 
             self.logger.info(message)
             self.stdout.write(self.style.SUCCESS(message))
-
-        return current_allocation
 
     def send_emails(self, project, expiry_date, dry_run):
         """

--- a/coldfront/core/project/management/commands/deactivate_ica_projects.py
+++ b/coldfront/core/project/management/commands/deactivate_ica_projects.py
@@ -144,16 +144,12 @@ class Command(BaseCommand):
             }
 
             recipients = project.managers_and_pis_emails()
+            plural = '' if len(recipients) == 1 else 's'
 
             if dry_run:
-                msg_plain = \
-                    render_to_string('email/expired_ica_project.txt',
-                                     context)
-
-                message = f'Would send the following email to ' \
-                          f'{len(recipients)} users:'
+                message = f'Would send a notification email to ' \
+                          f'{len(recipients)} user{plural}.'
                 self.stdout.write(self.style.WARNING(message))
-                self.stdout.write(self.style.WARNING(msg_plain))
 
             else:
                 try:
@@ -165,7 +161,7 @@ class Command(BaseCommand):
                         recipients)
 
                     message = f'Sent deactivation notification email to ' \
-                              f'{len(recipients)} users.'
+                              f'{len(recipients)} user{plural}.'
                     self.stdout.write(self.style.SUCCESS(message))
 
                 except Exception as e:

--- a/coldfront/core/project/management/commands/pending_join_request_reminder.py
+++ b/coldfront/core/project/management/commands/pending_join_request_reminder.py
@@ -60,16 +60,8 @@ class Command(BaseCommand):
                     'review_url': review_project_join_requests_url(project),
                     'signature': settings.EMAIL_SIGNATURE,
                 }
-                pi_condition = Q(
-                    role__name='Principal Investigator', status__name='Active',
-                    enable_notifications=True)
-                manager_condition = Q(role__name='Manager', status__name='Active')
-                recipients = list(
-                    project.projectuser_set.filter(
-                        pi_condition | manager_condition
-                    ).values_list(
-                        'user__email', flat=True
-                    ))
+
+                recipients = project.managers_and_pis_emails()
                 try:
                     msg_plain = \
                         render_to_string('email/project_join_request/pending_project_join_requests.txt',

--- a/coldfront/core/project/management/commands/utils.py
+++ b/coldfront/core/project/management/commands/utils.py
@@ -1,0 +1,75 @@
+from coldfront.api.statistics.utils import get_accounting_allocation_objects
+from coldfront.api.statistics.utils import set_project_allocation_value
+from coldfront.api.statistics.utils import set_project_usage_value
+from coldfront.api.statistics.utils import set_project_user_allocation_value
+from coldfront.api.statistics.utils import set_project_user_usage_value
+from coldfront.core.statistics.models import ProjectTransaction
+from coldfront.core.statistics.models import ProjectUserTransaction
+from coldfront.core.utils.common import utc_now_offset_aware
+
+
+def set_service_units(project, allocation_objects, updated_su, reason,
+                      update_usage):
+    """
+    Sets allocation and allocation_user service units to updated_su. Creates
+    the relevant transaction objects to record the change. Updates the
+    relevant historical objects with the reason for the SU change. If
+    update_usage is True, allocation and allocation_user usage values are
+    updated.
+    """
+
+    def set_historical_reason(obj):
+        """Set the latest historical object reason"""
+        obj.refresh_from_db()
+        historical_obj = obj.history.latest('id')
+        historical_obj.history_change_reason = reason
+        historical_obj.save()
+
+    current_date = utc_now_offset_aware()
+
+    # Set the value for the Project.
+    set_project_allocation_value(project, updated_su)
+
+    if update_usage:
+        set_project_usage_value(project, updated_su)
+
+    # Create a transaction to record the change.
+    ProjectTransaction.objects.create(
+        project=project,
+        date_time=current_date,
+        allocation=updated_su)
+
+    # Set the reason for the change in the newly-created historical object.
+    set_historical_reason(
+        allocation_objects.allocation_attribute)
+
+    # Do the same for each ProjectUser.
+    for project_user in project.projectuser_set.all():
+        user = project_user.user
+        # Attempt to set the value for the ProjectUser. The method returns
+        # whether it succeeded; it may not because not every ProjectUser has a
+        # corresponding AllocationUser (e.g., PIs). Only proceed with further
+        # steps if an update occurred.
+        allocation_updated = set_project_user_allocation_value(
+            user, project, updated_su)
+        success_flag = allocation_updated
+
+        if update_usage:
+            allocation_usage_updated = set_project_user_usage_value(
+                user, project, updated_su)
+
+            success_flag = allocation_updated and allocation_usage_updated
+
+        if success_flag:
+            # Create a transaction to record the change.
+            ProjectUserTransaction.objects.create(
+                project_user=project_user,
+                date_time=current_date,
+                allocation=updated_su)
+
+            # Set the reason for the change in the newly-created historical
+            # object.
+            allocation_user_obj = get_accounting_allocation_objects(
+                project, user=user)
+            set_historical_reason(
+                allocation_user_obj.allocation_user_attribute)

--- a/coldfront/core/project/tests/test_commands/test_add_service_units_to_project.py
+++ b/coldfront/core/project/tests/test_commands/test_add_service_units_to_project.py
@@ -1,129 +1,63 @@
-from io import StringIO
-import sys
+from decimal import Decimal
 
-from django.core.management import call_command, CommandError
+from django.core.management import CommandError
 
-from coldfront.api.allocation.tests.test_allocation_base import TestAllocationBase
-from coldfront.api.statistics.utils import get_accounting_allocation_objects
-from coldfront.core.allocation.models import Allocation, AllocationAttributeType
-from coldfront.core.project.models import Project
+from coldfront.api.statistics.utils import create_project_allocation, \
+    create_user_project_allocation
+from coldfront.core.allocation.models import Allocation
+from coldfront.core.project.models import Project, ProjectStatusChoice, \
+    ProjectUserStatusChoice, ProjectUserRoleChoice, ProjectUser
+from coldfront.core.project.tests.test_commands.test_service_units_base import \
+    TestSUBase
 from coldfront.core.resource.models import Resource
-from coldfront.core.statistics.models import ProjectTransaction, ProjectUserTransaction
 from coldfront.core.utils.common import utc_now_offset_aware
 
 
-class TestAddServiceUnitsToProject(TestAllocationBase):
+class TestAddServiceUnitsToProject(TestSUBase):
     """Class for testing the management command add_service_units_to_project"""
 
     def setUp(self):
         """Set up test data."""
         super().setUp()
 
-    def record_historical_objects_len(self, project):
-        """ Records the lengths of all relevant historical objects to a dict"""
-        length_dict = {}
-        allocation_objects = get_accounting_allocation_objects(project)
-        historical_allocation_attribute = \
-            allocation_objects.allocation_attribute.history.all()
+        self.reason = 'This is a test for add_service_units command'
 
-        length_dict['historical_allocation_attribute'] = \
-            len(historical_allocation_attribute)
+        # Create Projects and associate Users with them.
+        project_status = ProjectStatusChoice.objects.get(name='Active')
+        project_user_status = ProjectUserStatusChoice.objects.get(
+            name='Active')
+        user_role = ProjectUserRoleChoice.objects.get(name='User')
+        manager_role = ProjectUserRoleChoice.objects.get(name='Manager')
 
-        allocation_attribute_type = AllocationAttributeType.objects.get(
-            name="Service Units")
-        for project_user in project.projectuser_set.all():
-            if project_user.role.name != 'User':
-                continue
+        for i in range(2):
+            # Create an ICA Project and ProjectUsers.
+            project = Project.objects.create(
+                name=f'project{i}', status=project_status)
+            setattr(self, f'project{i}', project)
+            for j in range(2):
+                ProjectUser.objects.create(
+                    user=getattr(self, f'user{j}'), project=project,
+                    role=user_role, status=project_user_status)
+            ProjectUser.objects.create(
+                user=self.pi, project=project, role=manager_role,
+                status=project_user_status)
 
-            allocation_user = \
-                allocation_objects.allocation.allocationuser_set.get(
-                    user=project_user.user)
-            allocation_user_attribute = \
-                allocation_user.allocationuserattribute_set.get(
-                    allocation_attribute_type=allocation_attribute_type,
-                    allocation=allocation_objects.allocation)
-            historical_allocation_user_attribute = \
-                allocation_user_attribute.history.all()
+            # Create a compute allocation for the Project.
+            allocation = Decimal(f'{i + 1}000.00')
+            create_project_allocation(project, allocation)
 
-            key = 'historical_allocation_user_attribute_' + project_user.user.username
-            length_dict[key] = len(historical_allocation_user_attribute)
-
-        return length_dict
-
-    def allocation_values_test(self, project, value, user_value):
-        allocation_objects = get_accounting_allocation_objects(project)
-        self.assertEqual(allocation_objects.allocation_attribute.value, value)
-
-        for project_user in project.projectuser_set.all():
-            if project_user.role.name != 'User':
-                continue
-            allocation_objects = get_accounting_allocation_objects(
-                project, user=project_user.user)
-
-            self.assertEqual(allocation_objects.allocation_user_attribute.value,
-                             user_value)
-
-    def transactions_created(self, project, pre_time, post_time, amount):
-        proj_transaction = ProjectTransaction.objects.get(project=project,
-                                                          allocation=amount)
-
-        self.assertTrue(pre_time <= proj_transaction.date_time <= post_time)
-
-        for project_user in project.projectuser_set.all():
-            if project_user.role.name != 'User':
-                continue
-
-            proj_user_transaction = ProjectUserTransaction.objects.get(
-                project_user=project_user,
-                allocation=amount)
-
-            self.assertTrue(pre_time <= proj_user_transaction.date_time <= post_time)
-
-    def historical_objects_created(self, pre_length_dict, post_length_dict):
-        """Test that historical objects were created"""
-        for k, v in pre_length_dict.items():
-            self.assertEqual(v + 1, post_length_dict[k])
-
-    def historical_objects_updated(self, project):
-        allocation_objects = get_accounting_allocation_objects(project)
-        historical_allocation_attribute = \
-            allocation_objects.allocation_attribute.history.latest("id")
-        historical_reason = historical_allocation_attribute.history_change_reason
-
-        self.assertEqual(historical_reason, 'This is a test for add_service_units command')
-
-        allocation_attribute_type = AllocationAttributeType.objects.get(
-            name="Service Units")
-        for project_user in project.projectuser_set.all():
-            if project_user.role.name != 'User':
-                continue
-
-            allocation_user = \
-                allocation_objects.allocation.allocationuser_set.get(
-                    user=project_user.user)
-            allocation_user_attribute = \
-                allocation_user.allocationuserattribute_set.get(
-                    allocation_attribute_type=allocation_attribute_type,
-                    allocation=allocation_objects.allocation)
-            historical_allocation_user_attribute = \
-                allocation_user_attribute.history.latest("id")
-            historical_reason = \
-                historical_allocation_user_attribute.history_change_reason
-            self.assertEqual(historical_reason,
-                             'This is a test for add_service_units command')
+            # Create a compute allocation for each User on the Project.
+            for j in range(2):
+                create_user_project_allocation(
+                    getattr(self, f'user{j}'), project, allocation / 2)
 
     def test_dry_run(self):
         """Testing add_service_units_to_project dry run"""
-        out, err = StringIO(''), StringIO('')
-        call_command('add_service_units_to_project',
-                     '--project_name=project0',
-                     '--amount=1000',
-                     '--reason=This is a test for add_service_units command',
-                     '--dry_run',
-                     stdout=out,
-                     stderr=err)
-        sys.stdout = sys.__stdout__
-        out.seek(0)
+        output, error = self.call_deactivate_command('add_service_units_to_project',
+                                                     '--project_name=project0',
+                                                     '--amount=1000',
+                                                     f'--reason={self.reason}',
+                                                     '--dry_run')
 
         dry_run_message = 'Would add 1000 additional SUs to project ' \
                           'project0. This would increase project0 ' \
@@ -132,13 +66,11 @@ class TestAddServiceUnitsToProject(TestAllocationBase):
                           'would be: "This is a test for ' \
                           'add_service_units command".'
 
-        self.assertIn(dry_run_message, out.read())
-        err.seek(0)
-        self.assertEqual(err.read(), '')
+        self.assertIn(dry_run_message, output)
+        self.assertEqual(error, '')
 
     def test_creates_and_updates_objects_positive_SU(self):
         """Testing add_service_units_to_project with positive SUs"""
-
         # test allocation values before command
         project = Project.objects.get(name='project0')
         pre_time = utc_now_offset_aware()
@@ -147,23 +79,17 @@ class TestAddServiceUnitsToProject(TestAllocationBase):
         self.allocation_values_test(project, '1000.00', '500.00')
 
         # run command
-        out, err = StringIO(''), StringIO('')
-        call_command('add_service_units_to_project',
-                     '--project_name=project0',
-                     '--amount=1000',
-                     '--reason=This is a test for add_service_units command',
-                     stdout=out,
-                     stderr=err)
-        sys.stdout = sys.__stdout__
-        out.seek(0)
+        output, error = self.call_deactivate_command('add_service_units_to_project',
+                                                     '--project_name=project0',
+                                                     '--amount=1000',
+                                                     f'--reason={self.reason}')
 
         message = f'Successfully added 1000 SUs to project0 and its users, ' \
                   f'updating project0\'s SUs from 1000.00 to 2000.00. The ' \
                   f'reason was: "This is a test for add_service_units command".'
 
-        self.assertIn(message, out.read())
-        err.seek(0)
-        self.assertEqual(err.read(), '')
+        self.assertIn(message, output)
+        self.assertEqual(error, '')
 
         post_time = utc_now_offset_aware()
 
@@ -176,11 +102,10 @@ class TestAddServiceUnitsToProject(TestAllocationBase):
         # test historical objects created and updated
         post_length_dict = self.record_historical_objects_len(project)
         self.historical_objects_created(pre_length_dict, post_length_dict)
-        self.historical_objects_updated(project)
+        self.historical_objects_updated(project, self.reason)
 
     def test_creates_and_updates_objects_negative_SU(self):
         """Testing add_service_units_to_project with negative SUs"""
-
         # test allocation values before command
         project = Project.objects.get(name='project0')
         pre_time = utc_now_offset_aware()
@@ -189,23 +114,17 @@ class TestAddServiceUnitsToProject(TestAllocationBase):
         self.allocation_values_test(project, '1000.00', '500.00')
 
         # run command
-        out, err = StringIO(''), StringIO('')
-        call_command('add_service_units_to_project',
-                     '--project_name=project0',
-                     '--amount=-800',
-                     '--reason=This is a test for add_service_units command',
-                     stdout=out,
-                     stderr=err)
-        sys.stdout = sys.__stdout__
-        out.seek(0)
+        output, error = self.call_deactivate_command('add_service_units_to_project',
+                                                     '--project_name=project0',
+                                                     '--amount=-800',
+                                                     f'--reason={self.reason}')
 
         message = f'Successfully added -800 SUs to project0 and its users, ' \
                   f'updating project0\'s SUs from 1000.00 to 200.00. The ' \
                   f'reason was: "This is a test for add_service_units command".'
 
-        self.assertIn(message, out.read())
-        err.seek(0)
-        self.assertEqual(err.read(), '')
+        self.assertIn(message, output)
+        self.assertEqual(error, '')
 
         post_time = utc_now_offset_aware()
 
@@ -218,9 +137,12 @@ class TestAddServiceUnitsToProject(TestAllocationBase):
         # test historical objects created and updated
         post_length_dict = self.record_historical_objects_len(project)
         self.historical_objects_created(pre_length_dict, post_length_dict)
-        self.historical_objects_updated(project)
+        self.historical_objects_updated(project, self.reason)
 
     def test_input_validations(self):
+        """
+        Tests that validate_inputs throws errors in the correct situations
+        """
         project = Project.objects.get(name='project1')
         allocation = Allocation.objects.get(project=project)
 
@@ -240,92 +162,62 @@ class TestAddServiceUnitsToProject(TestAllocationBase):
         # command should throw a CommandError because the allocation is not
         # part of Savio Compute
         with self.assertRaises(CommandError):
-            out, err = StringIO(''), StringIO('')
-            call_command('add_service_units_to_project',
-                         '--project_name=project1',
-                         '--amount=1000',
-                         '--reason=This is a test for add_service_units command',
-                         stdout=out,
-                         stderr=err)
-            sys.stdout = sys.__stdout__
-            out.seek(0)
-            self.assertEqual(out.read(), '')
-            err.seek(0)
-            self.assertEqual(err.read(), '')
+            output, error = \
+                self.call_deactivate_command('add_service_units_to_project',
+                                             '--project_name=project1',
+                                             '--amount=1000',
+                                             f'--reason={self.reason}')
+            self.assertEqual(output, '')
+            self.assertEqual(error, '')
 
         # testing a project that does not exist
         with self.assertRaises(CommandError):
-            out, err = StringIO(''), StringIO('')
-            call_command('add_service_units_to_project',
-                         '--project_name=project555',
-                         '--amount=1000',
-                         '--reason=This is a test for add_service_units command',
-                         stdout=out,
-                         stderr=err)
-            sys.stdout = sys.__stdout__
-            out.seek(0)
-            self.assertEqual(out.read(), '')
-            err.seek(0)
-            self.assertEqual(err.read(), '')
+            output, error = \
+                self.call_deactivate_command('add_service_units_to_project',
+                                             '--project_name=project555',
+                                             '--amount=1000',
+                                             f'--reason={self.reason}')
+            self.assertEqual(output, '')
+            self.assertEqual(error, '')
 
         # adding service units that results in allocation having less
         # than settings.ALLOCATION_MIN
         with self.assertRaises(CommandError):
-            out, err = StringIO(''), StringIO('')
-            call_command('add_service_units_to_project',
-                         '--project_name=project0',
-                         '--amount=-100000',
-                         '--reason=This is a test for add_service_units command',
-                         stdout=out,
-                         stderr=err)
-            sys.stdout = sys.__stdout__
-            out.seek(0)
-            self.assertEqual(out.read(), '')
-            err.seek(0)
-            self.assertEqual(err.read(), '')
+            output, error = \
+                self.call_deactivate_command('add_service_units_to_project',
+                                             '--project_name=project0',
+                                             '--amount=-100000',
+                                             f'--reason={self.reason}')
+            self.assertEqual(output, '')
+            self.assertEqual(error, '')
 
         # adding service units that results in allocation having more
         # than settings.ALLOCATION_MAX
         with self.assertRaises(CommandError):
-            out, err = StringIO(''), StringIO('')
-            call_command('add_service_units_to_project',
-                         '--project_name=project0',
-                         '--amount=99999500',
-                         '--reason=This is a test for add_service_units command',
-                         stdout=out,
-                         stderr=err)
-            sys.stdout = sys.__stdout__
-            out.seek(0)
-            self.assertEqual(out.read(), '')
-            err.seek(0)
-            self.assertEqual(err.read(), '')
+            output, error = \
+                self.call_deactivate_command('add_service_units_to_project',
+                                             '--project_name=project0',
+                                             '--amount=99999500',
+                                             f'--reason={self.reason}')
+            self.assertEqual(output, '')
+            self.assertEqual(error, '')
 
-        # adding service units that are greater than settings.ALLOCATION_MIN
+        # adding service units that are greater than settings.ALLOCATION_MAX
         with self.assertRaises(CommandError):
-            out, err = StringIO(''), StringIO('')
-            call_command('add_service_units_to_project',
-                         '--project_name=project0',
-                         '--amount=500000000',
-                         '--reason=This is a test for add_service_units command',
-                         stdout=out,
-                         stderr=err)
-            sys.stdout = sys.__stdout__
-            out.seek(0)
-            self.assertEqual(out.read(), '')
-            err.seek(0)
-            self.assertEqual(err.read(), '')
+            output, error = \
+                self.call_deactivate_command('add_service_units_to_project',
+                                             '--project_name=project0',
+                                             '--amount=500000000',
+                                             f'--reason={self.reason}')
+            self.assertEqual(output, '')
+            self.assertEqual(error, '')
 
         # reason is not long enough
         with self.assertRaises(CommandError):
-            out, err = StringIO(''), StringIO('')
-            call_command('add_service_units_to_project',
-                         '--project_name=project0',
-                         '--amount=1000',
-                         '--reason=notlong',
-                         stdout=out,
-                         stderr=err)
-            sys.stdout = sys.__stdout__
-            out.seek(0)
-            self.assertEqual(out.read(), '')
-            err.seek(0)
-            self.assertEqual(err.read(), '')
+            output, error = \
+                self.call_deactivate_command('add_service_units_to_project',
+                                             '--project_name=project0',
+                                             '--amount=1000',
+                                             '--reason=notlong')
+            self.assertEqual(output, '')
+            self.assertEqual(error, '')

--- a/coldfront/core/project/tests/test_commands/test_add_service_units_to_project.py
+++ b/coldfront/core/project/tests/test_commands/test_add_service_units_to_project.py
@@ -53,11 +53,11 @@ class TestAddServiceUnitsToProject(TestSUBase):
 
     def test_dry_run(self):
         """Testing add_service_units_to_project dry run"""
-        output, error = self.call_deactivate_command('add_service_units_to_project',
-                                                     '--project_name=project0',
-                                                     '--amount=1000',
-                                                     f'--reason={self.reason}',
-                                                     '--dry_run')
+        output, error = self.call_command('add_service_units_to_project',
+                                          '--project_name=project0',
+                                          '--amount=1000',
+                                          f'--reason={self.reason}',
+                                          '--dry_run')
 
         dry_run_message = 'Would add 1000 additional SUs to project ' \
                           'project0. This would increase project0 ' \
@@ -79,10 +79,10 @@ class TestAddServiceUnitsToProject(TestSUBase):
         self.allocation_values_test(project, '1000.00', '500.00')
 
         # run command
-        output, error = self.call_deactivate_command('add_service_units_to_project',
-                                                     '--project_name=project0',
-                                                     '--amount=1000',
-                                                     f'--reason={self.reason}')
+        output, error = self.call_command('add_service_units_to_project',
+                                          '--project_name=project0',
+                                          '--amount=1000',
+                                          f'--reason={self.reason}')
 
         message = f'Successfully added 1000 SUs to project0 and its users, ' \
                   f'updating project0\'s SUs from 1000.00 to 2000.00. The ' \
@@ -114,10 +114,10 @@ class TestAddServiceUnitsToProject(TestSUBase):
         self.allocation_values_test(project, '1000.00', '500.00')
 
         # run command
-        output, error = self.call_deactivate_command('add_service_units_to_project',
-                                                     '--project_name=project0',
-                                                     '--amount=-800',
-                                                     f'--reason={self.reason}')
+        output, error = self.call_command('add_service_units_to_project',
+                                          '--project_name=project0',
+                                          '--amount=-800',
+                                          f'--reason={self.reason}')
 
         message = f'Successfully added -800 SUs to project0 and its users, ' \
                   f'updating project0\'s SUs from 1000.00 to 200.00. The ' \
@@ -163,20 +163,20 @@ class TestAddServiceUnitsToProject(TestSUBase):
         # part of Savio Compute
         with self.assertRaises(CommandError):
             output, error = \
-                self.call_deactivate_command('add_service_units_to_project',
-                                             '--project_name=project1',
-                                             '--amount=1000',
-                                             f'--reason={self.reason}')
+                self.call_command('add_service_units_to_project',
+                                  '--project_name=project1',
+                                  '--amount=1000',
+                                  f'--reason={self.reason}')
             self.assertEqual(output, '')
             self.assertEqual(error, '')
 
         # testing a project that does not exist
         with self.assertRaises(CommandError):
             output, error = \
-                self.call_deactivate_command('add_service_units_to_project',
-                                             '--project_name=project555',
-                                             '--amount=1000',
-                                             f'--reason={self.reason}')
+                self.call_command('add_service_units_to_project',
+                                  '--project_name=project555',
+                                  '--amount=1000',
+                                  f'--reason={self.reason}')
             self.assertEqual(output, '')
             self.assertEqual(error, '')
 
@@ -184,10 +184,10 @@ class TestAddServiceUnitsToProject(TestSUBase):
         # than settings.ALLOCATION_MIN
         with self.assertRaises(CommandError):
             output, error = \
-                self.call_deactivate_command('add_service_units_to_project',
-                                             '--project_name=project0',
-                                             '--amount=-100000',
-                                             f'--reason={self.reason}')
+                self.call_command('add_service_units_to_project',
+                                  '--project_name=project0',
+                                  '--amount=-100000',
+                                  f'--reason={self.reason}')
             self.assertEqual(output, '')
             self.assertEqual(error, '')
 
@@ -195,29 +195,29 @@ class TestAddServiceUnitsToProject(TestSUBase):
         # than settings.ALLOCATION_MAX
         with self.assertRaises(CommandError):
             output, error = \
-                self.call_deactivate_command('add_service_units_to_project',
-                                             '--project_name=project0',
-                                             '--amount=99999500',
-                                             f'--reason={self.reason}')
+                self.call_command('add_service_units_to_project',
+                                  '--project_name=project0',
+                                  '--amount=99999500',
+                                  f'--reason={self.reason}')
             self.assertEqual(output, '')
             self.assertEqual(error, '')
 
         # adding service units that are greater than settings.ALLOCATION_MAX
         with self.assertRaises(CommandError):
             output, error = \
-                self.call_deactivate_command('add_service_units_to_project',
-                                             '--project_name=project0',
-                                             '--amount=500000000',
-                                             f'--reason={self.reason}')
+                self.call_command('add_service_units_to_project',
+                                  '--project_name=project0',
+                                  '--amount=500000000',
+                                  f'--reason={self.reason}')
             self.assertEqual(output, '')
             self.assertEqual(error, '')
 
         # reason is not long enough
         with self.assertRaises(CommandError):
             output, error = \
-                self.call_deactivate_command('add_service_units_to_project',
-                                             '--project_name=project0',
-                                             '--amount=1000',
-                                             '--reason=notlong')
+                self.call_command('add_service_units_to_project',
+                                  '--project_name=project0',
+                                  '--amount=1000',
+                                  '--reason=notlong')
             self.assertEqual(output, '')
             self.assertEqual(error, '')

--- a/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
@@ -101,9 +101,9 @@ class TestDeactivateICAProjects(TestSUBase):
 
     def test_dry_run_no_expired_projects(self):
         """Testing a dry run in which no ICA projects are expired"""
-        output, error = self.call_deactivate_command('deactivate_ica_projects',
-                                                     '--dry_run',
-                                                     '--send_emails')
+        output, error = self.call_command('deactivate_ica_projects',
+                                          '--dry_run',
+                                          '--send_emails')
         self.assertIn(output, '')
         self.assertEqual(error, '')
 
@@ -111,9 +111,9 @@ class TestDeactivateICAProjects(TestSUBase):
         """Testing a dry run in which an ICA project is expired"""
         self.create_expired_project('ic_project0')
 
-        output, error = self.call_deactivate_command('deactivate_ica_projects',
-                                                     '--dry_run',
-                                                     '--send_emails')
+        output, error = self.call_command('deactivate_ica_projects',
+                                          '--dry_run',
+                                          '--send_emails')
 
         project = Project.objects.get(name='ic_project0')
         allocation = get_project_compute_allocation(project)
@@ -128,14 +128,7 @@ class TestDeactivateICAProjects(TestSUBase):
                     f'would be: "Resetting SUs while deactivating expired '
                     f'ICA project."',
 
-                    'Would send the following email to 1 users:',
-                    f'Dear managers of {project.name},',
-
-                    f'This is a notification that the project {project.name} '
-                    f'expired on {allocation.end_date.strftime("%m-%d-%Y")} '
-                    f'and has therefore been deactivated. '
-                    f'Accounts under this project will no longer be able '
-                    f'to access its compute resources.']
+                    'Would send a notification email to 1 user.']
 
         for message in messages:
             self.assertIn(message, output)
@@ -156,7 +149,7 @@ class TestDeactivateICAProjects(TestSUBase):
         self.allocation_values_test(project, '1000.00', '500.00')
 
         # run command
-        output, error = self.call_deactivate_command('deactivate_ica_projects')
+        output, error = self.call_command('deactivate_ica_projects')
 
         messages = [
             f'Updated Project {project.name} ({project.pk})\'s status to '
@@ -208,8 +201,8 @@ class TestDeactivateICAProjects(TestSUBase):
         old_end_date = allocation.end_date
 
         # run command
-        output, error = self.call_deactivate_command('deactivate_ica_projects',
-                                                     '--send_emails')
+        output, error = self.call_command('deactivate_ica_projects',
+                                          '--send_emails')
 
         recipients = project.managers_and_pis_emails()
 

--- a/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
@@ -1,0 +1,415 @@
+import datetime
+from decimal import Decimal
+from io import StringIO
+import sys
+
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.management import call_command
+from django.db.models import Q
+
+from coldfront.api.statistics.utils import create_project_allocation, \
+    create_user_project_allocation, AccountingAllocationObjects, \
+    get_accounting_allocation_objects
+from coldfront.config import settings
+from coldfront.core.allocation.models import Allocation, \
+    AllocationAttributeType, AllocationAttribute, \
+    AllocationAttributeUsage, AllocationUserStatusChoice, AllocationUser, \
+    AllocationUserAttribute, AllocationUserAttributeUsage
+from coldfront.core.project.models import Project, ProjectStatusChoice, \
+    ProjectUserStatusChoice, ProjectUserRoleChoice, ProjectUser
+from coldfront.core.project.utils import get_project_compute_allocation
+from coldfront.core.statistics.models import ProjectTransaction, ProjectUserTransaction
+from coldfront.core.user.models import UserProfile
+from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.tests.test_base import TestBase
+
+
+class TestDeactivateICAProjects(TestBase):
+    """Class for testing the management command deactivate_ica_projects"""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+
+        # Create a PI.
+        self.pi = User.objects.create(
+            username='pi0', email='pi0@nonexistent.com')
+        user_profile = UserProfile.objects.get(user=self.pi)
+        user_profile.is_pi = True
+        user_profile.save()
+
+        # Create two Users.
+        for i in range(2):
+            user = User.objects.create(
+                username=f'user{i}', email=f'user{i}@nonexistent.com')
+            user_profile = UserProfile.objects.get(user=user)
+            user_profile.cluster_uid = f'{i}'
+            user_profile.save()
+            setattr(self, f'user{i}', user)
+            setattr(self, f'user_profile{i}', user_profile)
+
+        # Create Projects and associate Users with them.
+        project_status = ProjectStatusChoice.objects.get(name='Active')
+        project_user_status = ProjectUserStatusChoice.objects.get(
+            name='Active')
+        user_role = ProjectUserRoleChoice.objects.get(name='User')
+        manager_role = ProjectUserRoleChoice.objects.get(name='Manager')
+        current_date = utc_now_offset_aware()
+
+        for i in range(2):
+            # Create an ICA Project and ProjectUsers.
+            project = Project.objects.create(
+                name=f'ic_project{i}', status=project_status)
+            setattr(self, f'ic_project{i}', project)
+            for j in range(2):
+                ProjectUser.objects.create(
+                    user=getattr(self, f'user{j}'), project=project,
+                    role=user_role, status=project_user_status)
+            ProjectUser.objects.create(
+                user=self.pi, project=project, role=manager_role,
+                status=project_user_status)
+
+            # Create a compute allocation for the Project.
+            allocation = Decimal(f'{i + 1}000.00')
+            create_project_allocation(project, allocation)
+
+            # Set start and end dates for allocations
+            allocation_object = get_project_compute_allocation(project)
+            allocation_object.start_date = \
+                current_date - datetime.timedelta(days=(i+1)*5)
+            allocation_object.end_date = \
+                current_date + datetime.timedelta(days=(i+1)*5)
+            allocation_object.save()
+
+            # Create a compute allocation for each User on the Project.
+            for j in range(2):
+                create_user_project_allocation(
+                    getattr(self, f'user{j}'), project, allocation / 2)
+
+        # Clear the mail outbox.
+        mail.outbox = []
+
+    @staticmethod
+    def call_deactivate_command(*args):
+        """Call the command with the given arguments, returning the messages
+        written to stdout and stderr."""
+        out, err = StringIO(), StringIO()
+        args = ['deactivate_ica_projects', *args]
+        kwargs = {'stdout': out, 'stderr': err}
+        call_command(*args, **kwargs)
+        return out.getvalue(), err.getvalue()
+
+    def get_accounting_allocation_objects(self, project, user=None):
+        """Return a namedtuple of database objects related to accounting and
+        allocation for the given project and optional user.
+
+        Parameters:
+            - project (Project): an instance of the Project model
+            - user (User): an instance of the User model
+
+        Returns:
+            - AccountingAllocationObjects instance
+
+        Raises:
+            - MultipleObjectsReturned, if a database retrieval returns more
+            than one object
+            - ObjectDoesNotExist, if a database retrieval returns less than
+            one object
+            - TypeError, if one or more inputs has the wrong type
+
+        NOTE: this function was taken from coldfront.core.statistics.utils.
+        This version does not check that the allocation status is Active
+        """
+        if not isinstance(project, Project):
+            raise TypeError(f'Project {project} is not a Project object.')
+
+        objects = AccountingAllocationObjects()
+
+        allocation = Allocation.objects.get(
+            project=project, resources__name='Savio Compute')
+
+        # Check that the allocation has an attribute for Service Units and
+        # an associated usage.
+        allocation_attribute_type = AllocationAttributeType.objects.get(
+            name='Service Units')
+        allocation_attribute = AllocationAttribute.objects.get(
+            allocation_attribute_type=allocation_attribute_type,
+            allocation=allocation)
+        allocation_attribute_usage = AllocationAttributeUsage.objects.get(
+            allocation_attribute=allocation_attribute)
+
+        objects.allocation = allocation
+        objects.allocation_attribute = allocation_attribute
+        objects.allocation_attribute_usage = allocation_attribute_usage
+
+        if user is None:
+            return objects
+
+        if not isinstance(user, User):
+            raise TypeError(f'User {user} is not a User object.')
+
+        # Check that there is an active association between the user and project.
+        active_status = ProjectUserStatusChoice.objects.get(name='Active')
+        ProjectUser.objects.get(user=user, project=project, status=active_status)
+
+        # Check that the user is an active member of the allocation.
+        active_status = AllocationUserStatusChoice.objects.get(name='Active')
+        allocation_user = AllocationUser.objects.get(
+            allocation=allocation, user=user, status=active_status)
+
+        # Check that the allocation user has an attribute for Service Units
+        # and an associated usage.
+        allocation_user_attribute = AllocationUserAttribute.objects.get(
+            allocation_attribute_type=allocation_attribute_type,
+            allocation=allocation, allocation_user=allocation_user)
+        allocation_user_attribute_usage = AllocationUserAttributeUsage.objects.get(
+            allocation_user_attribute=allocation_user_attribute)
+
+        objects.allocation_user = allocation_user
+        objects.allocation_user_attribute = allocation_user_attribute
+        objects.allocation_user_attribute_usage = allocation_user_attribute_usage
+
+        return objects
+
+    def create_expired_project(self, project_name):
+        """Change the end date of ic_project0 to be expired"""
+        project = Project.objects.get(name=project_name)
+        allocation = get_project_compute_allocation(project)
+        current_date = utc_now_offset_aware()
+        expired_date = (current_date - datetime.timedelta(days=4)).date()
+
+        allocation.end_date = expired_date
+        allocation.save()
+        allocation.refresh_from_db()
+        self.assertEqual(allocation.end_date, expired_date)
+
+    def record_historical_objects_len(self, project):
+        """ Records the lengths of all relevant historical objects to a dict"""
+        length_dict = {}
+        allocation_objects = self.get_accounting_allocation_objects(project)
+        historical_allocation_attribute = \
+            allocation_objects.allocation_attribute.history.all()
+
+        length_dict['historical_allocation_attribute'] = \
+            len(historical_allocation_attribute)
+
+        allocation_attribute_type = AllocationAttributeType.objects.get(
+            name="Service Units")
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            allocation_user_obj = self.get_accounting_allocation_objects(
+                project, user=project_user.user)
+
+            historical_allocation_user_attribute = \
+                allocation_user_obj.allocation_user_attribute.history.all()
+
+            key = 'historical_allocation_user_attribute_' + project_user.user.username
+            length_dict[key] = len(historical_allocation_user_attribute)
+
+        return length_dict
+
+    def allocation_values_test(self, project, value, user_value):
+        """
+        Tests that the allocation user values are correct
+        """
+        allocation_objects = self.get_accounting_allocation_objects(project)
+        self.assertEqual(allocation_objects.allocation_attribute.value, value)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+            allocation_objects = self.get_accounting_allocation_objects(
+                project, user=project_user.user)
+
+            self.assertEqual(allocation_objects.allocation_user_attribute.value,
+                             user_value)
+
+    def transactions_created(self, project, pre_time, post_time, amount):
+        """
+        Tests that transactions were created for the zeroing of SUs
+        """
+        proj_transaction = ProjectTransaction.objects.get(project=project,
+                                                          allocation=amount)
+
+        self.assertTrue(pre_time <= proj_transaction.date_time <= post_time)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            proj_user_transaction = ProjectUserTransaction.objects.get(
+                project_user=project_user,
+                allocation=amount)
+
+            self.assertTrue(pre_time <= proj_user_transaction.date_time <= post_time)
+
+    def historical_objects_created(self, pre_length_dict, post_length_dict):
+        """Test that historical objects were created"""
+        for k, v in pre_length_dict.items():
+            self.assertEqual(v + 1, post_length_dict[k])
+
+    def historical_objects_updated(self, project):
+        """
+        Tests that the relevant historical objects have the correct reason
+        """
+
+        reason = 'Resetting SUs while deactivating expired ICA project.'
+        allocation_objects = self.get_accounting_allocation_objects(project)
+
+        alloc_attr_hist_reason = \
+            allocation_objects.allocation_attribute.history.\
+                latest('id').history_change_reason
+        self.assertEqual(alloc_attr_hist_reason, reason)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            allocation_user_obj = self.get_accounting_allocation_objects(
+                project, user=project_user.user)
+
+            alloc_attr_hist_reason = \
+                allocation_user_obj.allocation_user_attribute.history. \
+                    latest('id').history_change_reason
+            self.assertEqual(alloc_attr_hist_reason, reason)
+
+    def project_allocation_updates(self, project, allocation, pre_time, post_time):
+        """Tests that the project and allocation were correctly updated"""
+        self.assertEqual(project.status.name, 'Inactive')
+        self.assertEqual(allocation.status.name, 'Expired')
+        self.assertTrue(pre_time.date() <= allocation.start_date <= post_time.date())
+        self.assertTrue(allocation.end_date is None)
+
+    def test_dry_run_no_expired_projects(self):
+        """Testing a dry run in which no ICA projects are expired"""
+        output, error = self.call_deactivate_command('--dry_run',
+                                                     '--send_emails')
+        self.assertIn(output, '')
+        self.assertEqual(error, '')
+
+    def test_dry_run_with_expired_projects(self):
+        """Testing a dry run in which an ICA project is expired"""
+        self.create_expired_project('ic_project0')
+
+        output, error = self.call_deactivate_command('--dry_run',
+                                                     '--send_emails')
+
+        project = Project.objects.get(name='ic_project0')
+        allocation = get_project_compute_allocation(project)
+
+        # Messages that should be output to stdout during a dry run
+        messages = [f'Would update Project {project.name} ({project.pk})\'s '
+                    f'status to Inactive and Allocation '
+                    f'{allocation.pk}\'s status to Expired.',
+
+                    f'Would reset {project.name} and its users\'s SUs from '
+                    f'1000.00 to 0.00. The reason '
+                    f'would be: "Resetting SUs while deactivating expired '
+                    f'ICA project."',
+
+                    'Would send the following email to 1 users:',
+                    f'Dear managers of {project.name},',
+
+                    f'This is a notification that the project {project.name} '
+                    f'expired on {allocation.end_date.strftime("%m-%d-%Y")} '
+                    f'and has therefore been deactivated. '
+                    f'Accounts under this project will no longer be able '
+                    f'to access its compute resources.']
+
+        for message in messages:
+            self.assertIn(message, output)
+
+        self.assertEqual(error, '')
+
+    def test_creates_and_updates_objects(self):
+        """Testing deactivate_ica_projects WITHOUT send_emails flag"""
+        self.create_expired_project('ic_project0')
+
+        project = Project.objects.get(name='ic_project0')
+        allocation = get_project_compute_allocation(project)
+
+        pre_time = utc_now_offset_aware()
+        pre_length_dict = self.record_historical_objects_len(project)
+
+        # test allocation values before command
+        self.allocation_values_test(project, '1000.00', '500.00')
+
+        # run command
+        output, error = self.call_deactivate_command()
+
+        messages = [
+            f'Updated Project {project.name} ({project.pk})\'s status to '
+            f'Inactive and Allocation {allocation.pk}\'s '
+            f'status to Expired.',
+
+            f'Successfully reset SUs for {project.name} '
+            f'and its users, updating {project.name}\'s SUs from '
+            f'1000.00 to 0.00. The reason '
+            f'was: "Resetting SUs while deactivating expired ICA '
+            f'project.".']
+
+        for message in messages:
+            self.assertIn(message, output)
+        self.assertEqual(error, '')
+
+        post_time = utc_now_offset_aware()
+        project.refresh_from_db()
+        allocation.refresh_from_db()
+
+        # test project and allocation statuses
+        self.project_allocation_updates(project, allocation, pre_time, post_time)
+
+        # test allocation values after command
+        self.allocation_values_test(project, '0.00', '0.00')
+
+        # test ProjectTransaction created
+        self.transactions_created(project, pre_time, post_time, 0.00)
+
+        # test historical objects created and updated
+        post_length_dict = self.record_historical_objects_len(project)
+        self.historical_objects_created(pre_length_dict, post_length_dict)
+        self.historical_objects_updated(project)
+
+    def test_emails_sent(self):
+        """
+        Tests that emails are sent correctly when there is an expired
+        ICA project
+        """
+
+        self.create_expired_project('ic_project0')
+
+        project = Project.objects.get(name='ic_project0')
+        allocation = get_project_compute_allocation(project)
+        old_end_date = allocation.end_date
+
+        # run command
+        output, error = self.call_deactivate_command('--send_emails')
+
+        recipients = project.managers_and_pis_emails()
+
+        # Testing that the correct text is output to stdout
+        message = f'Sent deactivation notification email to ' \
+                  f'{len(recipients)} users.'
+
+        self.assertIn(message, output)
+        self.assertEqual(error, '')
+
+        # Testing that the correct number of emails were sent
+        self.assertEqual(len(mail.outbox), len(recipients))
+
+        email_body = [f'Dear managers of {project.name},',
+
+                      f'This is a notification that the project {project.name} '
+                      f'expired on {old_end_date.strftime("%m-%d-%Y")} '
+                      f'and has therefore been deactivated. '
+                      f'Accounts under this project will no longer be able '
+                      f'to access its compute resources.']
+
+        for email in mail.outbox:
+            for section in email_body:
+                self.assertIn(section, email.body)
+            self.assertIn(email.to[0], recipients)
+            self.assertEqual(settings.EMAIL_SENDER, email.from_email)

--- a/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
@@ -123,7 +123,7 @@ class TestDeactivateICAProjects(TestSUBase):
                     f'status to Inactive and Allocation '
                     f'{allocation.pk}\'s status to Expired.',
 
-                    f'Would reset {project.name} and its users\'s SUs from '
+                    f'Would reset {project.name} and its users\' SUs from '
                     f'1000.00 to 0.00. The reason '
                     f'would be: "Resetting SUs while deactivating expired '
                     f'ICA project."',

--- a/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
@@ -1,53 +1,26 @@
 import datetime
 from decimal import Decimal
-from io import StringIO
-import sys
 
-from django.contrib.auth.models import User
 from django.core import mail
-from django.core.management import call_command
-from django.db.models import Q
 
 from coldfront.api.statistics.utils import create_project_allocation, \
-    create_user_project_allocation, AccountingAllocationObjects, \
-    get_accounting_allocation_objects
+    create_user_project_allocation
 from coldfront.config import settings
-from coldfront.core.allocation.models import Allocation, \
-    AllocationAttributeType, AllocationAttribute, \
-    AllocationAttributeUsage, AllocationUserStatusChoice, AllocationUser, \
-    AllocationUserAttribute, AllocationUserAttributeUsage
+from coldfront.core.allocation.models import AllocationAttributeUsage, \
+    AllocationUserAttributeUsage
 from coldfront.core.project.models import Project, ProjectStatusChoice, \
     ProjectUserStatusChoice, ProjectUserRoleChoice, ProjectUser
 from coldfront.core.project.utils import get_project_compute_allocation
-from coldfront.core.statistics.models import ProjectTransaction, ProjectUserTransaction
-from coldfront.core.user.models import UserProfile
 from coldfront.core.utils.common import utc_now_offset_aware
-from coldfront.core.utils.tests.test_base import TestBase
+from coldfront.core.project.tests.test_commands.test_service_units_base import TestSUBase
 
 
-class TestDeactivateICAProjects(TestBase):
+class TestDeactivateICAProjects(TestSUBase):
     """Class for testing the management command deactivate_ica_projects"""
 
     def setUp(self):
         """Set up test data."""
         super().setUp()
-
-        # Create a PI.
-        self.pi = User.objects.create(
-            username='pi0', email='pi0@nonexistent.com')
-        user_profile = UserProfile.objects.get(user=self.pi)
-        user_profile.is_pi = True
-        user_profile.save()
-
-        # Create two Users.
-        for i in range(2):
-            user = User.objects.create(
-                username=f'user{i}', email=f'user{i}@nonexistent.com')
-            user_profile = UserProfile.objects.get(user=user)
-            user_profile.cluster_uid = f'{i}'
-            user_profile.save()
-            setattr(self, f'user{i}', user)
-            setattr(self, f'user_profile{i}', user_profile)
 
         # Create Projects and associate Users with them.
         project_status = ProjectStatusChoice.objects.get(name='Active')
@@ -87,91 +60,6 @@ class TestDeactivateICAProjects(TestBase):
                 create_user_project_allocation(
                     getattr(self, f'user{j}'), project, allocation / 2)
 
-        # Clear the mail outbox.
-        mail.outbox = []
-
-    @staticmethod
-    def call_deactivate_command(*args):
-        """Call the command with the given arguments, returning the messages
-        written to stdout and stderr."""
-        out, err = StringIO(), StringIO()
-        args = ['deactivate_ica_projects', *args]
-        kwargs = {'stdout': out, 'stderr': err}
-        call_command(*args, **kwargs)
-        return out.getvalue(), err.getvalue()
-
-    def get_accounting_allocation_objects(self, project, user=None):
-        """Return a namedtuple of database objects related to accounting and
-        allocation for the given project and optional user.
-
-        Parameters:
-            - project (Project): an instance of the Project model
-            - user (User): an instance of the User model
-
-        Returns:
-            - AccountingAllocationObjects instance
-
-        Raises:
-            - MultipleObjectsReturned, if a database retrieval returns more
-            than one object
-            - ObjectDoesNotExist, if a database retrieval returns less than
-            one object
-            - TypeError, if one or more inputs has the wrong type
-
-        NOTE: this function was taken from coldfront.core.statistics.utils.
-        This version does not check that the allocation status is Active
-        """
-        if not isinstance(project, Project):
-            raise TypeError(f'Project {project} is not a Project object.')
-
-        objects = AccountingAllocationObjects()
-
-        allocation = Allocation.objects.get(
-            project=project, resources__name='Savio Compute')
-
-        # Check that the allocation has an attribute for Service Units and
-        # an associated usage.
-        allocation_attribute_type = AllocationAttributeType.objects.get(
-            name='Service Units')
-        allocation_attribute = AllocationAttribute.objects.get(
-            allocation_attribute_type=allocation_attribute_type,
-            allocation=allocation)
-        allocation_attribute_usage = AllocationAttributeUsage.objects.get(
-            allocation_attribute=allocation_attribute)
-
-        objects.allocation = allocation
-        objects.allocation_attribute = allocation_attribute
-        objects.allocation_attribute_usage = allocation_attribute_usage
-
-        if user is None:
-            return objects
-
-        if not isinstance(user, User):
-            raise TypeError(f'User {user} is not a User object.')
-
-        # Check that there is an active association between the user and project.
-        active_status = ProjectUserStatusChoice.objects.get(name='Active')
-        ProjectUser.objects.get(user=user, project=project, status=active_status)
-
-        # Check that the user is an active member of the allocation.
-        active_status = AllocationUserStatusChoice.objects.get(name='Active')
-        allocation_user = AllocationUser.objects.get(
-            allocation=allocation, user=user, status=active_status)
-
-        # Check that the allocation user has an attribute for Service Units
-        # and an associated usage.
-        allocation_user_attribute = AllocationUserAttribute.objects.get(
-            allocation_attribute_type=allocation_attribute_type,
-            allocation=allocation, allocation_user=allocation_user)
-        allocation_user_attribute_usage = AllocationUserAttributeUsage.objects.get(
-            allocation_user_attribute=allocation_user_attribute)
-
-        objects.allocation_user = allocation_user
-        objects.allocation_user_attribute = allocation_user_attribute
-        objects.allocation_user_attribute_usage = allocation_user_attribute_usage
-
-        return objects
-
     def create_expired_project(self, project_name):
         """Change the end date of ic_project0 to be expired"""
         project = Project.objects.get(name=project_name)
@@ -184,98 +72,6 @@ class TestDeactivateICAProjects(TestBase):
         allocation.refresh_from_db()
         self.assertEqual(allocation.end_date, expired_date)
 
-    def record_historical_objects_len(self, project):
-        """ Records the lengths of all relevant historical objects to a dict"""
-        length_dict = {}
-        allocation_objects = self.get_accounting_allocation_objects(project)
-        historical_allocation_attribute = \
-            allocation_objects.allocation_attribute.history.all()
-
-        length_dict['historical_allocation_attribute'] = \
-            len(historical_allocation_attribute)
-
-        allocation_attribute_type = AllocationAttributeType.objects.get(
-            name="Service Units")
-        for project_user in project.projectuser_set.all():
-            if project_user.role.name != 'User':
-                continue
-
-            allocation_user_obj = self.get_accounting_allocation_objects(
-                project, user=project_user.user)
-
-            historical_allocation_user_attribute = \
-                allocation_user_obj.allocation_user_attribute.history.all()
-
-            key = 'historical_allocation_user_attribute_' + project_user.user.username
-            length_dict[key] = len(historical_allocation_user_attribute)
-
-        return length_dict
-
-    def allocation_values_test(self, project, value, user_value):
-        """
-        Tests that the allocation user values are correct
-        """
-        allocation_objects = self.get_accounting_allocation_objects(project)
-        self.assertEqual(allocation_objects.allocation_attribute.value, value)
-
-        for project_user in project.projectuser_set.all():
-            if project_user.role.name != 'User':
-                continue
-            allocation_objects = self.get_accounting_allocation_objects(
-                project, user=project_user.user)
-
-            self.assertEqual(allocation_objects.allocation_user_attribute.value,
-                             user_value)
-
-    def transactions_created(self, project, pre_time, post_time, amount):
-        """
-        Tests that transactions were created for the zeroing of SUs
-        """
-        proj_transaction = ProjectTransaction.objects.get(project=project,
-                                                          allocation=amount)
-
-        self.assertTrue(pre_time <= proj_transaction.date_time <= post_time)
-
-        for project_user in project.projectuser_set.all():
-            if project_user.role.name != 'User':
-                continue
-
-            proj_user_transaction = ProjectUserTransaction.objects.get(
-                project_user=project_user,
-                allocation=amount)
-
-            self.assertTrue(pre_time <= proj_user_transaction.date_time <= post_time)
-
-    def historical_objects_created(self, pre_length_dict, post_length_dict):
-        """Test that historical objects were created"""
-        for k, v in pre_length_dict.items():
-            self.assertEqual(v + 1, post_length_dict[k])
-
-    def historical_objects_updated(self, project):
-        """
-        Tests that the relevant historical objects have the correct reason
-        """
-
-        reason = 'Resetting SUs while deactivating expired ICA project.'
-        allocation_objects = self.get_accounting_allocation_objects(project)
-
-        alloc_attr_hist_reason = \
-            allocation_objects.allocation_attribute.history.\
-                latest('id').history_change_reason
-        self.assertEqual(alloc_attr_hist_reason, reason)
-
-        for project_user in project.projectuser_set.all():
-            if project_user.role.name != 'User':
-                continue
-
-            allocation_user_obj = self.get_accounting_allocation_objects(
-                project, user=project_user.user)
-
-            alloc_attr_hist_reason = \
-                allocation_user_obj.allocation_user_attribute.history. \
-                    latest('id').history_change_reason
-            self.assertEqual(alloc_attr_hist_reason, reason)
-
     def project_allocation_updates(self, project, allocation, pre_time, post_time):
         """Tests that the project and allocation were correctly updated"""
         self.assertEqual(project.status.name, 'Inactive')
@@ -283,9 +79,30 @@ class TestDeactivateICAProjects(TestBase):
         self.assertTrue(pre_time.date() <= allocation.start_date <= post_time.date())
         self.assertTrue(allocation.end_date is None)
 
+    def usage_values_updated(self, project, updated_value):
+        """Tests that allocation and allocation user usages are reset"""
+        updated_value = Decimal(updated_value)
+        allocation_objects = self.get_accounting_allocation_objects(project)
+        project_usage = \
+            AllocationAttributeUsage.objects.get(
+                pk=allocation_objects.allocation_attribute_usage.pk)
+        self.assertEqual(project_usage.value, updated_value)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+            allocation_objects = self.get_accounting_allocation_objects(
+                project, user=project_user.user)
+            user_project_usage = \
+                AllocationUserAttributeUsage.objects.get(
+                    pk=allocation_objects.allocation_user_attribute_usage.pk)
+            self.assertEqual(user_project_usage.value,
+                             updated_value)
+
     def test_dry_run_no_expired_projects(self):
         """Testing a dry run in which no ICA projects are expired"""
-        output, error = self.call_deactivate_command('--dry_run',
+        output, error = self.call_deactivate_command('deactivate_ica_projects',
+                                                     '--dry_run',
                                                      '--send_emails')
         self.assertIn(output, '')
         self.assertEqual(error, '')
@@ -294,7 +111,8 @@ class TestDeactivateICAProjects(TestBase):
         """Testing a dry run in which an ICA project is expired"""
         self.create_expired_project('ic_project0')
 
-        output, error = self.call_deactivate_command('--dry_run',
+        output, error = self.call_deactivate_command('deactivate_ica_projects',
+                                                     '--dry_run',
                                                      '--send_emails')
 
         project = Project.objects.get(name='ic_project0')
@@ -338,7 +156,7 @@ class TestDeactivateICAProjects(TestBase):
         self.allocation_values_test(project, '1000.00', '500.00')
 
         # run command
-        output, error = self.call_deactivate_command()
+        output, error = self.call_deactivate_command('deactivate_ica_projects')
 
         messages = [
             f'Updated Project {project.name} ({project.pk})\'s status to '
@@ -362,6 +180,9 @@ class TestDeactivateICAProjects(TestBase):
         # test project and allocation statuses
         self.project_allocation_updates(project, allocation, pre_time, post_time)
 
+        # test usages are updated
+        self.usage_values_updated(project, '0.00')
+
         # test allocation values after command
         self.allocation_values_test(project, '0.00', '0.00')
 
@@ -369,9 +190,10 @@ class TestDeactivateICAProjects(TestBase):
         self.transactions_created(project, pre_time, post_time, 0.00)
 
         # test historical objects created and updated
+        reason = 'Resetting SUs while deactivating expired ICA project.'
         post_length_dict = self.record_historical_objects_len(project)
         self.historical_objects_created(pre_length_dict, post_length_dict)
-        self.historical_objects_updated(project)
+        self.historical_objects_updated(project, reason)
 
     def test_emails_sent(self):
         """
@@ -386,7 +208,8 @@ class TestDeactivateICAProjects(TestBase):
         old_end_date = allocation.end_date
 
         # run command
-        output, error = self.call_deactivate_command('--send_emails')
+        output, error = self.call_deactivate_command('deactivate_ica_projects',
+                                                     '--send_emails')
 
         recipients = project.managers_and_pis_emails()
 

--- a/coldfront/core/project/tests/test_commands/test_pending_auto_request_reminder.py
+++ b/coldfront/core/project/tests/test_commands/test_pending_auto_request_reminder.py
@@ -149,16 +149,7 @@ class TestPendingJoinRequestReminderCommand(TestCase):
         call_command('pending_join_request_reminder', stdout=out, stderr=err)
         sys.stdout = sys.__stdout__
 
-        pi_condition = Q(
-            role__name='Principal Investigator', status__name='Active',
-            enable_notifications=True)
-        manager_condition = Q(role__name='Manager', status__name='Active')
-        manager_emails = list(
-            self.project1.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
+        manager_emails = self.project1.managers_and_pis_emails()
 
         for email in mail.outbox:
             for addr in email.to:
@@ -208,16 +199,7 @@ class TestPendingJoinRequestReminderCommand(TestCase):
         call_command('pending_join_request_reminder', stdout=out, stderr=err)
         sys.stdout = sys.__stdout__
 
-        pi_condition = Q(
-            role__name='Principal Investigator', status__name='Active',
-            enable_notifications=True)
-        manager_condition = Q(role__name='Manager', status__name='Active')
-        manager_emails = list(
-            self.project1.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
+        manager_emails = self.project1.managers_and_pis_emails()
 
         for email in mail.outbox:
             for addr in email.to:
@@ -297,23 +279,7 @@ class TestPendingJoinRequestReminderCommand(TestCase):
         call_command('pending_join_request_reminder', stdout=out, stderr=err)
         sys.stdout = sys.__stdout__
 
-        pi_condition = Q(
-            role__name='Principal Investigator', status__name='Active',
-            enable_notifications=True)
-        manager_condition = Q(role__name='Manager', status__name='Active')
-        manager_emails1 = list(
-            self.project1.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
-
-        manager_emails2 = list(
-            project2.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
+        manager_emails1 = self.project1.managers_and_pis_emails()
 
         for email in mail.outbox:
             for addr in email.to:
@@ -381,16 +347,7 @@ class TestPendingJoinRequestReminderCommand(TestCase):
         call_command('pending_join_request_reminder', stdout=out, stderr=err)
         sys.stdout = sys.__stdout__
 
-        pi_condition = Q(
-            role__name='Principal Investigator', status__name='Active',
-            enable_notifications=True)
-        manager_condition = Q(role__name='Manager', status__name='Active')
-        manager_emails = list(
-            self.project1.projectuser_set.filter(
-                pi_condition | manager_condition
-            ).values_list(
-                'user__email', flat=True
-            ))
+        manager_emails = self.project1.managers_and_pis_emails()
 
         for email in mail.outbox:
             for addr in email.to:

--- a/coldfront/core/project/tests/test_commands/test_service_units_base.py
+++ b/coldfront/core/project/tests/test_commands/test_service_units_base.py
@@ -1,0 +1,220 @@
+from io import StringIO
+
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.management import call_command
+
+from coldfront.api.statistics.utils import AccountingAllocationObjects
+from coldfront.core.allocation.models import Allocation, \
+    AllocationAttributeType, AllocationAttribute, \
+    AllocationAttributeUsage, AllocationUserStatusChoice, AllocationUser, \
+    AllocationUserAttribute, AllocationUserAttributeUsage
+from coldfront.core.project.models import Project, \
+    ProjectUserStatusChoice, ProjectUser
+from coldfront.core.statistics.models import ProjectTransaction, \
+    ProjectUserTransaction
+from coldfront.core.user.models import UserProfile
+from coldfront.core.utils.tests.test_base import TestBase
+
+
+class TestSUBase(TestBase):
+    """Base class for testing the management commands that alter project SUs"""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+
+        # Create a PI.
+        self.pi = User.objects.create(
+            username='pi0', email='pi0@nonexistent.com')
+        user_profile = UserProfile.objects.get(user=self.pi)
+        user_profile.is_pi = True
+        user_profile.save()
+
+        # Create two Users.
+        for i in range(2):
+            user = User.objects.create(
+                username=f'user{i}', email=f'user{i}@nonexistent.com')
+            user_profile = UserProfile.objects.get(user=user)
+            user_profile.cluster_uid = f'{i}'
+            user_profile.save()
+            setattr(self, f'user{i}', user)
+            setattr(self, f'user_profile{i}', user_profile)
+
+        # Clear the mail outbox.
+        mail.outbox = []
+
+    @staticmethod
+    def call_deactivate_command(*args):
+        """
+        Call the command with the given arguments, returning the messages
+        written to stdout and stderr.
+        """
+        out, err = StringIO(), StringIO()
+        kwargs = {'stdout': out, 'stderr': err}
+        call_command(*args, **kwargs)
+        return out.getvalue(), err.getvalue()
+
+    def get_accounting_allocation_objects(self, project, user=None):
+        """Return a namedtuple of database objects related to accounting and
+        allocation for the given project and optional user.
+
+        Parameters:
+            - project (Project): an instance of the Project model
+            - user (User): an instance of the User model
+
+        Returns:
+            - AccountingAllocationObjects instance
+
+        Raises:
+            - MultipleObjectsReturned, if a database retrieval returns more
+            than one object
+            - ObjectDoesNotExist, if a database retrieval returns less than
+            one object
+            - TypeError, if one or more inputs has the wrong type
+
+        NOTE: this function was taken from coldfront.core.statistics.utils.
+        This version does not check that the allocation status is Active
+        """
+        if not isinstance(project, Project):
+            raise TypeError(f'Project {project} is not a Project object.')
+
+        objects = AccountingAllocationObjects()
+
+        allocation = Allocation.objects.get(
+            project=project, resources__name='Savio Compute')
+
+        # Check that the allocation has an attribute for Service Units and
+        # an associated usage.
+        allocation_attribute_type = AllocationAttributeType.objects.get(
+            name='Service Units')
+        allocation_attribute = AllocationAttribute.objects.get(
+            allocation_attribute_type=allocation_attribute_type,
+            allocation=allocation)
+        allocation_attribute_usage = AllocationAttributeUsage.objects.get(
+            allocation_attribute=allocation_attribute)
+
+        objects.allocation = allocation
+        objects.allocation_attribute = allocation_attribute
+        objects.allocation_attribute_usage = allocation_attribute_usage
+
+        if user is None:
+            return objects
+
+        if not isinstance(user, User):
+            raise TypeError(f'User {user} is not a User object.')
+
+        # Check that there is an active association between the user and project.
+        active_status = ProjectUserStatusChoice.objects.get(name='Active')
+        ProjectUser.objects.get(user=user, project=project, status=active_status)
+
+        # Check that the user is an active member of the allocation.
+        active_status = AllocationUserStatusChoice.objects.get(name='Active')
+        allocation_user = AllocationUser.objects.get(
+            allocation=allocation, user=user, status=active_status)
+
+        # Check that the allocation user has an attribute for Service Units
+        # and an associated usage.
+        allocation_user_attribute = AllocationUserAttribute.objects.get(
+            allocation_attribute_type=allocation_attribute_type,
+            allocation=allocation, allocation_user=allocation_user)
+        allocation_user_attribute_usage = AllocationUserAttributeUsage.objects.get(
+            allocation_user_attribute=allocation_user_attribute)
+
+        objects.allocation_user = allocation_user
+        objects.allocation_user_attribute = allocation_user_attribute
+        objects.allocation_user_attribute_usage = allocation_user_attribute_usage
+
+        return objects
+
+    def record_historical_objects_len(self, project):
+        """
+        Records the lengths of all relevant historical objects to a dict
+        """
+        length_dict = {}
+        allocation_objects = self.get_accounting_allocation_objects(project)
+        historical_allocation_attribute = \
+            allocation_objects.allocation_attribute.history.all()
+
+        length_dict['historical_allocation_attribute'] = \
+            len(historical_allocation_attribute)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            allocation_user_obj = self.get_accounting_allocation_objects(
+                project, user=project_user.user)
+
+            historical_allocation_user_attribute = \
+                allocation_user_obj.allocation_user_attribute.history.all()
+
+            key = 'historical_allocation_user_attribute_' + project_user.user.username
+            length_dict[key] = len(historical_allocation_user_attribute)
+
+        return length_dict
+
+    def allocation_values_test(self, project, value, user_value):
+        """
+        Tests that the allocation user values are correct
+        """
+        allocation_objects = self.get_accounting_allocation_objects(project)
+        self.assertEqual(allocation_objects.allocation_attribute.value, value)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+            allocation_objects = self.get_accounting_allocation_objects(
+                project, user=project_user.user)
+
+            self.assertEqual(allocation_objects.allocation_user_attribute.value,
+                             user_value)
+
+    def transactions_created(self, project, pre_time, post_time, amount):
+        """
+        Tests that transactions were created for the zeroing of SUs
+        """
+        proj_transaction = ProjectTransaction.objects.get(project=project,
+                                                          allocation=amount)
+
+        self.assertTrue(pre_time <= proj_transaction.date_time <= post_time)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            proj_user_transaction = ProjectUserTransaction.objects.get(
+                project_user=project_user,
+                allocation=amount)
+
+            self.assertTrue(pre_time <= proj_user_transaction.date_time <= post_time)
+
+    def historical_objects_created(self, pre_length_dict, post_length_dict):
+        """
+        Test that historical objects were created
+        """
+        for k, v in pre_length_dict.items():
+            self.assertEqual(v + 1, post_length_dict[k])
+
+    def historical_objects_updated(self, project, reason):
+        """
+        Tests that the relevant historical objects have the correct reason
+        """
+        allocation_objects = self.get_accounting_allocation_objects(project)
+
+        alloc_attr_hist_reason = \
+            allocation_objects.allocation_attribute.history. \
+                latest('id').history_change_reason
+        self.assertEqual(alloc_attr_hist_reason, reason)
+
+        for project_user in project.projectuser_set.all():
+            if project_user.role.name != 'User':
+                continue
+
+            allocation_user_obj = self.get_accounting_allocation_objects(
+                project, user=project_user.user)
+
+            alloc_attr_hist_reason = \
+                allocation_user_obj.allocation_user_attribute.history. \
+                    latest('id').history_change_reason
+            self.assertEqual(alloc_attr_hist_reason, reason)

--- a/coldfront/core/project/tests/test_commands/test_service_units_base.py
+++ b/coldfront/core/project/tests/test_commands/test_service_units_base.py
@@ -45,7 +45,7 @@ class TestSUBase(TestBase):
         mail.outbox = []
 
     @staticmethod
-    def call_deactivate_command(*args):
+    def call_command(*args):
         """
         Call the command with the given arguments, returning the messages
         written to stdout and stderr.

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -128,16 +128,7 @@ def send_project_join_notification_email(project, project_user):
                'review_url': review_project_join_requests_url(project),
                'url': __project_detail_url(project)}
 
-    pi_condition = Q(
-        role__name='Principal Investigator', status__name='Active',
-        enable_notifications=True)
-    manager_condition = Q(role__name='Manager', status__name='Active')
-    receiver_list = list(
-        project.projectuser_set.filter(
-            pi_condition | manager_condition
-        ).values_list(
-            'user__email', flat=True
-        ))
+    receiver_list = project.managers_and_pis_emails()
 
     msg_plain = \
         render_to_string('email/new_project_join_request.txt',
@@ -438,18 +429,7 @@ def send_project_request_pooling_email(request):
     }
 
     sender = settings.EMAIL_SENDER
-
-    pi_condition = Q(
-        role__name='Principal Investigator', status__name='Active',
-        enable_notifications=True)
-    manager_condition = Q(role__name='Manager', status__name='Active')
-    receiver_list = list(
-        request.project.projectuser_set.filter(
-            pi_condition | manager_condition
-        ).values_list(
-            'user__email', flat=True
-        ))
-
+    receiver_list = request.project.managers_and_pis_emails()
     send_email_template(subject, template_name, context, sender, receiver_list)
 
 

--- a/coldfront/core/project/utils_/addition_utils.py
+++ b/coldfront/core/project/utils_/addition_utils.py
@@ -223,3 +223,69 @@ def has_pending_allocation_addition_request(project):
         name='Under Review')
     return AllocationAdditionRequest.objects.filter(
         project=project, status=under_review_status).exists()
+
+
+def set_service_units(project, allocation_objects, updated_su, reason, update_usage):
+    """
+    Sets allocation and allocation_user service units to updated_su. Creates
+    the relevant transaction objects to record the change. Updates the
+    relevant historical objects with the reason for the SU change. If
+    update_usage is True, allocation and allocation_user usage values are
+    updated.
+    """
+
+    def set_historical_reason(obj):
+        """Set the latest historical object reason"""
+        obj.refresh_from_db()
+        historical_obj = obj.history.latest('id')
+        historical_obj.history_change_reason = reason
+        historical_obj.save()
+
+    current_date = utc_now_offset_aware()
+
+    # Set the value for the Project.
+    set_project_allocation_value(project, updated_su)
+
+    if update_usage:
+        set_project_usage_value(project, updated_su)
+
+    # Create a transaction to record the change.
+    ProjectTransaction.objects.create(
+        project=project,
+        date_time=current_date,
+        allocation=updated_su)
+
+    # Set the reason for the change in the newly-created historical object.
+    set_historical_reason(
+        allocation_objects.allocation_attribute)
+
+    # Do the same for each ProjectUser.
+    for project_user in project.projectuser_set.all():
+        user = project_user.user
+        # Attempt to set the value for the ProjectUser. The method returns whether
+        # it succeeded; it may not because not every ProjectUser has a
+        # corresponding AllocationUser (e.g., PIs). Only proceed with further steps
+        # if an update occurred.
+
+        allocation_updated = set_project_user_allocation_value(
+            user, project, updated_su)
+        success_flag = allocation_updated
+
+        if update_usage:
+            allocation_usage_updated = set_project_user_usage_value(
+                user, project, updated_su)
+
+            success_flag = allocation_updated and allocation_usage_updated
+
+        if success_flag:
+            # Create a transaction to record the change.
+            ProjectUserTransaction.objects.create(
+                project_user=project_user,
+                date_time=current_date,
+                allocation=updated_su)
+
+            # Set the reason for the change in the newly-created historical object.
+            allocation_user_obj = get_accounting_allocation_objects(
+                project, user=user)
+            set_historical_reason(
+                allocation_user_obj.allocation_user_attribute)

--- a/coldfront/core/project/utils_/addition_utils.py
+++ b/coldfront/core/project/utils_/addition_utils.py
@@ -11,10 +11,8 @@ from coldfront.core.statistics.models import ProjectTransaction
 from coldfront.core.statistics.models import ProjectUserTransaction
 from coldfront.core.utils.common import project_detail_url
 from coldfront.core.utils.common import utc_now_offset_aware
-from coldfront.core.utils.common import validate_num_service_units
 from coldfront.core.utils.mail import send_email_template
 
-from collections import namedtuple
 from decimal import Decimal
 from django.conf import settings
 
@@ -223,69 +221,3 @@ def has_pending_allocation_addition_request(project):
         name='Under Review')
     return AllocationAdditionRequest.objects.filter(
         project=project, status=under_review_status).exists()
-
-
-def set_service_units(project, allocation_objects, updated_su, reason, update_usage):
-    """
-    Sets allocation and allocation_user service units to updated_su. Creates
-    the relevant transaction objects to record the change. Updates the
-    relevant historical objects with the reason for the SU change. If
-    update_usage is True, allocation and allocation_user usage values are
-    updated.
-    """
-
-    def set_historical_reason(obj):
-        """Set the latest historical object reason"""
-        obj.refresh_from_db()
-        historical_obj = obj.history.latest('id')
-        historical_obj.history_change_reason = reason
-        historical_obj.save()
-
-    current_date = utc_now_offset_aware()
-
-    # Set the value for the Project.
-    set_project_allocation_value(project, updated_su)
-
-    if update_usage:
-        set_project_usage_value(project, updated_su)
-
-    # Create a transaction to record the change.
-    ProjectTransaction.objects.create(
-        project=project,
-        date_time=current_date,
-        allocation=updated_su)
-
-    # Set the reason for the change in the newly-created historical object.
-    set_historical_reason(
-        allocation_objects.allocation_attribute)
-
-    # Do the same for each ProjectUser.
-    for project_user in project.projectuser_set.all():
-        user = project_user.user
-        # Attempt to set the value for the ProjectUser. The method returns whether
-        # it succeeded; it may not because not every ProjectUser has a
-        # corresponding AllocationUser (e.g., PIs). Only proceed with further steps
-        # if an update occurred.
-
-        allocation_updated = set_project_user_allocation_value(
-            user, project, updated_su)
-        success_flag = allocation_updated
-
-        if update_usage:
-            allocation_usage_updated = set_project_user_usage_value(
-                user, project, updated_su)
-
-            success_flag = allocation_updated and allocation_usage_updated
-
-        if success_flag:
-            # Create a transaction to record the change.
-            ProjectUserTransaction.objects.create(
-                project_user=project_user,
-                date_time=current_date,
-                allocation=updated_su)
-
-            # Set the reason for the change in the newly-created historical object.
-            allocation_user_obj = get_accounting_allocation_objects(
-                project, user=user)
-            set_historical_reason(
-                allocation_user_obj.allocation_user_attribute)

--- a/coldfront/core/project/utils_/email_utils.py
+++ b/coldfront/core/project/utils_/email_utils.py
@@ -22,11 +22,4 @@ def project_email_receiver_list(project):
     """
     if not isinstance(project, Project):
         raise TypeError(f'{project} is not a Project object.')
-    pi_condition = Q(
-        role__name='Principal Investigator', status__name='Active',
-        enable_notifications=True)
-    manager_condition = Q(role__name='Manager', status__name='Active')
-    return list(
-        project.projectuser_set.filter(
-            pi_condition | manager_condition
-        ).distinct().values_list('user__email', flat=True))
+    return project.managers_and_pis_emails()

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -334,16 +334,7 @@ def send_new_allocation_renewal_request_pooling_notification_email(request):
     }
 
     sender = settings.EMAIL_SENDER
-    pi_condition = Q(
-        role__name='Principal Investigator', status__name='Active',
-        enable_notifications=True)
-    manager_condition = Q(role__name='Manager', status__name='Active')
-    receiver_list = list(
-        request.post_project.projectuser_set.filter(
-            pi_condition | manager_condition
-        ).values_list(
-            'user__email', flat=True
-        ))
+    receiver_list = request.post_project.managers_and_pis_emails()
 
     send_email_template(subject, template_name, context, sender, receiver_list)
 

--- a/coldfront/templates/email/expired_ica_project.txt
+++ b/coldfront/templates/email/expired_ica_project.txt
@@ -1,0 +1,8 @@
+Dear managers of {{ project_name }},
+
+This is a notification that the project {{ project_name }} expired on {{ expiry_date }} and has therefore been deactivated. Accounts under this project will no longer be able to access its compute resources.
+
+If you believe this is a mistake, please contact us at {{ support_email }}.
+
+Thank you,
+{{ signature }}


### PR DESCRIPTION
This is an extension of #357 by @jofeinstein.

Original PR text:
- created new management command `coldfront/core/project/management/commands/deactivate_ica_projects.py`
- added tests in `coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py`
- all tests pass on my setup

- Much of the code in `test_deactivate_ica_projects.py` is the same as code for `test_add_service_units_to_project.py` from [PR 355](https://github.com/ucb-rit/coldfront/pull/355). If we merge these branches, I can either create a new base class for both testing classes to inherit or have one of the testing classes inherit the other