### PR TITLE
Customize new project survey based on deployment

### DIFF
--- a/coldfront/core/project/forms_/new_project_forms/request_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/request_forms.py
@@ -18,6 +18,7 @@ from coldfront.core.utils.common import utc_now_offset_aware
 from django import forms
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.exceptions import ImproperlyConfigured
 from django.core.validators import MaxValueValidator
 from django.core.validators import MinLengthValidator
 from django.core.validators import MinValueValidator
@@ -567,9 +568,7 @@ class SavioProjectDetailsForm(forms.Form):
 
 
 class SavioProjectSurveyForm(forms.Form):
-    # TODO: Customize based on feature flags.
 
-    # Question 3
     scope_and_intent = forms.CharField(
         label='Scope and intent of research needing computation',
         validators=[MinLengthValidator(10)],
@@ -581,19 +580,26 @@ class SavioProjectSurveyForm(forms.Form):
         required=True,
         widget=forms.Textarea(attrs={'rows': 3}))
     existing_resources = forms.CharField(
-        label=(
-            'Existing computing resources (outside of Savio) currently being '
-            'used by this project. If you use cloud computing resources, we '
-            'would be interested in hearing about it.'),
+        label='',  # Set dynamically.
         required=False,
         widget=forms.Textarea(attrs={'rows': 3}))
     system_needs = forms.MultipleChoiceField(
         choices=(
-            ('intermittent_need', 'Meets intermittent or small need for compute cycles'),
-            ('cannot_purchase', 'Provides a resource since my group/area cannot purchase its own'),
-            ('additional_compute_beyond_cluster', 'Provides additional compute cycles beyond what is provided on my own cluster'),
-            ('larger_jobs', 'Provides ability to run larger-scale jobs than those I can\'t run on my own cluster'),
-            ('onramp', 'Provides an onramp to prepare for running on large systems or applying for grants and supercomputing center allocations'),
+            ('intermittent_need', (
+                'Meets intermittent or small need for compute cycles')),
+            ('cannot_purchase', (
+                'Provides a resource since my group/area cannot purchase its '
+                'own')),
+            ('additional_compute_beyond_cluster', (
+                'Provides additional compute cycles beyond what is provided '
+                'on my own cluster')),
+            ('larger_jobs', (
+                'Provides ability to run larger-scale jobs than those I '
+                'can\'t run on my own cluster')),
+            ('onramp', (
+                'Provides an onramp to prepare for running on large systems '
+                'or applying for grants and supercomputing center '
+                'allocations')),
             ('additional_compute', 'Provides additional compute cycles'),
         ),
         label=(
@@ -602,7 +608,6 @@ class SavioProjectSurveyForm(forms.Form):
         required=False,
         widget=forms.CheckboxSelectMultiple())
 
-    # Question 4
     num_processor_cores = forms.CharField(
         label=(
             'How many processor cores does your application use? (min, max, '
@@ -619,28 +624,14 @@ class SavioProjectSurveyForm(forms.Form):
             'over the year.'),
         required=False)
     large_memory_nodes = forms.CharField(
-        label=(
-            'BRC has a number of large memory nodes, each with 512GB or '
-            '384GB. Do you have a need to use these nodes? If so, what is '
-            'your expected use of these nodes?'),
+        label='',  # Set dynamically.
         required=False)
     data_storage_space = forms.CharField(
-        help_text=mark_safe(
-            'BRC provides each user with 10GB of backed up home directory '
-            'space; and free access to a not-backed-up shared Global Scratch '
-            'high performance parallel filesystem. Research projects that '
-            'need to share datasets among their team members can also be '
-            'allocated up to 30 GB of not-backed-up shared filesystem space '
-            'on request. Users needing more storage can choose to join the '
-            'Condo Storage service by purchasing 42TB at the cost of $6539. '
-            'More details about this program are available <a href="https://docs-research-it.berkeley.edu/services/high-performance-computing/condos/condo-storage-service/"><span class="accessibility-link-text">Data Storage program details</span>here</a>. '
-            'Please indicate if you need additional space and how much.'),
+        help_text='',  # Set dynamically.
         label='Data Storage Space',
         required=False)
     io = forms.CharField(
-        help_text=(
-            'Savio provides a shared Lustre parallel filesystem for jobs '
-            'needing access to high performance storage.'),
+        help_text='',  # Set dynamically.
         label='Describe your applications I/O requirements',
         required=False)
     interconnect = forms.ChoiceField(
@@ -663,7 +654,7 @@ class SavioProjectSurveyForm(forms.Form):
             'cluster? If yes, what is the max you you might transfer in a '
             'day? What would be typical for a month? Do you have need for '
             'file sharing of large datasets?'),
-        label='Network connection from Savio to the Internet',
+        label='',  # Set dynamically.
         required=False)
     cloud_computing = forms.ChoiceField(
         choices=(
@@ -674,13 +665,10 @@ class SavioProjectSurveyForm(forms.Form):
             ('4', '4'),
             ('5', '5 - Important'),
         ),
-        help_text=(
-            'BRC is developing a cloud computing offering. What is your '
-            'interest in using the cloud for your computation?'),
+        help_text='',  # Set dynamically.
         label='Cloud computing',
         required=False)
 
-    # Question 5
     software_source = forms.CharField(
         help_text=(
             'Specify your software applications. If you have need for '
@@ -694,39 +682,85 @@ class SavioProjectSurveyForm(forms.Form):
         required=False)
 
     def __init__(self, *args, **kwargs):
+        self.primary_cluster_name = settings.PRIMARY_CLUSTER_NAME
         self.computing_allowance = kwargs.pop('computing_allowance', None)
         disable_fields = kwargs.pop('disable_fields', False)
         super().__init__(*args, **kwargs)
         if self.computing_allowance is not None:
             self.computing_allowance = ComputingAllowance(
                 self.computing_allowance)
-            self._update_field_attributes()
+        self._update_field_attributes()
         if disable_fields:
             for field in self.fields:
                 self.fields[field].disabled = True
 
     def _update_field_attributes(self):
-        """Update fields for select allowances."""
-        if self.computing_allowance.is_instructional():
-            self.fields['scope_and_intent'].label = (
-                'Scope and intent of coursework needing computation')
-            self.fields['computational_aspects'].help_text = (
-                'Describe the nature of the coursework for which students '
-                'will use Savio (e.g., homework, problem sets, projects, '
-                'etc.).')
-            self.fields['computational_aspects'].label = (
-                'Computational aspects of the coursework')
-            self.fields['existing_resources'].label = (
-                'Existing computing resources (outside of Savio) currently '
-                'being used by this course. If you use cloud computing '
-                'resources, we would be interested in hearing about it.')
-            self.fields['num_processor_cores'].label = (
-                'How many processor cores does a single execution (i.e., by '
-                'one student) of your application use? (min, max, typical '
-                'runs)')
-            self.fields['processor_core_hours_year'].label = (
-                'Estimate how many processor-core-hrs your students will need '
-                'over the duration of the course.')
+        """Update field attributes that have deployment-specific
+        content."""
+        self.fields['existing_resources'].label = (
+            f'Existing computing resources (outside of '
+            f'{self.primary_cluster_name}) currently being used by this '
+            f'project. If you use cloud computing resources, we would be '
+            f'interested in hearing about it.')
+        self.fields['large_memory_nodes'].label = (
+            f'{settings.PROGRAM_NAME_SHORT} has a number of large memory '
+            f'nodes, each with hundreds of GB. Do you have a need to use '
+            f'these nodes? If so, what is your expected use of these nodes?')
+        self.fields['io'].help_text = (
+            f'{self.primary_cluster_name} provides a shared Lustre parallel '
+            f'filesystem for jobs needing access to high performance storage.')
+        self.fields['network_to_internet'].label = (
+            f'Network connection from {self.primary_cluster_name} to the '
+            f'Internet')
+
+        if flag_enabled('BRC_ONLY'):
+            condo_docs_url = (
+                'https://docs-research-it.berkeley.edu/services/'
+                'high-performance-computing/condos/condo-storage-service/')
+            self.fields['data_storage_space'].help_text = mark_safe(
+                f'{settings.PROGRAM_NAME_SHORT} provides each user with 10GB '
+                f'of backed up home directory space; and free access to a '
+                f'not-backed-up shared Global Scratch high performance '
+                f'parallel filesystem. Research projects that need to share '
+                f'datasets among their team members can also be allocated up '
+                f'to 30 GB of not-backed-up shared filesystem space on '
+                f'request. Users needing more storage can choose to join the '
+                f'Condo Storage service by purchasing 42TB at the cost of '
+                f'$6539. More details about this program are available '
+                f'<a href="{condo_docs_url}">'
+                f'<span class="accessibility-link-text">Data Storage program '
+                f'details</span>here</a>. Please indicate if you need '
+                f'additional space and how much.')
+            self.fields['cloud_computing'].help_text = (
+                f'{settings.PROGRAM_NAME_SHORT} is developing a cloud '
+                f'computing offering. What is your interest in using the '
+                f'cloud for your computation?')
+            if (isinstance(self.computing_allowance, ComputingAllowance) and
+                    self.computing_allowance.is_instructional()):
+                self.fields['scope_and_intent'].label = (
+                    'Scope and intent of coursework needing computation')
+                self.fields['computational_aspects'].help_text = (
+                    f'Describe the nature of the coursework for which students '
+                    f'will use {self.primary_cluster_name} (e.g., homework, '
+                    f'problem sets, projects, etc.).')
+                self.fields['computational_aspects'].label = (
+                    'Computational aspects of the coursework')
+                self.fields['existing_resources'].label = (
+                    f'Existing computing resources (outside of '
+                    f'{self.primary_cluster_name}) currently being used by '
+                    f'this course. If you use cloud computing resources, we '
+                    f'would be interested in hearing about it.')
+                self.fields['num_processor_cores'].label = (
+                    'How many processor cores does a single execution (i.e., '
+                    'by one student) of your application use? (min, max, '
+                    'typical runs)')
+                self.fields['processor_core_hours_year'].label = (
+                    'Estimate how many processor-core-hrs your students will '
+                    'need over the duration of the course.')
+
+        if flag_enabled('LRC_ONLY'):
+            self.fields.pop('data_storage_space')
+            self.fields.pop('cloud_computing')
 
 
 # =============================================================================

--- a/coldfront/core/project/forms_/new_project_forms/request_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/request_forms.py
@@ -740,9 +740,9 @@ class SavioProjectSurveyForm(forms.Form):
                 self.fields['scope_and_intent'].label = (
                     'Scope and intent of coursework needing computation')
                 self.fields['computational_aspects'].help_text = (
-                    f'Describe the nature of the coursework for which students '
-                    f'will use {self.primary_cluster_name} (e.g., homework, '
-                    f'problem sets, projects, etc.).')
+                    f'Describe the nature of the coursework for which '
+                    f'students will use {self.primary_cluster_name} (e.g., '
+                    f'homework, problem sets, projects, etc.).')
                 self.fields['computational_aspects'].label = (
                     'Computational aspects of the coursework')
                 self.fields['existing_resources'].label = (

--- a/coldfront/core/project/tests/test_forms/test_new_project_forms/test_savio_project_survey_form.py
+++ b/coldfront/core/project/tests/test_forms/test_new_project_forms/test_savio_project_survey_form.py
@@ -1,0 +1,115 @@
+from copy import deepcopy
+
+from django.conf import settings
+from django.test import override_settings
+from flags.state import flag_enabled
+
+from coldfront.core.project.forms_.new_project_forms.request_forms import SavioProjectSurveyForm
+from coldfront.core.resource.models import Resource
+from coldfront.core.resource.utils_.allowance_utils.computing_allowance import ComputingAllowance
+from coldfront.core.resource.utils_.allowance_utils.constants import BRCAllowances
+from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
+from coldfront.core.utils.tests.test_base import TestBase
+
+
+class TestSavioProjectSurveyForm(TestBase):
+    """A class for testing SavioProjectSurveyForm."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+
+    def test_fields_conditionally_included_for_deployment(self):
+        """Test that, based on whether BRC_ONLY or LRC_ONLY is enabled,
+        some fields are (not) included."""
+        self.assertTrue(flag_enabled('BRC_ONLY'))
+        self.assertFalse(flag_enabled('LRC_ONLY'))
+
+        brc_only_fields = ['data_storage_space', 'cloud_computing']
+
+        computing_allowance = Resource.objects.get(name=BRCAllowances.FCA)
+
+        form = SavioProjectSurveyForm(computing_allowance=computing_allowance)
+        for field in brc_only_fields:
+            self.assertIn(field, form.fields)
+
+        flags_copy = deepcopy(settings.FLAGS)
+        flags_copy.pop('BRC_ONLY')
+        flags_copy['LRC_ONLY'] = [{'condition': 'boolean', 'value': True}]
+        with override_settings(FLAGS=flags_copy):
+            form = SavioProjectSurveyForm(
+                computing_allowance=computing_allowance)
+            for field in brc_only_fields:
+                self.assertNotIn(field, form.fields)
+
+    def test_text_updated_for_deployment(self):
+        """Test that, based on whether BRC_ONLY or LRC_ONLY is enabled,
+        some fields have updated help text and labels."""
+        self.assertTrue(flag_enabled('BRC_ONLY'))
+        self.assertFalse(flag_enabled('LRC_ONLY'))
+
+        altered_fields = [
+            ('existing_resources', 'label'),
+            ('large_memory_nodes', 'label'),
+            ('io', 'help_text'),
+            ('network_to_internet', 'label'),
+        ]
+
+        computing_allowance = Resource.objects.get(name=BRCAllowances.FCA)
+
+        with override_settings(
+                PRIMARY_CLUSTER_NAME='Savio', PROGRAM_NAME_SHORT='BRC'):
+            form = SavioProjectSurveyForm(
+                computing_allowance=computing_allowance)
+            for field_name, field_attribute in altered_fields:
+                attribute_value = getattr(
+                    form.fields[field_name], field_attribute)
+                self.assertTrue(
+                    'Savio' in attribute_value or 'BRC' in attribute_value)
+
+        flags_copy = deepcopy(settings.FLAGS)
+        flags_copy.pop('BRC_ONLY')
+        flags_copy['LRC_ONLY'] = [{'condition': 'boolean', 'value': True}]
+        with override_settings(
+                FLAGS=flags_copy, PRIMARY_CLUSTER_NAME='Lawrencium',
+                PROGRAM_NAME_SHORT='LRC'):
+            form = SavioProjectSurveyForm(
+                computing_allowance=computing_allowance)
+            for field_name, field_attribute in altered_fields:
+                attribute_value = getattr(
+                    form.fields[field_name], field_attribute)
+                self.assertTrue(
+                    'Lawrencium' in attribute_value or
+                    'LRC' in attribute_value)
+
+    def test_text_updated_for_instructional_allowance(self):
+        """Test that, if the input computing allowance is instructional,
+        some fields have updated help text and labels."""
+        self.assertTrue(flag_enabled('BRC_ONLY'))
+        self.assertFalse(flag_enabled('LRC_ONLY'))
+
+        altered_fields = {
+            ('scope_and_intent', 'label'),
+            ('computational_aspects', 'label'),
+            ('existing_resources', 'label'),
+            ('processor_core_hours_year', 'label'),
+        }
+
+        instructional_encountered = False
+        for allowance in ComputingAllowanceInterface().allowances():
+            form = SavioProjectSurveyForm(computing_allowance=allowance)
+            wrapper = ComputingAllowance(allowance)
+            for field_name, field_attribute in altered_fields:
+                attribute_value = getattr(
+                    form.fields[field_name], field_attribute)
+                if not wrapper.is_instructional():
+                    self.assertTrue(
+                        'research' in attribute_value or
+                        'project' in attribute_value or
+                        'user' in attribute_value)
+                else:
+                    self.assertTrue(
+                        'course' in attribute_value or
+                        'student' in attribute_value)
+            instructional_encountered = True
+        self.assertTrue(instructional_encountered)


### PR DESCRIPTION
Refs #383

**Changes**
- Updated the survey form for new project requests to:
    - Display text from variables instead of hard-coded strings, and
    - Hide two fields ("data_storage_space", "cloud_computing") on LRC.
- Added tests.

**How to Test**
- Review the code changes and add comments as needed.
- Ensure that the test suite passes.
- Manual Testing
    - On a BRC/LRC VM, ensure that the correct text and fields appear.
        - (Updating `FLAGS` manually in this case seems to cause the multi-part form (on my box, at least) to hang, so a properly-configured VM may be required.)
        - Note any discrepancies.
        - The form should also be rendered correctly in the approval view for the request.

**Notes**
- This branch depends on the `issue_414` branch.