### PR TITLE
Fix tests failures on LRC VMs caused by LRC_ONLY being enabled

### DIFF
--- a/coldfront/api/utils/tests/test_api_base.py
+++ b/coldfront/api/utils/tests/test_api_base.py
@@ -1,14 +1,28 @@
-from coldfront.core.user.models import ExpiringToken
-from django.contrib.auth.models import User
-from django.core.management import call_command
-from django.test import TestCase
-from flags.state import enable_flag
+from copy import deepcopy
 from http import HTTPStatus
-from rest_framework.test import APIClient
 import os
 import sys
 
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.test import override_settings
+from django.test import TestCase
 
+from flags.state import enable_flag
+from rest_framework.test import APIClient
+
+from coldfront.core.user.models import ExpiringToken
+
+
+# TODO: Because FLAGS is set directly in settings, the disable_flag method has
+# TODO: no effect. A better approach is to have a dedicated test_settings
+# TODO: module that is used exclusively for testing.
+FLAGS_COPY = deepcopy(settings.FLAGS)
+FLAGS_COPY.pop('LRC_ONLY')
+
+
+@override_settings(FLAGS=FLAGS_COPY)
 class TestAPIBase(TestCase):
     """A base class for testing the API."""
 

--- a/coldfront/core/project/tests/test_utils/test_renewal_utils/test_allocation_renewal_processing_runner.py
+++ b/coldfront/core/project/tests/test_utils/test_renewal_utils/test_allocation_renewal_processing_runner.py
@@ -617,8 +617,9 @@ class TestRunnerMixin(TestRunnerMixinBase):
         allocation = get_project_compute_allocation(project)
 
         # Set the end_date, but not the start_date.
+        today = display_time_zone_current_date()
         allocation.start_date = None
-        end_date = date.today() + timedelta(days=30)
+        end_date = today + timedelta(days=30)
         allocation.end_date = end_date
         allocation.save()
 
@@ -628,7 +629,7 @@ class TestRunnerMixin(TestRunnerMixinBase):
 
         # The start_date should have been updated, but not the end_date.
         allocation.refresh_from_db()
-        self.assertEqual(date.today(), allocation.start_date)
+        self.assertEqual(today, allocation.start_date)
         self.assertEqual(end_date, allocation.end_date)
 
     def test_runner_sets_allocation_type(self):

--- a/coldfront/core/utils/tests/test_base.py
+++ b/coldfront/core/utils/tests/test_base.py
@@ -1,21 +1,35 @@
+from copy import deepcopy
+from http import HTTPStatus
+from io import StringIO
+import os
+import sys
+
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.messages import get_messages
 from django.core.management import call_command
+from django.test import Client
+from django.test import override_settings
+from django.test import TestCase
+
+from flags.state import enable_flag
+
 from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectStatusChoice
 from coldfront.core.project.models import ProjectUser
 from coldfront.core.project.models import ProjectUserRoleChoice
 from coldfront.core.project.models import ProjectUserStatusChoice
 from coldfront.core.utils.common import utc_now_offset_aware
-from django.test import Client
-from django.test import TestCase
-from flags.state import enable_flag
-from http import HTTPStatus
-from io import StringIO
-import os
-import sys
 
 
+# TODO: Because FLAGS is set directly in settings, the disable_flag method has
+# TODO: no effect. A better approach is to have a dedicated test_settings
+# TODO: module that is used exclusively for testing.
+FLAGS_COPY = deepcopy(settings.FLAGS)
+FLAGS_COPY.pop('LRC_ONLY')
+
+
+@override_settings(FLAGS=FLAGS_COPY)
 class TestBase(TestCase):
     """A base class for testing the application."""
 


### PR DESCRIPTION
**Changes**
- Overrode the `FLAGS` setting in test classes to disable `LRC_ONLY`. This is necessary because the `disable_flag` method does not successfully disable the flag, due to the fact that it is enabled directly in the setting.
- Fixed a test that was failing at certain times of day due to a lack of timezone conversion.

**How to Test**
- Review the code changes and add comments as needed.
- Ensure that the test suite passes on an LRC-based VM.

**Notes**
- A longer-term solution is to define a `test_settings.py` module that can be set via `export DJANGO_SETTINGS_MODULE=path.to.test_settings` during tests.