### PR TITLE
Modify status code returned by can_submit_job API endpoint in three cases

### DIFF
--- a/coldfront/api/statistics/tests/test_can_submit_job.py
+++ b/coldfront/api/statistics/tests/test_can_submit_job.py
@@ -85,7 +85,7 @@ class TestCanSubmitJobView(TestJobBase):
         fail."""
         self.project_user.delete()
         message = f'User user0 is not a member of account test_project.'
-        self.assert_result('1.00', '0', 'test_project', 400, False, message)
+        self.assert_result('1.00', '0', 'test_project', 200, False, message)
 
     def test_no_active_compute_allocation(self):
         """Test that requests wherein the account has no active compute
@@ -95,17 +95,17 @@ class TestCanSubmitJobView(TestJobBase):
         self.allocation.status = AllocationStatusChoice.objects.get(
             name='Expired')
         self.allocation.save()
-        self.assert_result('1.00', '0', 'test_project', 400, False, message)
+        self.assert_result('1.00', '0', 'test_project', 200, False, message)
         # The allocation is active, but does not have Savio Compute as a
         # resource.
         self.allocation.status = AllocationStatusChoice.objects.get(
             name='Active')
         self.allocation.resources.all().delete()
         self.allocation.save()
-        self.assert_result('1.00', '0', 'test_project', 400, False, message)
+        self.assert_result('1.00', '0', 'test_project', 200, False, message)
         # The allocation does not exist.
         self.allocation.delete()
-        self.assert_result('1.00', '0', 'test_project', 400, False, message)
+        self.assert_result('1.00', '0', 'test_project', 200, False, message)
 
     def test_user_not_member_of_compute_allocation(self):
         """Test that requests wherein the user is not an active member
@@ -117,10 +117,10 @@ class TestCanSubmitJobView(TestJobBase):
         self.allocation_user.status = AllocationUserStatusChoice.objects.get(
             name='Removed')
         self.allocation_user.save()
-        self.assert_result('1.00', '0', 'test_project', 400, False, message)
+        self.assert_result('1.00', '0', 'test_project', 200, False, message)
         # The allocation user does not exist.
         self.allocation_user.delete()
-        self.assert_result('1.00', '0', 'test_project', 400, False, message)
+        self.assert_result('1.00', '0', 'test_project', 200, False, message)
 
     def test_bad_database_state_causes_server_error(self):
         """Test that requests fails if there are too few or too many of

--- a/coldfront/api/statistics/views.py
+++ b/coldfront/api/statistics/views.py
@@ -704,11 +704,11 @@ def can_submit_job(request, job_cost, user_id, account_id):
         message = (
             f'User {user.username} is not a member of account {account.name}.')
         logger.error(message)
-        return client_error(message)
+        return non_affirmative(message)
     except Allocation.DoesNotExist:
         message = f'Account {account.name} has no active compute allocation.'
         logger.error(message)
-        return client_error(message)
+        return non_affirmative(message)
     except Allocation.MultipleObjectsReturned:
         logger.error(
             f'Account {account.name} has more than one active compute '
@@ -719,7 +719,7 @@ def can_submit_job(request, job_cost, user_id, account_id):
             f'User {user.username} is not an active member of the compute '
             f'allocation for account {account.name}.')
         logger.error(message)
-        return client_error(message)
+        return non_affirmative(message)
     except (MultipleObjectsReturned, ObjectDoesNotExist) as e:
         logger.error(
             f'Failed to retrieve a required database object. Details: {e}')


### PR DESCRIPTION
**Context**
- At job submission time, the job submit plugin makes a GET request to `/api/can_submit_job/`, which returns one of the following responses:
    - 200 OK, with a boolean (whether the job can be submitted), or
        - Examples:
            - `True` if the `Project`/`User` have enough SUs,
            - `False` otherwise.
    - 400 Bad Request (or, rarely, 500 Internal Server Error)
        - Examples:
            - The job's `Allocation` is inactive,
            - The `User` and `Project`/`Allocation` are not associated.
- When the plugin receives an error (e.g., 400 Bad Request), it allows the job through, at which point Slurm associations and CPU hours are [checked](https://slurm.schedmd.com/accounting.html#slurm-accounting-configuration-after-build) (`AccountingStorageEnforce=associations,limits,qos` in `slurm.conf`).
    - For example, a `Project` with an inactive `Allocation` should have 0 CPU hours in Slurm, so it would be blocked at this time.

**Changes**
- Modified the endpoint to return 200 instead of 400 in the following cases, so that such jobs are immediately blocked:
    - The `User` is not a member of the `Project`.
    - The `Project`'s `Allocation` is not `Active`.
    - The `User` is not an active member of the `Allocation`.
- Updated tests.