### PR TITLE
Issue 409

### DIFF
--- a/coldfront/core/allocation/views_/secure_dir_views.py
+++ b/coldfront/core/allocation/views_/secure_dir_views.py
@@ -261,25 +261,20 @@ class SecureDirManageUsersView(LoginRequiredMixin,
                 }
 
                 try:
-                    msg_plain = \
-                        render_to_string(
-                            ('email/secure_dir_request/'
-                             'pending_secure_dir_manage_user_requests.txt'),
-                            context)
-                    msg_html = \
-                        render_to_string(
-                            ('email/secure_dir_request/'
-                             'pending_secure_dir_manage_user_requests.html'),
-                            context)
-
-                    send_mail(
-                        f'Pending Secure Directory '
-                        f'{self.language_dict["noun"]} Requests',
-                        msg_plain,
-                        settings.EMAIL_SENDER,
-                        settings.EMAIL_ADMIN_LIST,
-                        html_message=msg_html,
-                    )
+                    subject = f'Pending Secure Directory '\
+                              f'{self.language_dict["noun"]} Requests'
+                    plain_template = 'email/secure_dir_request/'\
+                                     'pending_secure_dir_manage_' \
+                                     'user_requests.txt'
+                    html_template = 'email/secure_dir_request/' \
+                                    'pending_secure_dir_manage_' \
+                                    'user_requests.html'
+                    send_email_template(subject,
+                                        plain_template,
+                                        context,
+                                        settings.EMAIL_SENDER,
+                                        settings.EMAIL_ADMIN_LIST,
+                                        html_template=html_template)
 
                 except Exception as e:
                     message = f'Failed to send notification email.'

--- a/coldfront/core/allocation/views_/secure_dir_views.py
+++ b/coldfront/core/allocation/views_/secure_dir_views.py
@@ -4,13 +4,11 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import User
-from django.core.mail import send_mail
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.db.models import Q
 from django.forms import formset_factory
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views.generic import ListView, FormView
 from django.views.generic.base import TemplateView, View

--- a/coldfront/core/project/management/commands/pending_join_request_reminder.py
+++ b/coldfront/core/project/management/commands/pending_join_request_reminder.py
@@ -1,20 +1,16 @@
 from django.contrib.auth.models import User
+from django.conf import settings
+from django.core.management.base import BaseCommand
 
-from coldfront.core.utils.common import import_from_settings
 from coldfront.core.utils.mail import send_email_template
 from coldfront.core.project.models import ProjectUserJoinRequest, Project
 from coldfront.core.project.utils import project_join_list_url
 from coldfront.core.project.utils import review_project_join_requests_url
-from django.conf import settings
-from django.core.management.base import BaseCommand
-from django.urls import reverse
-from urllib.parse import urljoin
+
 import logging
-from django.db.models import Q
-from django.core.mail import send_mail
-from django.template.loader import render_to_string
 
 """An admin command that sends PIs reminder emails of pending join requests."""
+
 
 class Command(BaseCommand):
 

--- a/coldfront/core/project/management/commands/pending_join_request_reminder.py
+++ b/coldfront/core/project/management/commands/pending_join_request_reminder.py
@@ -63,20 +63,18 @@ class Command(BaseCommand):
 
                 recipients = project.managers_and_pis_emails()
                 try:
-                    msg_plain = \
-                        render_to_string('email/project_join_request/pending_project_join_requests.txt',
-                                         context)
-                    msg_html = \
-                        render_to_string('email/project_join_request/pending_project_join_requests.html',
-                                         context)
+                    subject = 'Pending Project Join Requests'
+                    plain_template = 'email/project_join_request/' \
+                                     'pending_project_join_requests.txt'
+                    html_template = 'email/project_join_request/' \
+                                    'pending_project_join_requests.html'
+                    send_email_template(subject,
+                                        plain_template,
+                                        context,
+                                        settings.EMAIL_SENDER,
+                                        recipients,
+                                        html_template=html_template)
 
-                    send_mail(
-                        'Pending Project Join Requests',
-                        msg_plain,
-                        settings.EMAIL_SENDER,
-                        recipients,
-                        html_message=msg_html,
-                    )
                     emails_sent += len(recipients)
                 except Exception as e:
                     message = 'Failed to send reminder email. Details:'

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -87,20 +87,12 @@ def send_project_join_notification_email(project, project_user):
 
     receiver_list = project.managers_and_pis_emails()
 
-    msg_plain = \
-        render_to_string('email/new_project_join_request.txt',
-                         context)
-    msg_html = \
-        render_to_string('email/new_project_join_request.html',
-                         context)
-
-    send_mail(
-        subject,
-        msg_plain,
-        settings.EMAIL_SENDER,
-        receiver_list,
-        html_message=msg_html,
-    )
+    send_email_template(subject,
+                        'email/new_project_join_request.txt',
+                        context,
+                        settings.EMAIL_SENDER,
+                        receiver_list,
+                        html_template='email/new_project_join_request.html')
 
 
 def send_project_join_request_approval_email(project, project_user):

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -1,6 +1,4 @@
-from django.core.mail import send_mail
 from django.db import transaction
-from django.template.loader import render_to_string
 
 from coldfront.api.statistics.utils import get_accounting_allocation_objects
 from coldfront.core.allocation.models import Allocation

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1346,7 +1346,7 @@ class ProjectReivewEmailView(LoginRequiredMixin, UserPassesTestMixin, FormView):
             form_data.get('email_body'),
             EMAIL_DIRECTOR_EMAIL_ADDRESS,
             receiver_list,
-            cc
+            cc=cc
         )
 
         if receiver_list:

--- a/coldfront/core/utils/mail.py
+++ b/coldfront/core/utils/mail.py
@@ -15,7 +15,7 @@ if EMAIL_ENABLED:
         'EMAIL_DEVELOPMENT_EMAIL_LIST')
 
 
-def send_email(subject, body, sender, receiver_list, html_body, cc=[]):
+def send_email(subject, body, sender, receiver_list, cc=[], html_body=''):
     """Helper function for sending emails
     """
 
@@ -72,5 +72,5 @@ def send_email_template(subject, template_name, context, sender,
                       plain_body,
                       sender,
                       receiver_list,
-                      html_body,
-                      cc=cc)
+                      cc=cc,
+                      html_body=html_body)


### PR DESCRIPTION
- Altered `send_email` in `coldfront/core/mail.py` to use EmailMultiAlternatives class instead of EmailMessage. We use `attach_alternative` to send an html version of the email, if an html version is provided. 
- `send_email_template` in `coldfront/core/mail.py` now has a new arg `html_template`. If provided, the html template is rendered and passed into send_email to be sent as an alternative version of the email.

- There were only 3 places that used Django's `send_mail`. Each was rendering an additional html body. They now pass the html template into send_email_template which renders it.

- Reran the test suite and all tests still pass.