### PR TITLE
added help text about lbl employees being PIs

### DIFF
--- a/coldfront/core/project/forms_/new_project_forms/request_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/request_forms.py
@@ -8,6 +8,7 @@ from coldfront.core.project.models import ProjectUserRoleChoice
 from coldfront.core.project.models import SavioProjectAllocationRequest
 from coldfront.core.project.utils_.new_project_utils import non_denied_new_project_request_statuses
 from coldfront.core.project.utils_.renewal_utils import non_denied_renewal_request_statuses
+from coldfront.core.user.models import EmailAddress
 from coldfront.core.utils.common import utc_now_offset_aware
 
 from django import forms
@@ -184,6 +185,24 @@ class SavioProjectExistingPIForm(forms.Form):
             exclude_user_pks.update(
                 set.union(pis_with_existing_pcas, pis_with_pending_requests))
 
+        if flag_enabled('LRC_ONLY'):
+            # Exclude users with non-LBL emails.
+            users_with_non_lbl_primary_emails = set(ProjectUser.objects.exclude(
+                user__email__endswith='@lbl.gov'
+            ).values_list('user__pk', flat=True))
+
+            # Checking if users have a non-primary LBL email.
+            users_with_lbl_nonprimary_emails = set(EmailAddress.objects.filter(
+                email__endswith='@lbl.gov',
+                is_verified=True
+            ).values_list('user__pk', flat=True))
+
+            users_with_non_lbl_email = \
+                users_with_non_lbl_primary_emails.difference(
+                    users_with_lbl_nonprimary_emails)
+
+            exclude_user_pks.update(users_with_non_lbl_email)
+
         # Exclude any user that does not have an email address.
         queryset = queryset.exclude(Q(email__isnull=True) | Q(email__exact=''))
         self.fields['PI'].queryset = queryset
@@ -211,6 +230,12 @@ class SavioProjectNewPIForm(forms.Form):
                 User.objects.filter(email=email).exists()):
             raise forms.ValidationError(
                 'A user with that email address already exists.')
+
+        if flag_enabled('LRC_ONLY'):
+            if not email.endswith('@lbl.gov'):
+                raise forms.ValidationError(
+                    'New PI must be an LBL employee with an LBL email.')
+
         return email
 
 

--- a/coldfront/core/project/templates/project/project_request/savio/project_existing_pi.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_existing_pi.html
@@ -1,4 +1,5 @@
 {% extends "common/base.html" %}
+{% load feature_flags %}
 {% load crispy_forms_tags %}
 {% load static %}
 
@@ -27,6 +28,10 @@ Savio Project Request - Existing PI
 </ol>
 
 <p>Select an existing user to be a Principal Investigator of the project. You may search for the user in the selection field. If the desired user is not listed, you may skip this step and specify information for a new PI in the next step.</p>
+{% flag_enabled 'LRC_ONLY' as lrc_only %}
+{% if lrc_only %}
+  <p>Note: Only LBL employees, users with an "@lbl.gov" email, can be selected as a PI.</p>
+{% endif %}
 
 {% if allocation_type == 'FCA' %}
   <p>Note: Each PI may only have one FCA at a time, so any that have pending requests or active allocations are not selectable.</p>

--- a/coldfront/core/project/templates/project/project_request/savio/project_new_pi.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_new_pi.html
@@ -1,4 +1,5 @@
 {% extends "common/base.html" %}
+{% load feature_flags %}
 {% load crispy_forms_tags %}
 {% load static %}
 
@@ -23,6 +24,11 @@ Savio Project Request - New PI
 </ol>
 
 <p>Provide details about a new user, who will be a Principal Investigator for the project. An existing user should have been selected in the previous step.</p>
+
+{% flag_enabled 'LRC_ONLY' as lrc_only %}
+{% if lrc_only %}
+  <p>Note: Only LBL employees, users with an "@lbl.gov" email, can be a PI.</p>
+{% endif %}
 
 <form action="" method="post">
   {% csrf_token %}

--- a/coldfront/core/project/tests/test_forms/test_new_project_forms/test_savio_project_existing_pi_form.py
+++ b/coldfront/core/project/tests/test_forms/test_new_project_forms/test_savio_project_existing_pi_form.py
@@ -205,4 +205,5 @@ class TestSavioProjectExistingPIForm(TestBase):
             else:
                 self.assertNotIn(self.user.pk, pi_field_disabled_choices)
 
-    # TODO
+    # TODO: Test LRC-only functionality. PIs are only shown/allowed if
+    #  they have an lbl.gov email


### PR DESCRIPTION
Addresses [issue 392](https://github.com/ucb-rit/coldfront/issues/392).

- Added validation to `SavioProjectNewPIForm` to enforce new PIs being lbl employees
- Added filtering to `SavioProjectExistingPIForm` to gray out users without an lbl email
   - checks both primary email and any additional EmailAddresses associated with a user
- Added conditionally visible text to inform users of this in `savio/project_existing_pi.html` and `savio/project_new_pi.html`