### PR TITLE
Issue 421

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ of variables used by Ansible to configure the system.
    cp bootstrap/development/main.copyme main.yml
    ```
 7. Customize `main.yml`. In particular, fill in the below variables. Note
-that quotes should not be provided, except in the list variable.
+that quotes need not be provided, except in the list variable.
    ```
    db_admin_passwd: password_here
    redis_passwd: password_here

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ of variables used by Ansible to configure the system.
 that quotes should not be provided, except in the list variable.
    ```
    db_admin_passwd: password_here
+   redis_passwd: password_here
    from_email: you@email.com
    admin_email: you@email.com
    request_approval_cc_list: ["you@email.com"]

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -66,14 +66,14 @@
         state: restarted
         enabled: yes
 
-    - name: Install Postgresql repo
+    - name: Install Postgresql packages
       yum:
-        name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-        state: present
-
-    - name: Install Postgresql Packages
-      yum:
-        name: [ 'postgresql96', 'postgresql96-server', 'postgresql96-devel' ]
+        name:
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.24-1PGDG.rhel7.x86_64.rpm'
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.24-1PGDG.rhel7.x86_64.rpm'
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-devel-9.6.24-1PGDG.rhel7.x86_64.rpm'
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-test-9.6.24-1PGDG.rhel7.x86_64.rpm'
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.24-1PGDG.rhel7.x86_64.rpm'
         state: present
 
     - name: Create a folder for keeping Django app logs

--- a/bootstrap/development/playbook.yml
+++ b/bootstrap/development/playbook.yml
@@ -121,17 +121,14 @@
         state: restarted
         enabled: yes
 
-    - name: Install the PostgreSQL rpm from a remote repository
-      yum:
-        name: https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-        state: present
-
-    - name: Install PostgreSQL packages from the local rpm
+    - name: Install Postgresql packages
       yum:
         name:
-          - postgresql96
-          - postgresql96-server
-          - postgresql96-devel
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.24-1PGDG.rhel7.x86_64.rpm'
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.24-1PGDG.rhel7.x86_64.rpm'
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-devel-9.6.24-1PGDG.rhel7.x86_64.rpm'
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-test-9.6.24-1PGDG.rhel7.x86_64.rpm'
+          - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.24-1PGDG.rhel7.x86_64.rpm'
         state: present
 
     # Configure PostgreSQL.


### PR DESCRIPTION
### Changes:
  - Removed "Install Postgresql repo" ansible task
  - Instead of specifying Postgresql package names, ansible now installs Postgresql packages using their URLs from https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/
  - Also added one line to the documentation to show that the redis_passwd variable should also be changed.

### Notes:
  - I tested the changes by running `vagrant destroy` and then `vagrant up`, seeing no errors in the playbook. I also sshed in and ran `systemctl status postgresql-9.6` and saw that postgresql was running. localhost:8880 was also running properly.
  - I don't know what the difference is between `bootstrap/development/playbook.yml` and `bootstrap/ansible/playbook.yml` but I modified both with the same change just in case.
  - The redis_passwd documentation change was very small so I guessed it didn't need a whole new issue and branch. Also, because it also dealt with ansible variables in main.yml, it fits within the general theme of fixing the ansible playbook.
  - The line above the list of variables that need changing says `quotes should not be provided, except in the list variable.` This might be a bit confusing because in main.yml the default redis_passwd line is `redis_passwd: ''` and has quotes. Maybe change the line to `quotes are not **necessary**, except in the list variable`