### PR TITLE
Replace majority of user-facing, hard-coded strings with settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ prod_settings.py
 staging_settings.py
 local_settings.py
 local_strings.py
+password_reset_subject.txt
 coldfront.db*
 *.code-workspace
 .vscode

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -54,8 +54,10 @@ flag_lrc_enabled: False
 flag_next_period_renewal_requestable_month: 5
 
 # Portal settings.
-# TODO: For LRC, use the string "MyLRC".
+# TODO: For LRC, use "MyLRC", "Laboratory Research Computing", and "LRC".
 portal_name: "MyBRC"
+program_name_long: "Berkeley Research Computing"
+program_name_short: "BRC"
 
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""

--- a/bootstrap/ansible/password_reset_subject_template.tmpl
+++ b/bootstrap/ansible/password_reset_subject_template.tmpl
@@ -1,0 +1,1 @@
+[{{ portal_name }}-User-Portal] Password Reset

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -179,7 +179,12 @@
     - name: Create the deployment-specific _settings.py file from a template
       template: src={{ git_prefix }}/{{ reponame }}/bootstrap/ansible/settings_template.tmpl
                 dest={{ git_prefix }}/{{ reponame }}/{{ djangoprojname }}/config/{{ deployment }}_settings.py
-      become_user:  "{{ djangooperator }}"
+      become_user: "{{ djangooperator }}"
+
+    - name: Create the deployment-specific password reset email subject text file from a template
+      template: src={{ git_prefix }}/{{ reponame }}/bootstrap/ansible/password_reset_subject_template.tmpl
+                dest={{ git_prefix }}/{{ reponame }}/{{ djangoprojname }}/core/user/templates/user/passwords/password_reset_subject.txt
+      become_user: "{{ djangooperator }}"
 
     - name: Run Django management command - initial_setup
       django_manage:

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -5,6 +5,10 @@ DEBUG = {{ debug }}
 
 ALLOWED_HOSTS = ['0.0.0.0', '{{ hostname }}', '{{ host_ip }}']
 
+PROGRAM_NAME_LONG = '{{ program_name_long }}'
+PROGRAM_NAME_SHORT = '{{ program_name_short }}'
+
+CENTER_NAME = PROGRAM_NAME_SHORT + ' HPC Resources'
 CENTER_BASE_URL = '{{ full_host_path }}'
 CENTER_HELP_URL = CENTER_BASE_URL + '/help'
 CENTER_PROJECT_RENEWAL_HELP_URL = CENTER_BASE_URL + '/help'

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -5,6 +5,7 @@ DEBUG = {{ debug }}
 
 ALLOWED_HOSTS = ['0.0.0.0', '{{ hostname }}', '{{ host_ip }}']
 
+PORTAL_NAME = '{{ portal_name }}'
 PROGRAM_NAME_LONG = '{{ program_name_long }}'
 PROGRAM_NAME_SHORT = '{{ program_name_short }}'
 

--- a/bootstrap/development/main.copyme
+++ b/bootstrap/development/main.copyme
@@ -54,8 +54,10 @@ flag_lrc_enabled: False
 flag_next_period_renewal_requestable_month: 5
 
 # Portal settings.
-# TODO: For LRC, use the string "MyLRC".
+# TODO: For LRC, use "MyLRC", "Laboratory Research Computing", and "LRC".
 portal_name: "MyBRC"
+program_name_long: "Berkeley Research Computing"
+program_name_short: "BRC"
 
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""
@@ -80,7 +82,7 @@ git_prefix: /vagrant/coldfront_app
 hostname: localhost
 host_ip: localhost
 app_port: 80
-full_host_path: http://localhost
+full_host_path: http://localhost:8880
 
 # SSL settings.
 ssl_enabled: false

--- a/bootstrap/development/playbook.yml
+++ b/bootstrap/development/playbook.yml
@@ -295,6 +295,10 @@
         src: "{{ git_prefix }}/{{ reponame }}/bootstrap/ansible/settings_template.tmpl"
         dest: "{{ git_prefix }}/{{ reponame }}/{{ djangoprojname }}/config/{{ deployment }}_settings.py"
 
+    - name: Create the deployment-specific password reset email subject text file from a template
+      template: src={{ git_prefix }}/{{ reponame }}/bootstrap/ansible/password_reset_subject_template.tmpl
+                dest={{ git_prefix }}/{{ reponame }}/{{ djangoprojname }}/core/user/templates/user/passwords/password_reset_subject.txt
+
     # Run Django management commands.
 
     - name: Run Django management command - initial_setup

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -136,6 +136,7 @@ TEMPLATES = [
                 'coldfront.core.utils.context_processors.allocation_navbar_visibility',
                 'coldfront.core.utils.context_processors.current_allowance_year_allocation_period',
                 'coldfront.core.utils.context_processors.display_time_zone',
+                'coldfront.core.utils.context_processors.program_name',
             ],
         },
     },

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -136,7 +136,7 @@ TEMPLATES = [
                 'coldfront.core.utils.context_processors.allocation_navbar_visibility',
                 'coldfront.core.utils.context_processors.current_allowance_year_allocation_period',
                 'coldfront.core.utils.context_processors.display_time_zone',
-                'coldfront.core.utils.context_processors.program_name',
+                'coldfront.core.utils.context_processors.portal_and_program_names',
             ],
         },
     },

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -2035,6 +2035,7 @@ class AllocationClusterAccountActivateRequestView(LoginRequiredMixin,
             CENTER_HELP_EMAIL = import_from_settings('CENTER_HELP_EMAIL')
 
             template_context = {
+                'PROGRAM_NAME_SHORT': settings.PROGRAM_NAME_SHORT,
                 'user': self.user_obj,
                 'project_name': project_obj.name,
                 'center_user_guide': CENTER_USER_GUIDE,

--- a/coldfront/core/allocation/views_/secure_dir_views.py
+++ b/coldfront/core/allocation/views_/secure_dir_views.py
@@ -284,8 +284,8 @@ class SecureDirManageUsersView(LoginRequiredMixin,
                 f'Successfully requested to {self.action} '
                 f'{reviewed_users_count} user'
                 f'{"s" if reviewed_users_count > 1 else ""} '
-                f'{self.language_dict["preposition"]} the secure '
-                f'directory {self.directory}. BRC staff have '
+                f'{self.language_dict["preposition"]} the secure directory '
+                f'{self.directory}. {settings.PROGRAM_NAME_SHORT} staff have '
                 f'been notified.')
             messages.success(request, message)
 

--- a/coldfront/core/portal/templates/portal/authorized_home.html
+++ b/coldfront/core/portal/templates/portal/authorized_home.html
@@ -5,13 +5,7 @@
     <h2>Welcome</h2>
     <hr>
 
-    <div class="alert alert-success" role="alert">
-      <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
-      </button>
-      <p>MyBRC is a new user portal available to all users of BRC clusters, starting on June 1st, 2021.</p>
-      We'd love to hear your feedback. Please fill out this <a target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLScZoYXkFMAVEYhoqE2guG64JQb4dsPcwidlhZ0W-TZ2t_Va4w/viewform">Google Form</a> letting us know what you think.
-    </div>
+    {% include 'portal/feedback_alert.html' %}
 
     <p>If you would like to set up or update your access to a cluster, please complete the following steps.</p>
     <p>First review and sign the cluster user agreement. Only then you can join a cluster project and gain access to the cluster.</p>
@@ -112,7 +106,7 @@
 
 <div class="row">
   <div class="col-lg-12">
-    Your BRC Supercluster account username:
+    Your {{ PROGRAM_NAME_SHORT }} cluster account username:
     {% if cluster_username is not None %}
       <span class="alert alert-success"><b>{{ cluster_username }}</b></span>
     {% else %}
@@ -125,7 +119,7 @@
 <div class="row">
   <div class="col-lg-12 mt-2">
     <a href="{% url 'project-list' %}">
-      <h3>My BRC Cluster Projects &raquo;</h3>
+      <h3>My {{ PROGRAM_NAME_SHORT }} Cluster Projects &raquo;</h3>
     </a>
     <hr>
     {% if num_join_requests %}

--- a/coldfront/core/portal/templates/portal/feedback_alert.html
+++ b/coldfront/core/portal/templates/portal/feedback_alert.html
@@ -3,7 +3,7 @@
     <span aria-hidden="true">&times;</span>
   </button>
   <p>
-	  MyBRC is a new user portal available to all users of
+	  {{ PORTAL_NAME }} is a new user portal available to all users of
 	  {{ PROGRAM_NAME_SHORT }} clusters, starting on June 1st, 2021.
   </p>
   We'd love to hear your feedback. Please fill out this

--- a/coldfront/core/portal/templates/portal/feedback_alert.html
+++ b/coldfront/core/portal/templates/portal/feedback_alert.html
@@ -1,0 +1,13 @@
+<div class="alert alert-success" role="alert">
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+  <p>
+	  MyBRC is a new user portal available to all users of
+	  {{ PROGRAM_NAME_SHORT }} clusters, starting on June 1st, 2021.
+  </p>
+  We'd love to hear your feedback. Please fill out this
+	<a target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLScZoYXkFMAVEYhoqE2guG64JQb4dsPcwidlhZ0W-TZ2t_Va4w/viewform">
+		Google Form
+	</a> letting us know what you think.
+</div>

--- a/coldfront/core/portal/templates/portal/help.html
+++ b/coldfront/core/portal/templates/portal/help.html
@@ -9,13 +9,7 @@ Contact
 
 {% block content %}
 <h1>Contact</h1><hr>
-  <div class="alert alert-success" role="alert">
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
-    </button>
-    <p>MyBRC is a new user portal available to all users of BRC clusters, starting on June 1st, 2021.</p>
-      We'd love to hear your feedback. Please fill out this <a target="_blank" href="https://docs.google.com/forms/d/e/1FAIpQLScZoYXkFMAVEYhoqE2guG64JQb4dsPcwidlhZ0W-TZ2t_Va4w/viewform">Google Form</a> letting us know what you think.
-  </div>
+{% include 'portal/feedback_alert.html' %}
 
 <p>
   For general inquiries, please email <a href="">research-it@berkeley.edu</a>.

--- a/coldfront/core/portal/templates/portal/help.html
+++ b/coldfront/core/portal/templates/portal/help.html
@@ -1,5 +1,6 @@
 {% extends "common/base.html" %}
 {% load crispy_forms_tags %}
+{% load common_tags %}
 {% load static %}
 
 {% block title %}
@@ -15,7 +16,7 @@ Contact
   For general inquiries, please email <a href="">research-it@berkeley.edu</a>.
 </p>
 <p>
-  If you are having a technical problem with one of our HPC clusters (Savio, Vector, ABC), you can email the HPC ticketing system directly at <a href="">brc-hpc-help@berkeley.edu</a>.
+  If you are having a technical problem with one of our HPC clusters (Savio, Vector, ABC), you can email the HPC ticketing system directly at <a href="">{% settings_value 'CENTER_HELP_EMAIL' %}</a>.
 </p>
 <p>
   For research computing consulting questions, please email <a href="">brc@berkeley.edu</a>.

--- a/coldfront/core/portal/templates/portal/nonauthorized_home.html
+++ b/coldfront/core/portal/templates/portal/nonauthorized_home.html
@@ -7,7 +7,7 @@
 
 <div class="row" style="margin-top:25px">
     <div class="col mr-5">
-        <h2 class="text-center">Log In to MyBRC</h2>
+        <h2 class="text-center">Log In to {{ PORTAL_NAME }}</h2>
         <hr>
         <p><a class="btn btn-primary btn-block" href="{% url 'login' %}" role="button"><i class="fas fa-sign-in-alt" aria-hidden="true"></i> Log In</a></p>
         <div class="card bg-light">

--- a/coldfront/core/project/management/commands/pending_join_request_reminder.py
+++ b/coldfront/core/project/management/commands/pending_join_request_reminder.py
@@ -48,6 +48,7 @@ class Command(BaseCommand):
                                        for request in proj_join_requests_qeuryset]
 
                 context = {
+                    'PORTAL_NAME': settings.PORTAL_NAME,
                     'project_name': project.name,
                     'request_list': '\n'.join(request_string_list),
                     'num_requests': proj_join_requests_qeuryset.count(),
@@ -94,6 +95,7 @@ class Command(BaseCommand):
                                        for request in proj_join_requests_qeuryset]
 
                 context = {
+                    'PORTAL_NAME': settings.PORTAL_NAME,
                     'user_name': f'{user.first_name} {user.last_name}',
                     'request_list': '\n'.join(request_string_list),
                     'num_requests': proj_join_requests_qeuryset.count(),

--- a/coldfront/core/project/templates/project/project_list.html
+++ b/coldfront/core/project/templates/project/project_list.html
@@ -38,7 +38,7 @@
 <!--    </div>-->
   </div>
 </div>
-<h1>My BRC Cluster Projects</h1><hr>
+<h1>{{ PROGRAM_NAME_SHORT }} Cluster Projects</h1><hr>
 {% if expand_accordion == "show" or project_list or user.is_superuser%}
 <div class="mb-3" id="accordion">
   <div class="card">
@@ -63,7 +63,7 @@
 <hr>
 {% endif %}
 {% if project_list %}
-<strong>My BRC Cluster Projects: {{projects_count}}  </strong>
+<strong>{{ PROGRAM_NAME_SHORT }} Cluster Projects: {{projects_count}}  </strong>
 <div class="table-responsive">
   <table class="table table-sm">
     <thead>

--- a/coldfront/core/project/tests/test_commands/test_pending_auto_request_reminder.py
+++ b/coldfront/core/project/tests/test_commands/test_pending_auto_request_reminder.py
@@ -116,8 +116,8 @@ class TestPendingJoinRequestReminderCommand(TestBase):
         verb = 'are' if num_requests > 1 else 'is'
         return (
             f'This is a reminder that there {verb} {num_requests} request(s) '
-            f'to join your project, {project_name}, via the MyBRC User '
-            f'Portal.')
+            f'to join your project, {project_name}, via the '
+            f'{settings.PORTAL_NAME} User Portal.')
 
     @staticmethod
     def user_message_body(num_requests):
@@ -125,7 +125,7 @@ class TestPendingJoinRequestReminderCommand(TestBase):
         given an integer number of requests."""
         return (
             f'This is a reminder that you have {num_requests} project join '
-            f'request(s) in the MyBRC User Portal.')
+            f'request(s) in the {settings.PORTAL_NAME} User Portal.')
 
     def test_command_single_proj_multiple_requests(self):
         """

--- a/coldfront/core/project/tests/test_views/test_auto_approval_removal.py
+++ b/coldfront/core/project/tests/test_views/test_auto_approval_removal.py
@@ -147,7 +147,8 @@ class TestProjectJoinView(TestBase):
         body_components = [
             (f'User {self.user1.first_name} {self.user1.last_name} '
              f'({self.user1.email}) has requested to join your project, '
-             f'{self.project1.name} via the MyBRC User Portal.'),
+             f'{self.project1.name} via the {settings.PORTAL_NAME} User '
+             f'Portal.'),
             f'Please approve/deny this request here: {review_url}.',
         ]
 

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -77,7 +77,8 @@ def send_project_join_notification_email(project, project_user):
     user = project_user.user
 
     subject = f'New request to join Project {project.name}'
-    context = {'project_name': project.name,
+    context = {'PORTAL_NAME': settings.PORTAL_NAME,
+               'project_name': project.name,
                'user_string': f'{user.first_name} {user.last_name} ({user.email})',
                'signature': import_from_settings('EMAIL_SIGNATURE', ''),
                'review_url': review_project_join_requests_url(project),

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -1,4 +1,5 @@
 from django.db import transaction
+from flags.state import flag_enabled
 
 from coldfront.api.statistics.utils import get_accounting_allocation_objects
 from coldfront.core.allocation.models import Allocation
@@ -58,6 +59,12 @@ def send_added_to_project_notification_email(project, project_user):
         'support_email': settings.CENTER_HELP_EMAIL,
         'signature': settings.EMAIL_SIGNATURE,
     }
+    if flag_enabled('BRC_ONLY'):
+        context['include_docs_txt'] = (
+            'deployments/brc/cluster_access_processing_docs.txt')
+    elif flag_enabled('LRC_ONLY'):
+        context['include_docs_txt'] = (
+            'deployments/lrc/cluster_access_processing_docs.txt')
 
     sender = settings.EMAIL_SENDER
     receiver_list = [user.email]
@@ -112,6 +119,12 @@ def send_project_join_request_approval_email(project, project_user):
         'support_email': settings.CENTER_HELP_EMAIL,
         'signature': settings.EMAIL_SIGNATURE,
     }
+    if flag_enabled('BRC_ONLY'):
+        context['include_docs_txt'] = (
+            'deployments/brc/cluster_access_processing_docs.txt')
+    elif flag_enabled('LRC_ONLY'):
+        context['include_docs_txt'] = (
+            'deployments/lrc/cluster_access_processing_docs.txt')
 
     sender = settings.EMAIL_SENDER
     receiver_list = [user.email]

--- a/coldfront/core/project/utils_/new_project_utils.py
+++ b/coldfront/core/project/utils_/new_project_utils.py
@@ -559,6 +559,7 @@ def send_new_project_request_pi_notification_email(request):
     password_reset_url = urljoin(center_base_url, reverse('password-reset'))
 
     context = {
+        'PORTAL_NAME': settings.PORTAL_NAME,
         'pooling': pooling,
         'project_name': request.project.name,
         'requester_str': requester_str,

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -370,6 +370,7 @@ def send_new_allocation_renewal_request_pi_notification_email(request):
     login_url = urljoin(center_base_url, reverse('login'))
 
     context = {
+        'PORTAL_NAME': settings.PORTAL_NAME,
         'login_url': login_url,
         'pi_str': pi_str,
         'requested_project_name': request.post_project.name,

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1,5 +1,6 @@
 import datetime
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import User
@@ -1807,8 +1808,9 @@ class ProjectReviewJoinRequestsView(LoginRequiredMixin, UserPassesTestMixin,
 
             message = (
                 f'{message_verb} {reviewed_users_count} user requests to join '
-                f'the project. BRC staff have been notified to set up cluster '
-                f'access for each approved request.')
+                f'the project. {settings.PROGRAM_NAME_SHORT} staff have been '
+                f'notified to set up cluster access for each approved '
+                f'request.')
             messages.success(request, message)
         else:
             for error in formset.errors:

--- a/coldfront/core/user/forms.py
+++ b/coldfront/core/user/forms.py
@@ -142,13 +142,14 @@ class UserLoginForm(AuthenticationForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.fields['username'].help_text = (
-            'This is your BRC cluster account username if you have one, or '
-            'any of the verified email addresses associated with your portal account, not your '
-            'CalNet username.')
+            f'This is your {settings.PROGRAM_NAME_SHORT} cluster account '
+            f'username if you have one, or any of the verified email '
+            f'addresses associated with your portal account, not your CalNet '
+            f'username.')
         self.fields['password'].help_text = (
-            'This password is unique to this portal, and is neither your '
-            'CalNet password nor the PIN and OTP used to access the BRC '
-            'cluster.')
+            f'This password is unique to this portal, and is neither your '
+            f'CalNet password nor the PIN and OTP used to access the '
+            f'{settings.PROGRAM_NAME_SHORT} cluster.')
 
     def clean_username(self):
         cleaned_data = super().clean()

--- a/coldfront/core/user/templates/request_hub/request_hub.html
+++ b/coldfront/core/user/templates/request_hub/request_hub.html
@@ -10,16 +10,16 @@
       <tr>
         <td>
           {% if show_all %}
-              Below are all of the requests in MyBRC. Click on a request
+              Below are all the requests in {{ PORTAL_NAME }}. Click on a request
               section to view requests of that type. To perform actions on a specific request,
               click the button to go to the request's main page and perform the actions there.
               Click <a href="{% url 'request-hub' %}">here</a> to view only your requests.
           {% else %}
-              Below are all of your requests in MyBRC. Click on a request
+              Below are all of your requests in {{ PORTAL_NAME }}. Click on a request
               section to view your requests of that type.
 
               {% if admin_staff %}
-                Click <a href="{% url 'request-hub-admin' %}">here</a> to view all requests in MyBRC.
+                Click <a href="{% url 'request-hub-admin' %}">here</a> to view all requests in {{ PORTAL_NAME }}.
               {% endif %}
           {% endif %}
         </td>

--- a/coldfront/core/user/templates/user/login.html
+++ b/coldfront/core/user/templates/user/login.html
@@ -31,9 +31,9 @@ Log In
     <div class="card-body">
       <div class="alert alert-info" role="alert">
         <i class="fas fa-info-circle" aria-hidden="true"></i>
-        Hint: If you are an existing BRC cluster user and this is your first time
-        visiting the portal, please <a href="{% url 'password-reset' %}">set
-        your password</a>.
+        Hint: If you are an existing {{ PROGRAM_NAME_SHORT }} cluster user and
+        this is your first time visiting the portal, please
+        <a href="{% url 'password-reset' %}">set your password</a>.
       </div>
       <div class="alert alert-info" role="alert">
         <i class="fas fa-info-circle" aria-hidden="true"></i>

--- a/coldfront/core/user/templates/user/passwords/password_change_form.html
+++ b/coldfront/core/user/templates/user/passwords/password_change_form.html
@@ -19,11 +19,16 @@ Change Password
       Change Password
     </div>
     <div class="card-body">
-      <p>Change your portal password. Note that this does not change the PIN and OTP used to access the BRC cluster.</p>
+      <p>
+        Change your portal password. Note that this does not change the PIN and
+        OTP used to access {{ PROGRAM_NAME_SHORT }} clusters.
+      </p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}
-        <button type="submit" class="btn btn-primary btn-block">Change Password</button>
+        <button type="submit" class="btn btn-primary btn-block">
+          Change Password
+        </button>
       </form>
     </div>
   </div>

--- a/coldfront/core/user/templates/user/passwords/password_reset_confirm.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_confirm.html
@@ -20,11 +20,16 @@ Set Password
       <h5>Set Password</h5>
     </div>
     <div class="card-body">
-      <p>Set your portal password. Note that this does not change the PIN and OTP used to access the BRC cluster.</p>
+      <p>
+        Set your portal password. Note that this does not change the PIN and
+        OTP used to access {{ PROGRAM_NAME_SHORT }} clusters.
+      </p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}
-        <button type="submit" class="btn btn-primary btn-block">Set Password</button>
+        <button type="submit" class="btn btn-primary btn-block">
+          Set Password
+        </button>
       </form>
     </div>
   </div>

--- a/coldfront/core/user/templates/user/passwords/password_reset_email.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_email.html
@@ -1,20 +1,20 @@
 {% load i18n %}{% autoescape off %}
 
-{% trans "Dear MyBRC Portal user," %}
+Dear {{ PORTAL_NAME }} Portal user,
 
-{% blocktrans %}You're receiving this email because you requested a password reset for your MyBRC portal account at {{ site_name }}.{% endblocktrans %}
+You're receiving this email because you requested a password reset for your {{ PORTAL_NAME }} portal account at {{ site_name }}.
 
-{% blocktrans %}As a reminder, this password is unique to the portal, and does not change the PIN and OTP used to access {{ PROGRAM_NAME_SHORT }} clusters.{% endblocktrans %}
+As a reminder, this password is unique to the portal, and does not change the PIN and OTP used to access {{ PROGRAM_NAME_SHORT }} clusters.
 
-{% trans "Please go to the following page and choose a new password:" %}
+Please go to the following page and choose a new password:
 {% block reset_link %}
 {{ protocol }}://{{ domain }}{% url 'password-reset-confirm' uidb64=uid token=token %}
 {% endblock %}
-{% trans "Your portal username, in case you've forgotten:" %} {{ user.get_username }}
+Your portal username, in case you've forgotten: {{ user.get_username }}
 
-{% trans "Thanks for using our site!" %}
+Thanks for using our site!
 
 {{signature}}
-{% blocktrans %}MyBRC User Portal team{% endblocktrans %}
+{{ PORTAL_NAME }} User Portal team
 
 {% endautoescape %}

--- a/coldfront/core/user/templates/user/passwords/password_reset_email.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_email.html
@@ -4,7 +4,7 @@
 
 {% blocktrans %}You're receiving this email because you requested a password reset for your MyBRC portal account at {{ site_name }}.{% endblocktrans %}
 
-{% blocktrans %}As a reminder, this password is unique to the portal, and does not change the PIN and OTP used to access the BRC cluster.{% endblocktrans %}
+{% blocktrans %}As a reminder, this password is unique to the portal, and does not change the PIN and OTP used to access {{ PROGRAM_NAME_SHORT }} clusters.{% endblocktrans %}
 
 {% trans "Please go to the following page and choose a new password:" %}
 {% block reset_link %}

--- a/coldfront/core/user/templates/user/passwords/password_reset_form.html
+++ b/coldfront/core/user/templates/user/passwords/password_reset_form.html
@@ -19,11 +19,17 @@ Reset Password
       Reset Password
     </div>
     <div class="card-body">
-      <p>Reset your portal password by providing a verified email address associated with your account. Note that this does not change the PIN and OTP used to access the BRC cluster.</p>
+      <p>
+        Reset your portal password by providing a verified email address
+        associated with your account. Note that this does not change the PIN
+        and OTP used to access {{ PROGRAM_NAME_SHORT }} clusters.
+      </p>
       <form method="post">
         {% csrf_token %}
         {{ form|crispy }}
-        <button type="submit" class="btn btn-primary btn-block">Reset Password</button>
+        <button type="submit" class="btn btn-primary btn-block">
+          Reset Password
+        </button>
       </form>
     </div>
   </div>

--- a/coldfront/core/user/templates/user/passwords/password_reset_subject.txt
+++ b/coldfront/core/user/templates/user/passwords/password_reset_subject.txt
@@ -1,1 +1,0 @@
-[MyBRC-User-Portal] Password Reset

--- a/coldfront/core/user/templates/user/registration_form.html
+++ b/coldfront/core/user/templates/user/registration_form.html
@@ -6,6 +6,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/axios/0.21.1/axios.min.js" integrity="sha512-bZS47S7sPOxkjU/4Bt0zrhEtWx0y0CRkhEp8IckzK+ltifIIE9EMIMTuT/mEzoIMewUINruDBIR/jJnbguonqQ==" crossorigin="anonymous"></script>
 <script type="text/javascript" src="{% static 'core/user/js/registration.js' %}"></script>
 
+{{ PROGRAM_NAME_SHORT|json_script:"program_name_short" }}
+
 <form method="post" action="{% url 'register' %}?next={{request.GET.next}}">
   {% csrf_token %}
   {{ form.email|as_crispy_field }}
@@ -20,9 +22,9 @@
   <div class="form-check" id="new-user-acknowledgement-form">
     <input class="form-check-input" type="checkbox" id="new-user-acknowledgement">
     <label class="form-check-label" for="new-user-acknowledgement">
-      I acknowledge that I am a new user and have not previously used a BRC
-      cluster. The Register button will be unavailable until this check box is
-      selected.
+      I acknowledge that I am a new user and have not previously used a
+      {{ PROGRAM_NAME_SHORT }} cluster. The Register button will be unavailable
+      until this check box is selected.
     </label>
   </div>
   <button type="submit" class="btn btn-primary btn-block" id="register-button">

--- a/coldfront/core/user/templates/user/user_list.html
+++ b/coldfront/core/user/templates/user/user_list.html
@@ -1,6 +1,6 @@
 {% extends "common/base.html" %} {% load common_tags %} {% load crispy_forms_tags %} {% load static %} {% block title %} User List {% endblock %} {% block content %}
 
-<h1>My BRC Cluster Users</h1><hr>
+<h1>{{ PROGRAM_NAME_SHORT }} Cluster Users</h1><hr>
 {% if expand_accordion == "show" or user_list or user.is_superuser%}
 <div class="mb-3" id="accordion">
   <div class="card">
@@ -25,7 +25,7 @@
 <hr>
 {% endif %}
 {% if user_list %}
-<strong>My BRC Cluster Users: {{user_count}}  </strong>
+<strong>{{ PROGRAM_NAME_SHORT }} Cluster Users: {{user_count}}  </strong>
 <div class="table-responsive">
   <table class="table table-sm">
     <thead>

--- a/coldfront/core/user/urls.py
+++ b/coldfront/core/user/urls.py
@@ -48,6 +48,8 @@ urlpatterns = [
              form_class=VerifiedEmailAddressPasswordResetForm,
              template_name='user/passwords/password_reset_form.html',
              email_template_name='user/passwords/password_reset_email.html',
+             extra_email_context={
+                 'PROGRAM_NAME_SHORT': settings.PROGRAM_NAME_SHORT},
              subject_template_name='user/passwords/password_reset_subject.txt',
              success_url=reverse_lazy('password-reset-done')),
          name='password-reset'

--- a/coldfront/core/user/urls.py
+++ b/coldfront/core/user/urls.py
@@ -49,6 +49,7 @@ urlpatterns = [
              template_name='user/passwords/password_reset_form.html',
              email_template_name='user/passwords/password_reset_email.html',
              extra_email_context={
+                 'PORTAL_NAME': settings.PORTAL_NAME,
                  'PROGRAM_NAME_SHORT': settings.PROGRAM_NAME_SHORT},
              subject_template_name='user/passwords/password_reset_subject.txt',
              success_url=reverse_lazy('password-reset-done')),

--- a/coldfront/core/user/utils.py
+++ b/coldfront/core/user/utils.py
@@ -222,6 +222,7 @@ def send_account_activation_email(user):
     subject = 'Account Activation Required'
     template_name = 'email/account_activation_required.txt'
     context = {
+        'PORTAL_NAME': settings.PORTAL_NAME,
         'center_name': import_from_settings('CENTER_NAME', ''),
         'activation_url': account_activation_url(user),
         'signature': import_from_settings('EMAIL_SIGNATURE', ''),
@@ -253,6 +254,7 @@ def send_account_already_active_email(user):
         center_base_url, reverse('password-reset'))
 
     context = {
+        'PORTAL_NAME': settings.PORTAL_NAME,
         'login_url': login_url,
         'password_reset_url': password_reset_url,
     }
@@ -273,6 +275,7 @@ def send_email_verification_email(email_address):
     subject = 'Email Verification Required'
     template_name = 'email/email_verification_required.txt'
     context = {
+        'PORTAL_NAME': settings.PORTAL_NAME,
         'center_name': import_from_settings('CENTER_NAME', ''),
         'verification_url': __email_verification_url(email_address),
         'signature': import_from_settings('EMAIL_SIGNATURE', ''),

--- a/coldfront/core/user/views_/request_hub_views.py
+++ b/coldfront/core/user/views_/request_hub_views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.db.models import Q
@@ -536,7 +537,7 @@ class RequestHubView(LoginRequiredMixin,
             request_obj = eval(f'self.get_{request}()')
             if context['show_all']:
                 request_obj.help_text = f'Showing all {request_obj.title} ' \
-                                        f'in MyBRC.'
+                                        f'in {settings.PORTAL_NAME}.'
             context[f'{request}_obj'] = request_obj
 
         context['admin_staff'] = (self.request.user.is_superuser or

--- a/coldfront/core/utils/context_processors.py
+++ b/coldfront/core/utils/context_processors.py
@@ -54,3 +54,10 @@ def current_allowance_year_allocation_period(request):
 
 def display_time_zone(request):
     return {'DISPLAY_TIME_ZONE': settings.DISPLAY_TIME_ZONE}
+
+
+def program_name(request):
+    return {
+        'PROGRAM_NAME_LONG': settings.PROGRAM_NAME_LONG,
+        'PROGRAM_NAME_SHORT': settings.PROGRAM_NAME_SHORT,
+    }

--- a/coldfront/core/utils/context_processors.py
+++ b/coldfront/core/utils/context_processors.py
@@ -56,8 +56,9 @@ def display_time_zone(request):
     return {'DISPLAY_TIME_ZONE': settings.DISPLAY_TIME_ZONE}
 
 
-def program_name(request):
+def portal_and_program_names(request):
     return {
+        'PORTAL_NAME': settings.PORTAL_NAME,
         'PROGRAM_NAME_LONG': settings.PROGRAM_NAME_LONG,
         'PROGRAM_NAME_SHORT': settings.PROGRAM_NAME_SHORT,
     }

--- a/coldfront/core/utils/templatetags/common_tags.py
+++ b/coldfront/core/utils/templatetags/common_tags.py
@@ -14,6 +14,7 @@ def settings_value(name):
         'CENTER_NAME',
         'CENTER_HELP_URL',
         'EMAIL_PROJECT_REVIEW_CONTACT',
+        'PORTAL_NAME',
         'PROGRAM_NAME_LONG',
         'PROGRAM_NAME_SHORT',
     ]

--- a/coldfront/core/utils/templatetags/common_tags.py
+++ b/coldfront/core/utils/templatetags/common_tags.py
@@ -14,6 +14,8 @@ def settings_value(name):
         'CENTER_NAME',
         'CENTER_HELP_URL',
         'EMAIL_PROJECT_REVIEW_CONTACT',
+        'PROGRAM_NAME_LONG',
+        'PROGRAM_NAME_SHORT',
     ]
     return mark_safe(getattr(settings, name, '') if name in allowed_names else '')
 

--- a/coldfront/core/utils/templatetags/common_tags.py
+++ b/coldfront/core/utils/templatetags/common_tags.py
@@ -12,6 +12,7 @@ def settings_value(name):
         'LOGIN_FAIL_MESSAGE',
         'ACCOUNT_CREATION_TEXT',
         'CENTER_NAME',
+        'CENTER_HELP_EMAIL',
         'CENTER_HELP_URL',
         'EMAIL_PROJECT_REVIEW_CONTACT',
         'PORTAL_NAME',

--- a/coldfront/static/core/user/js/registration.js
+++ b/coldfront/static/core/user/js/registration.js
@@ -104,13 +104,16 @@ function checkNameExists() {
         let data = response.data;
         let exists = data.name_exists;
         if (exists) {
+          let program_name_short = JSON.parse(
+            document.getElementById('program_name_short').textContent);
           alertDiv.innerHTML = '' +
             'A user with the provided first and last name already exists. ' +
-            'If you have previously used a BRC cluster, you should already ' +
-            'have an account. If so, please ' + loginTag + ' or ' +
-            passwordResetTag + ' using the existing address to gain access. ' +
-            'You may then associate additional email addresses with your ' +
-            'account. If you need any assistance, please contact us.';
+            'If you have previously used a ' + program_name_short +
+            ' cluster, you should already have an account. If so, please ' +
+            loginTag + ' or ' + passwordResetTag + ' using the existing ' +
+            'address to gain access. You may then associate additional ' +
+            'email addresses with your account. If you need any assistance, ' +
+            'please contact us.';
           ackDiv.style.display = 'block';
           registerButton.style.display = 'none';
         } else {

--- a/coldfront/templates/403.html
+++ b/coldfront/templates/403.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-MyBRC - Permission Denied
+{{ PORTAL_NAME }} - Permission Denied
 {% endblock %}
 
 

--- a/coldfront/templates/404.html
+++ b/coldfront/templates/404.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-MyBRC - Not found
+{{ PORTAL_NAME }} - Not found
 {% endblock %}
 
 

--- a/coldfront/templates/500.html
+++ b/coldfront/templates/500.html
@@ -2,7 +2,7 @@
 {% load static %}
 
 {% block title %}
-MyBRC - Error
+{{ PORTAL_NAME }} - Error
 {% endblock %}
 
 

--- a/coldfront/templates/common/authorized_navbar.html
+++ b/coldfront/templates/common/authorized_navbar.html
@@ -2,7 +2,7 @@
 {% load common_tags %}
 <nav class="navbar navbar-expand-md navbar-dark bg-primary">
   <div class="container">
-    <a class="navbar-brand d-block d-sm-none text-primary" href="#">MyBRC</a>
+    <a class="navbar-brand d-block d-sm-none text-primary" href="#">{{ PORTAL_NAME }}</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-main">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/coldfront/templates/common/base.html
+++ b/coldfront/templates/common/base.html
@@ -46,7 +46,7 @@
    <!-- Custom -->
   <link rel="stylesheet" href="{% static 'common/css/common.css' %}">
 
-  <title>{% block title %}Welcome to MyBRC Cluster Access Management System {% endblock %}</title>
+  <title>{% block title %}Welcome to {{ PORTAL_NAME }} Cluster Access Management System {% endblock %}</title>
 </head>
 
 <body>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -1,7 +1,7 @@
 <li id="navbar-admin" class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin</a>
     <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-        <li><a class="dropdown-item" href="/admin">MyBRC Administration</a></li>
+        <li><a class="dropdown-item" href="/admin">{{ PORTAL_NAME }} Administration</a></li>
         <li><a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a></li>
         <li><a id="navbar-jobs-list" class="dropdown-item" href="{% url 'slurm-job-list' %}?show_all_jobs=on">All Jobs</a></li>
         <li><a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a></li>

--- a/coldfront/templates/common/navbar_brand.html
+++ b/coldfront/templates/common/navbar_brand.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col">
-        <h1 class="float-left" style="max-width: 500px;">MyBRC - <small>Berkeley Research Computing Access Management System</small></h1>
+        <h1 class="float-left" style="max-width: 500px;">MyBRC - <small>{{ PROGRAM_NAME_LONG }} Access Management System</small></h1>
         <img src="{% static 'core/portal/imgs/brc_logo.png' %}" alt="brc_logo" width="100;" style="margin: 10px;" class="float-right">
       </div>
     </div>

--- a/coldfront/templates/common/navbar_brand.html
+++ b/coldfront/templates/common/navbar_brand.html
@@ -3,7 +3,7 @@
   <div class="container">
     <div class="row">
       <div class="col">
-        <h1 class="float-left" style="max-width: 500px;">MyBRC - <small>{{ PROGRAM_NAME_LONG }} Access Management System</small></h1>
+        <h1 class="float-left" style="max-width: 500px;">{{ PORTAL_NAME }} - <small>{{ PROGRAM_NAME_LONG }} Access Management System</small></h1>
         <img src="{% static 'core/portal/imgs/brc_logo.png' %}" alt="brc_logo" width="100;" style="margin: 10px;" class="float-right">
       </div>
     </div>

--- a/coldfront/templates/common/nonauthorized_navbar.html
+++ b/coldfront/templates/common/nonauthorized_navbar.html
@@ -2,7 +2,7 @@
 {% load common_tags %} 
 <nav class="navbar navbar-expand-md navbar-dark bg-primary">
   <div class="container">
-    <a class="navbar-brand d-block d-sm-none text-primary" href="#">MyBRC</a>
+    <a class="navbar-brand d-block d-sm-none text-primary" href="#">{{ PORTAL_NAME }}</a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-main">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/coldfront/templates/deployments/brc/cluster_access_processing_docs.txt
+++ b/coldfront/templates/deployments/brc/cluster_access_processing_docs.txt
@@ -1,0 +1,45 @@
+As you wait for your account to be processed and to get access to Savio, we strongly recommend that you see and familiarize yourself with our extensive Savio documentation here:
+
+https://docs-research-it.berkeley.edu/services/high-performance-computing/
+
+As you begin working on the Savio system, a lot of the questions that may come up are answered in the documentation.
+
+A good place to start (if you haven't already done so) would be to carefully read through our documentation on Getting An Account on Savio:
+
+https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-account/
+
+and How To Get Help on Savio:
+
+https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/
+
+https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/good-help-requests/
+
+as well as Frequently Asked Questions:
+
+https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/frequently-asked-questions
+
+We update the Savio documentation on a regular basis, so we encourage users to check back and consult the documentation frequently and often for additions and new content.
+
+Moreover, if you have suggestions for content to be added/included in our Savio documentation, please let us know.
+
+We also encourage Savio users to communicate and work with other Savio users in their labs or elsewhere when troubleshooting and debugging issues come up, as some of you are collaborating on the same projects and using the same software and software libraries, using the same or similar scripts, sharing the same data, etc.
+
+Also, please take the time if at all possible to see the training materials at
+
+https://github.com/ucb-rit/savio-training-intro-fall-2021
+
+https://htmlpreview.github.io/?https://github.com/ucb-rit/savio-training-intro-fall-2021/blob/main/intro.html
+
+from a recent Intro to Savio Training Workshop, as well as
+
+https://github.com/ucb-rit/savio-training-slurm-2020/blob/main/slurm.md
+
+from a recent Savio SLURM training workshop.
+
+A partial set of videos covering some of that intro material in various trainings can also be found at
+
+https://www.youtube.com/watch?v=Denj8NyUPVo&list=PLinUqTXTvciPNjqPxvScsXVLLh5MLCz4P
+
+Also, our consultants have done a lot of user facing trainings in the past and many of those sessions are video/audio recorded and available for users to consume here as well:
+
+https://research-it.berkeley.edu/services/high-performance-computing/training-and-tutorials

--- a/coldfront/templates/deployments/lrc/cluster_access_processing_docs.txt
+++ b/coldfront/templates/deployments/lrc/cluster_access_processing_docs.txt
@@ -1,0 +1,3 @@
+As you wait for your account to be processed and to get access to the cluster, we strongly recommend that you see and familiarize yourself with our extensive documentation here:
+
+https://it.lbl.gov/resource/hpc/

--- a/coldfront/templates/email/account_activation_required.txt
+++ b/coldfront/templates/email/account_activation_required.txt
@@ -1,6 +1,6 @@
-Dear MyBRC Portal user,
+Dear {{ PORTAL_NAME }} Portal user,
 
-Thank you for registering for a MyBRC User Portal account. Please click on the link below to complete registration and activate your account.
+Thank you for registering for a {{ PORTAL_NAME }} User Portal account. Please click on the link below to complete registration and activate your account.
 
 {{activation_url}}
 

--- a/coldfront/templates/email/account_already_active.txt
+++ b/coldfront/templates/email/account_already_active.txt
@@ -1,4 +1,4 @@
-Dear MyBRC Portal user,
+Dear {{ PORTAL_NAME }} Portal user,
 
 You're receiving this email because you requested a portal account reactivation. However, your account is already active, so no action is required at this time.
 

--- a/coldfront/templates/email/added_to_project.txt
+++ b/coldfront/templates/email/added_to_project.txt
@@ -2,51 +2,7 @@ Dear {{ user.first_name }} {{ user.last_name }},
 
 The managers of Project {{ project_name }} have added you to their project. A request to get access to the project on the cluster has been generated, and will be processed by admins. Once access is set up, you will receive a message indicating that you can run jobs under this project.
 
-As you wait for your account to be processed and to get access to Savio, we strongly recommend that you see and familiarize yourself with our extensive Savio documentation here:
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/
-
-As you begin working on the Savio system, a lot of the questions that may come up are answered in the documentation.
-
-A good place to start (if you haven't already done so) would be to carefully read through our documentation on Getting An Account on Savio:
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-account/
-
-and How To Get Help on Savio:
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/good-help-requests/
-
-as well as Frequently Asked Questions:
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/frequently-asked-questions
-
-We update the Savio documentation on a regular basis, so we encourage users to check back and consult the documentation frequently and often for additions and new content.
-
-Moreover, if you have suggestions for content to be added/included in our Savio documentation, please let us know.
-
-We also encourage Savio users to communicate and work with other Savio users in their labs or elsewhere when troubleshooting and debugging issues come up, as some of you are collaborating on the same projects and using the same software and software libraries, using the same or similar scripts, sharing the same data, etc.
-
-Also, please take the time if at all possible to see the training materials at
-
-https://github.com/ucb-rit/savio-training-intro-fall-2021
-
-https://htmlpreview.github.io/?https://github.com/ucb-rit/savio-training-intro-fall-2021/blob/main/intro.html
-
-from a recent Intro to Savio Training Workshop, as well as
-
-https://github.com/ucb-rit/savio-training-slurm-2020/blob/main/slurm.md
-
-from a recent Savio SLURM training workshop.
-
-A partial set of videos covering some of that intro material in various trainings can also be found at
-
-https://www.youtube.com/watch?v=Denj8NyUPVo&list=PLinUqTXTvciPNjqPxvScsXVLLh5MLCz4P
-
-Also, our consultants have done a lot of user facing trainings in the past and many of those sessions are video/audio recorded and available for users to consume here as well:
-
-https://research-it.berkeley.edu/services/high-performance-computing/training-and-tutorials
+{% if include_docs_txt %}{% include include_docs_txt %}{% endif %}
 
 If you have any further questions, please contact us at {{ support_email }}.
 

--- a/coldfront/templates/email/cluster_access_activated.txt
+++ b/coldfront/templates/email/cluster_access_activated.txt
@@ -1,12 +1,12 @@
 Dear {{ user.first_name }} {{ user.last_name }},
 
-As requested, your user account on the BRC supercluster now has access to the project {{ project_name }}.
+As requested, your user account on the {{ PROGRAM_NAME_SHORT }} supercluster now has access to the project {{ project_name }}.
 
-Your BRC supercluster username is - {{ user.username }}
+Your {{ PROGRAM_NAME_SHORT }} supercluster username is - {{ user.username }}
 
-Instructions on how to access the BRC supercluster, hardware details, filesystems, job scheduler etc... are all available at this user guide: {{ center_user_guide }}
+Instructions on how to access the {{ PROGRAM_NAME_SHORT }} supercluster, hardware details, filesystems, job scheduler etc... are all available at this user guide: {{ center_user_guide }}
 
-If this is the first time you are accessing the BRC supercluster, start with the below Logging In page: {{ center_login_guide }}
+If this is the first time you are accessing the {{ PROGRAM_NAME_SHORT }} supercluster, start with the below Logging In page: {{ center_login_guide }}
 
 Please review online documentation. For any additional help or support questions contact us at {{ center_help_email }}
 

--- a/coldfront/templates/email/email_verification_required.txt
+++ b/coldfront/templates/email/email_verification_required.txt
@@ -1,4 +1,4 @@
-Dear MyBRC Portal user,
+Dear {{ PORTAL_NAME }} Portal user,
 
 Thank you for adding this email address to your account. Please click on the link below to verify it.
 

--- a/coldfront/templates/email/new_project_join_request.html
+++ b/coldfront/templates/email/new_project_join_request.html
@@ -1,6 +1,6 @@
 Dear managers of {{ project_name }},
 
-User {{ user_string }} has requested to join your project, {{ project_name }} via the MyBRC User Portal.
+User {{ user_string }} has requested to join your project, {{ project_name }} via the {{ PORTAL_NAME }} User Portal.
 
 Please approve/deny this request <a href="{{ review_url }}">here</a>.
 

--- a/coldfront/templates/email/new_project_join_request.txt
+++ b/coldfront/templates/email/new_project_join_request.txt
@@ -1,6 +1,6 @@
 Dear managers of {{ project_name }},
 
-User {{ user_string }} has requested to join your project, {{ project_name }} via the MyBRC User Portal.
+User {{ user_string }} has requested to join your project, {{ project_name }} via the {{ PORTAL_NAME }} User Portal.
 
 Please approve/deny this request here: {{ review_url }}.
 

--- a/coldfront/templates/email/project_join_request/pending_project_join_request_user.txt
+++ b/coldfront/templates/email/project_join_request/pending_project_join_request_user.txt
@@ -1,6 +1,6 @@
 Dear {{ user_name }},
 
-This is a reminder that you have {{ num_requests }} project join request(s) in the MyBRC User Portal.
+This is a reminder that you have {{ num_requests }} project join request(s) in the {{ PORTAL_NAME }} User Portal.
 
 Project | Request Time
 {{ request_list }}

--- a/coldfront/templates/email/project_join_request/pending_project_join_requests.html
+++ b/coldfront/templates/email/project_join_request/pending_project_join_requests.html
@@ -1,6 +1,6 @@
 Dear managers of {{ project_name }},
 
-This is a reminder that there {{ verb }} {{ num_requests }} request(s) to join your project, {{ project_name }}, via the MyBRC User Portal.
+This is a reminder that there {{ verb }} {{ num_requests }} request(s) to join your project, {{ project_name }}, via the {{ PORTAL_NAME }} User Portal.
 
 Name | Email | Request Time
 {{ request_list }}

--- a/coldfront/templates/email/project_join_request/pending_project_join_requests.txt
+++ b/coldfront/templates/email/project_join_request/pending_project_join_requests.txt
@@ -1,6 +1,6 @@
 Dear managers of {{ project_name }},
 
-This is a reminder that there {{ verb }} {{ num_requests }} request(s) to join your project, {{ project_name }}, via the MyBRC User Portal.
+This is a reminder that there {{ verb }} {{ num_requests }} request(s) to join your project, {{ project_name }}, via the {{ PORTAL_NAME }} User Portal.
 
 Name | Email | Request Time
 {{ request_list }}

--- a/coldfront/templates/email/project_join_request_approved.txt
+++ b/coldfront/templates/email/project_join_request_approved.txt
@@ -2,51 +2,7 @@ Dear {{ user.first_name }} {{ user.last_name }},
 
 Your request to join Project {{ project_name }} has been approved by its managers. A request to get access to the project on the cluster has been generated, and will be processed by admins. Once access is set up, you will receive a message indicating that you can run jobs under this project.
 
-As you wait for your account to be processed and to get access to Savio, we strongly recommend that you see and familiarize yourself with our extensive Savio documentation here:
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/
-
-As you begin working on the Savio system, a lot of the questions that may come up are answered in the documentation.
-
-A good place to start (if you haven't already done so) would be to carefully read through our documentation on Getting An Account on Savio:
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-account/
-
-and How To Get Help on Savio:
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/good-help-requests/
-
-as well as Frequently Asked Questions:
-
-https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/frequently-asked-questions
-
-We update the Savio documentation on a regular basis, so we encourage users to check back and consult the documentation frequently and often for additions and new content.
-
-Moreover, if you have suggestions for content to be added/included in our Savio documentation, please let us know.
-
-We also encourage Savio users to communicate and work with other Savio users in their labs or elsewhere when troubleshooting and debugging issues come up, as some of you are collaborating on the same projects and using the same software and software libraries, using the same or similar scripts, sharing the same data, etc.
-
-Also, please take the time if at all possible to see the training materials at
-
-https://github.com/ucb-rit/savio-training-intro-fall-2021
-
-https://htmlpreview.github.io/?https://github.com/ucb-rit/savio-training-intro-fall-2021/blob/main/intro.html
-
-from a recent Intro to Savio Training Workshop, as well as
-
-https://github.com/ucb-rit/savio-training-slurm-2020/blob/main/slurm.md
-
-from a recent Savio SLURM training workshop.
-
-A partial set of videos covering some of that intro material in various trainings can also be found at
-
-https://www.youtube.com/watch?v=Denj8NyUPVo&list=PLinUqTXTvciPNjqPxvScsXVLLh5MLCz4P
-
-Also, our consultants have done a lot of user facing trainings in the past and many of those sessions are video/audio recorded and available for users to consume here as well:
-
-https://research-it.berkeley.edu/services/high-performance-computing/training-and-tutorials
+{% if include_docs_txt %}{% include include_docs_txt %}{% endif %}
 
 If you have any further questions, please contact us at {{ support_email }}.
 

--- a/coldfront/templates/email/project_renewal/pi_new_project_renewal_request.txt
+++ b/coldfront/templates/email/project_renewal/pi_new_project_renewal_request.txt
@@ -1,6 +1,6 @@
 Dear {{ pi_str }},
 
-A user ({{ requester_str }}) has made a request to renew your allowance under project {{ requested_project_name }} via the MyBRC User Portal.
+A user ({{ requester_str }}) has made a request to renew your allowance under project {{ requested_project_name }} via the {{ PORTAL_NAME }} User Portal.
 
 You may view the details of the request here: {{ review_url }}.
 

--- a/coldfront/templates/email/project_request/pi_new_project_request.txt
+++ b/coldfront/templates/email/project_request/pi_new_project_request.txt
@@ -1,6 +1,6 @@
 Dear {{ pi_str }},
 
-A user ({{ requester_str }}) has made a {% if pooling %}pooled {% endif %}project request with you as the Principal Investigator (PI) via the MyBRC User Portal.
+A user ({{ requester_str }}) has made a {% if pooling %}pooled {% endif %}project request with you as the Principal Investigator (PI) via the {{ PORTAL_NAME }} User Portal.
 
 You may view the details of the request here: {{ review_url }}.
 


### PR DESCRIPTION
Fixes #384

**Changes**
- Introduced three new settings:
	- `PORTAL_NAME`: "MyBRC" or "MyLRC"
	- `PROGRAM_NAME_LONG`: "Berkeley Research Computing" or "Laboratory Research Computing"
	- `PROGRAM_NAME_SHORT`: "BRC" or "LRC"
- Introduced corresponding Ansible variables for configuring them in `main.yml`.
- Replaced hard-coded strings with the new settings.
- Added a context processor `portal_and_program_names` so that the new settings are available in templates without being explicitly set as context variables.
- Refactored LRC-/BRC-specific documentation text in emails sent when a user joins/is added to a project into separate templates.
- Refactored the feedback alert into a template.
- Corrected `full_host_path` in the development `main.copyme` to fix the nav-bar "Help" link.

**How to Test**
- Review the code changes and add comments as needed.
	- Search for various terms like "Berkeley", "BRC", "MyBRC", "CalNet", "Savio", etc. Note any instances not covered by the exceptions below.
- Ensure that the test suite passes.
- Manual Testing
	- On both an LRC-based VM and a BRC-based VM, checkout the branch, configure new Ansible variables, re-run the playbook, and look for inconsistencies or errors around the UI.

**Notes**
- Not all deployment-specific words have been replaced. Notable exceptions include:
	- The user access agreement
	- The survey for new project requests
	- Savio/Vector new project requests (including URL paths)
	- `ACCOUNT_CREATION_TEXT` and some login/registration/password-reset help text
		- These can be ignored because they should not appear based on flags introduced in `issue_276`.
	- Feedback alert
	- The "Savio Compute" `Resource`