### PR TITLE
Issue 377 pylint

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ standards. The plugin pylint_django improves pylint's ability to analyse Django 
   ```
   pylint --load-plugins pylint_django --django-settings-module=<your.app.settings> <file_path>
   ```
+- Note you can also run pylint on each python file in a directory by passing in the directory as <file_path>
+- By default, output is written to stdout. To output to a file, include the --output=<filename> flag.
 
 ## Directory structure
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,16 @@ emails will be outputted here for inspection.
   python -m smtpd -n -c DebuggingServer localhost:1025
   ```
 
+#### pylint
+
+- pylint is a python module that tests code for style and helps enforce coding 
+standards. The plugin pylint_django improves pylint's ability to analyse Django code.
+
+- To run pylint with the pylint_django plugin on a python file, call pylint from the command line:
+  ```
+  pylint --load-plugins pylint_django --django-settings-module=<your.app.settings> <file_path>
+  ```
+
 ## Directory structure
 
 - coldfront

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ standards. The plugin pylint_django improves pylint's ability to analyse Django 
   ```
 - Note you can also run pylint on each python file in a directory by passing in the directory as <file_path>
 - By default, output is written to stdout. To output to a file, include the --output=<filename> flag.
+  ```
+  pylint --output=<filename> --load-plugins pylint_django --django-settings-module=<your.app.settings> <file_path>
+  ```
 
 ## Directory structure
 

--- a/README.md
+++ b/README.md
@@ -233,12 +233,12 @@ standards. The plugin pylint_django improves pylint's ability to analyse Django 
 
 - To run pylint with the pylint_django plugin on a python file, call pylint from the command line:
   ```
-  pylint --load-plugins pylint_django --django-settings-module=<your.app.settings> <file_path>
+  pylint --load-plugins pylint_django --django-settings-module=coldfront.config.settings <file_path>
   ```
-- Note you can also run pylint on each python file in a directory by passing in the directory as <file_path>
+- Note you can also run pylint on each python file in a directory by passing in the directory as <file_path>.
 - By default, output is written to stdout. To output to a file, include the --output=<filename> flag.
   ```
-  pylint --output=<filename> --load-plugins pylint_django --django-settings-module=<your.app.settings> <file_path>
+  pylint --output=<filename> --load-plugins pylint_django --django-settings-module=coldfront.config.settings <file_path>
   ```
 
 ## Directory structure

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,8 @@ openpyxl==3.0.9
 pandas==1.1.5
 phonenumbers==8.12.23
 psycopg2-binary==2.8.3
+pylint==2.12.2
+pylint-django==2.5.2
 pyparsing==2.4.7
 python-dateutil==2.8.0
 python-memcached==1.59


### PR DESCRIPTION
- added pylint and pylint-django to requirements.txt
 
- added documentation in the README about how to run pylint and pylint-django

- to install pylint and pylint-django, run `pip install -r requirements.txt`

- information on how to run pylint is in the README 