### PR TITLE
Moved status on Requests views into the 'Request Information' section.

### DIFF
--- a/coldfront/core/allocation/management/commands/create_allocation_periods.py
+++ b/coldfront/core/allocation/management/commands/create_allocation_periods.py
@@ -164,6 +164,11 @@ class Command(BaseCommand):
             periods.extend(
                 [
                     {
+                        "name": "Allowance Year 2021 - 2022",
+                        "start_date": "2021-10-01",
+                        "end_date": "2022-9-30"
+                    },
+                    {
                         "name": "Allowance Year 2022 - 2023",
                         "start_date": "2022-10-01",
                         "end_date": "2023-09-30"

--- a/coldfront/core/allocation/management/commands/create_allocation_periods.py
+++ b/coldfront/core/allocation/management/commands/create_allocation_periods.py
@@ -166,7 +166,7 @@ class Command(BaseCommand):
                     {
                         "name": "Allowance Year 2021 - 2022",
                         "start_date": "2021-10-01",
-                        "end_date": "2022-9-30"
+                        "end_date": "2022-09-30"
                     },
                     {
                         "name": "Allowance Year 2022 - 2023",

--- a/coldfront/core/project/templates/project/project_allocation_addition/request_card.html
+++ b/coldfront/core/project/templates/project/project_allocation_addition/request_card.html
@@ -3,6 +3,15 @@
     <h2>
       <i class="fas fa-info-circle" aria-hidden="true"></i>
       Request Information
+      {% with status=addition_request.status.name %}
+        {% if status == 'Under Review' %}
+          <span class="badge badge-warning" style="float:right; position:relative; top:5px;">{{ status }}</span>
+        {% elif status == 'Complete' %}
+          <span class="badge badge-success" style="float:right; position:relative; top:5px;">{{ status }}</span>
+        {% else %}
+          <span class="badge badge-danger" style="float:right; position:relative; top:5px;">{{ status }}</span>
+        {% endif %}
+      {% endwith %}
     </h2>
   </div>
   <div class="card-body">

--- a/coldfront/core/project/templates/project/project_allocation_addition/request_detail.html
+++ b/coldfront/core/project/templates/project/project_allocation_addition/request_detail.html
@@ -13,15 +13,6 @@ Service Units Purchase Request Detail
 {% block content %}
 <h1>
   Service Units Purchase Request ({{ addition_request.project.name }})
-  {% with status=addition_request.status.name %}
-    {% if status == 'Under Review' %}
-      <span class="badge badge-warning float-right">{{ status }}</span>
-    {% elif status == 'Complete' %}
-      <span class="badge badge-success float-right">{{ status }}</span>
-    {% else %}
-      <span class="badge badge-danger float-right">{{ status }}</span>
-    {% endif %}
-  {% endwith %}
 </h1>
 <hr>
 

--- a/coldfront/core/project/templates/project/project_renewal/project_renewal_request_detail.html
+++ b/coldfront/core/project/templates/project/project_renewal/project_renewal_request_detail.html
@@ -13,19 +13,6 @@ Project Renewal Request Detail
 {% block content %}
 <h1>
   Renewal Request: {{ renewal_request.pi.first_name }} {{ renewal_request.pi.last_name }}
-  {% with status=renewal_request.status.name %}
-    {% if status == 'Under Review' %}
-      <span class="badge badge-warning" style="float: right;">{{ status }}</span>
-    {% elif status == 'Approved' %}
-      <span class="badge badge-warning" style="float: right;">
-        {{ status }} - Scheduled
-      </span>
-    {% elif status == 'Complete' %}
-      <span class="badge badge-success" style="float: right;">{{ status }}</span>
-    {% else %}
-      <span class="badge badge-danger" style="float: right;">{{ status }}</span>
-    {% endif %}
-  {% endwith %}
 </h1>
 <hr>
 

--- a/coldfront/core/project/templates/project/project_renewal/request_card.html
+++ b/coldfront/core/project/templates/project/project_renewal/request_card.html
@@ -3,6 +3,19 @@
     <h2>
       <i class="fas fa-info-circle" aria-hidden="true"></i>
       Request Information
+      {% with status=renewal_request.status.name %}
+        {% if status == 'Under Review' %}
+          <span class="badge badge-warning" style="float:right; position:relative; top:5px;">{{ status }}</span>
+        {% elif status == 'Approved' %}
+          <span class="badge badge-warning" style="float:right; position:relative; top:5px;">
+            {{ status }} - Scheduled
+          </span>
+        {% elif status == 'Complete' %}
+          <span class="badge badge-success" style="float:right; position:relative; top:5px;">{{ status }}</span>
+        {% else %}
+          <span class="badge badge-danger" style="float:right; position:relative; top:5px;">{{ status }}</span>
+        {% endif %}
+      {% endwith %}
     </h2>
   </div>
   <div class="card-body">

--- a/coldfront/core/project/templates/project/project_request/savio/project_request_card.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_card.html
@@ -3,6 +3,21 @@
     <h2>
       <i class="fas fa-info-circle" aria-hidden="true"></i>
       Request Information
+
+        {% with status=savio_request.status.name %}
+          {% if status == 'Under Review' %}
+            <span class="badge badge-warning" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% elif status == 'Approved - Processing' %}
+            <span class="badge badge-warning" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% elif status == 'Approved - Scheduled' %}
+            <span class="badge badge-warning" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% elif status == 'Approved - Complete' %}
+            <span class="badge badge-success" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% else %}
+            <span class="badge badge-danger" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% endif %}
+        {% endwith %}
+
     </h2>
   </div>
   <div class="card-body">

--- a/coldfront/core/project/templates/project/project_request/savio/project_request_detail.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_detail.html
@@ -12,20 +12,7 @@ Savio Project Request Detail
 
 {% block content %}
 <h1>
-  Savio: {{ savio_request }}
-  {% with status=savio_request.status.name %}
-    {% if status == 'Under Review' %}
-      <span class="badge badge-warning" style="float: right;">{{ status }}</span>
-    {% elif status == 'Approved - Processing' %}
-      <span class="badge badge-warning" style="float: right;">{{ status }}</span>
-    {% elif status == 'Approved - Scheduled' %}
-      <span class="badge badge-warning" style="float: right;">{{ status }}</span>
-    {% elif status == 'Approved - Complete' %}
-      <span class="badge badge-success" style="float: right;">{{ status }}</span>
-    {% else %}
-      <span class="badge badge-danger" style="float: right;">{{ status }}</span>
-    {% endif %}
-  {% endwith %}
+Savio: {{ savio_request }}
 </h1>
 <hr>
 

--- a/coldfront/core/project/templates/project/project_request/vector/project_request_card.html
+++ b/coldfront/core/project/templates/project/project_request/vector/project_request_card.html
@@ -3,6 +3,17 @@
     <h2>
       <i class="fas fa-info-circle" aria-hidden="true"></i>
       Request Information
+        {% with status=vector_request.status.name %}
+          {% if status == 'Under Review' %}
+            <span class="badge badge-warning" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% elif status == 'Approved - Processing' %}
+            <span class="badge badge-warning" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% elif status == 'Approved - Complete' %}
+            <span class="badge badge-success" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% else %}
+            <span class="badge badge-danger" style="float:right; position:relative; top:5px;">{{ status }}</span>
+          {% endif %}
+        {% endwith %}
     </h2>
   </div>
   <div class="card-body">

--- a/coldfront/core/project/templates/project/project_request/vector/project_request_detail.html
+++ b/coldfront/core/project/templates/project/project_request/vector/project_request_detail.html
@@ -12,18 +12,7 @@ Vector Project Request Detail
 
 {% block content %}
 <h1>
-  Vector: {{ vector_request.project.name }} - {{ vector_request.requester.first_name }} {{ vector_request.requester.last_name }}
-  {% with status=vector_request.status.name %}
-    {% if status == 'Under Review' %}
-      <span class="badge badge-warning" style="float: right;">{{ status }}</span>
-    {% elif status == 'Approved - Processing' %}
-      <span class="badge badge-warning" style="float: right;">{{ status }}</span>
-    {% elif status == 'Approved - Complete' %}
-      <span class="badge badge-success" style="float: right;">{{ status }}</span>
-    {% else %}
-      <span class="badge badge-danger" style="float: right;">{{ status }}</span>
-    {% endif %}
-  {% endwith %}
+Vector: {{ vector_request.project.name }} - {{ vector_request.requester.first_name }} {{ vector_request.requester.last_name }}
 </h1>
 <hr>
 


### PR DESCRIPTION
Moved status into "Request Information" section.
Specifically for: 
- Savio Project Request page
- Vector Project Request page
- Project Allocation Addition page