### PR TITLE
Remove assumptions that AllocationPeriod exists in new project request request/approval views

### DIFF
--- a/coldfront/core/project/templates/project/project_request/savio/project_request_detail.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_detail.html
@@ -135,10 +135,14 @@ Savio Project Request Detail
       </p>
       {% with allocation_period=savio_request.allocation_period %}
         {% if has_allocation_period_started %}
-          <p>
-            If approved, the request will be processed immediately, since its
-            Allocation Period ({{ allocation_period.name }}) has already begun.
-          </p>
+          {% if allocation_period %}
+            <p>
+              If approved, the request will be processed immediately, since its
+              Allocation Period ({{ allocation_period.name }}) has already begun.
+            </p>
+          {% else %}
+            <p>If approved, the request will be processed immediately.</p>
+          {% endif %}
         {% else %}
           <p>
             If approved, the request will be scheduled for processing at the

--- a/coldfront/core/project/views_/new_project_views/approval_views.py
+++ b/coldfront/core/project/views_/new_project_views/approval_views.py
@@ -373,10 +373,12 @@ class SavioProjectRequestDetailView(LoginRequiredMixin, UserPassesTestMixin,
         return state['setup']['status']
 
     def has_request_allocation_period_started(self):
-        """Return whether the request's AllocationPeriod has started."""
-        return (
-            self.request_obj.allocation_period.start_date <=
-            display_time_zone_current_date())
+        """Return whether the request's AllocationPeriod has started. If
+        the request has no period, return True."""
+        allocation_period = self.request_obj.allocation_period
+        if not allocation_period:
+            return True
+        return allocation_period.start_date <= display_time_zone_current_date()
 
     def is_checklist_complete(self):
         status_choice = savio_request_state_status(self.request_obj)

--- a/coldfront/core/project/views_/new_project_views/request_views.py
+++ b/coldfront/core/project/views_/new_project_views/request_views.py
@@ -310,7 +310,7 @@ class SavioProjectRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
         """Return the AllocationPeriod the user selected."""
         step_number = self.step_numbers_by_form_name['allocation_period']
         data = form_data[step_number]
-        return data['allocation_period'] if data['allocation_period'] else None
+        return data.get('allocation_period', None)
 
     def __get_allocation_type(self, form_data):
         """Return the allocation type matching the provided input."""


### PR DESCRIPTION
Fixes #404

**Changes**
- Adjusted new project request request/approval views to account for Condo and Recharge projects, which do not have `AllocationPeriods`:
    - In `SavioProjectRequestWizard`, modified the method for retrieving the `AllocationPeriod` to return `None` if the request has no period.
    - In `SavioProjectRequestDetailView`:
        - Modified the method for determining whether the request's `AllocationPeriod` has started to return `True` if the request has no period.
        - Displayed different status text for such requests.
- Added tests for checking the final processing logic for Condo and Recharge requests.