### PR TITLE
Link to deployment-specific docs in Help/Contact page

### DIFF
--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -87,6 +87,8 @@ from datetime import date
 
 CONSTANCE_CONFIG = {
     'FEEDBACK_FORM_URL': ('', 'The URL to the feedback form.'),
+    'DOCS_GETTING_HELP_URL': (
+        '', 'The URL to the documentation page on getting help.'),
     'LAUNCH_DATE': (date(1970, 1, 1), 'The date the portal was launched.'),
 }
 CONSTANCE_REDIS_CONNECTION = {

--- a/coldfront/core/portal/templates/portal/help.html
+++ b/coldfront/core/portal/templates/portal/help.html
@@ -13,16 +13,8 @@ Contact
 {% include 'portal/feedback_alert.html' %}
 
 <p>
-  For general inquiries, please email <a href="">research-it@berkeley.edu</a>.
-</p>
-<p>
-  If you are having a technical problem with one of our HPC clusters (Savio, Vector, ABC), you can email the HPC ticketing system directly at <a href="">{% settings_value 'CENTER_HELP_EMAIL' %}</a>.
-</p>
-<p>
-  For research computing consulting questions, please email <a href="">brc@berkeley.edu</a>.
-</p>
-<p>
-  For research data management questions, please email <a href="">researchdata@berkeley.edu</a>.
+  Please refer to our
+  <a href="{{ CONSTANCE_CONFIG.DOCS_GETTING_HELP_URL }}">documentation</a>.
 </p>
 
 {% endblock %}


### PR DESCRIPTION
Refs #383

**Changes**
- Added a new dynamic setting `DOCS_GETTING_HELP_URL` that should point to:
    - BRC: https://docs-research-it.berkeley.edu/services/high-performance-computing/getting-help/
    - LRC: https://it.lbl.gov/resource/hpc/for-users/getting-help/
- Replaced BRC-specific help text with a sentence pointing the user to the URL.

**How to Test**
- Review the code changes and add comments as needed.
- Manual Testing
    - Re-run the Ansible playbook.
    - At `/admin/constance/config/`, set `DOCS_GETTING_HELP_URL` to the appropriate one above.
    - Navigate to the Help page (in the navbar), and ensure that the link behaves as expected.