### PR TITLE
Cluster access emails now cc managers and PIs

### DIFF
--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -2019,21 +2019,16 @@ class AllocationClusterAccountActivateRequestView(LoginRequiredMixin,
                 'center_help_email': CENTER_HELP_EMAIL,
                 'signature': EMAIL_SIGNATURE,
             }
-            sender = EMAIL_SENDER
 
-            user_filter = Q(user=self.user_obj)
-            manager_pi_filter = Q(
-                role__name__in=['Manager', 'Principal Investigator'],
-                status__name='Active')
-            receiver_list = list(
-                project_obj.projectuser_set.filter(
-                    user_filter | manager_pi_filter, enable_notifications=True
-                ).values_list(
-                    'user__email', flat=True
-                ))
+            cc_list = project_obj.managers_and_pis_emails()
 
             send_email_template(
-                subject, template, template_context, sender, receiver_list)
+                subject,
+                template,
+                template_context,
+                EMAIL_SENDER,
+                [self.user_obj.email],
+                cc=cc_list)
 
         return super().form_valid(form)
 
@@ -2135,27 +2130,23 @@ class AllocationClusterAccountDenyRequestView(LoginRequiredMixin,
             subject = 'Cluster Access Denied'
             template = 'email/cluster_access_denied.txt'
             template_context = {
+                'user': self.user_obj,
                 'center_name': EMAIL_CENTER_NAME,
                 'project': project_obj.name,
                 'allocation': allocation_obj.pk,
                 'opt_out_instruction_url': EMAIL_OPT_OUT_INSTRUCTION_URL,
                 'signature': EMAIL_SIGNATURE,
             }
-            sender = EMAIL_SENDER
 
-            user_filter = Q(user=self.user_obj)
-            manager_pi_filter = Q(
-                role__name__in=['Manager', 'Principal Investigator'],
-                status__name='Active')
-            receiver_list = list(
-                project_obj.projectuser_set.filter(
-                    user_filter | manager_pi_filter, enable_notifications=True
-                ).values_list(
-                    'user__email', flat=True
-                ))
+            cc_list = project_obj.managers_and_pis_emails()
 
             send_email_template(
-                subject, template, template_context, sender, receiver_list)
+                subject,
+                template,
+                template_context,
+                EMAIL_SENDER,
+                [self.user_obj.email],
+                cc=cc_list)
 
         return HttpResponseRedirect(
             reverse('allocation-cluster-account-request-list'))

--- a/coldfront/templates/email/cluster_access_denied.txt
+++ b/coldfront/templates/email/cluster_access_denied.txt
@@ -1,4 +1,4 @@
-Dear {{ center_user }} user,
+Dear {{ user.first_name }} {{ user.last_name }},
 
 Your cluster access request under project {{ project }} and allocation {{ allocation }} has been denied.
 


### PR DESCRIPTION
- altered the way emails are sent in AllocationClusterAccountDenyRequestView and AllocationClusterAccountActivateRequestView
- Managers and PIs (with notifications on) are cc'ed
- Addressed some confusion caused by ticket INC1369110