### PR TITLE
Also set host_user for LBL employees

### DIFF
--- a/coldfront/core/project/templates/project/project_join_list.html
+++ b/coldfront/core/project/templates/project/project_join_list.html
@@ -63,8 +63,8 @@ Project List
 <b>Make a New Request</b>
 <hr>
 
-{% if need_host %}
-  <div>If you are joining your first project and are not an LBL employee with an LBL email (@lbl.gov), you must
+{% if require_host_user %}
+  <div>If you are joining your first project and are not an LBL employee with a verified LBL email (@lbl.gov), you must
     select an eligible PI to become your host user when requesting to join a project.</div>
     <hr>
 {% endif %}
@@ -185,7 +185,7 @@ Project List
                             <label for="reason{{ project.pk }}Input">Reason*</label>
                             <textarea required id="reason{{ project.pk }}Input" aria-describedby="reason{{ project.pk }}Help" class="form-control" name="reason" minlength="20" maxlength="1000"></textarea>
                             <small id="reason{{ project.pk }}Help" class="form-text text-muted">Please provide a short reason that will be reviewed by the project managers.</small>
-                            {% if need_host %}
+                            {% if require_host_user %}
                               {{ selecthostform_dict|get_value_from_dict:project.name | crispy }}
                             {% endif %}
                         </div>

--- a/coldfront/core/project/views_/join_views/request_views.py
+++ b/coldfront/core/project/views_/join_views/request_views.py
@@ -27,6 +27,7 @@ from coldfront.core.project.models import VectorProjectAllocationRequest
 from coldfront.core.project.utils import annotate_queryset_with_cluster_name
 from coldfront.core.project.utils import send_project_join_notification_email
 from coldfront.core.project.views import ProjectListView
+from coldfront.core.user.utils_.host_user_utils import is_lbl_employee
 from coldfront.core.user.utils_.host_user_utils import needs_host
 
 
@@ -283,7 +284,7 @@ class ProjectJoinListView(ProjectListView, UserPassesTestMixin):
         pending_removal_requests = set([removal_request.project_user.project.name
                                         for removal_request in
                                         ProjectUserRemovalRequest.objects.filter(
-                                            Q(project_user__user__username=self.request.user.username) &
+                                            Q(project_user__user__username=user_obj.username) &
                                             Q(status__name='Pending'))])
 
         not_joinable = set.union(
@@ -300,21 +301,22 @@ class ProjectJoinListView(ProjectListView, UserPassesTestMixin):
         context['join_requests'] = join_requests
         context['not_joinable'] = not_joinable
 
-        # Only non-LBL employees without a host user and without any pending
-        # join requests need access to the SelectHostUserForm.
-        context['need_host'] = False
-        pending_status = ProjectUserStatusChoice.objects.get(name='Pending - Add')
-        if flag_enabled('LRC_ONLY') \
-                and needs_host(self.request.user) \
-                and not ProjectUser.objects.filter(user=self.request.user,
-                                                   status=pending_status).exists():
-            context['need_host'] = True
-
+        # On LRC only, require that the user select a host user if the user is
+        # not an LBL employee, does not already have a host user, and is not
+        # already in the process of being added to another project (for which
+        # they would have had to select a host user).
+        is_being_added_to_project = ProjectUser.objects.filter(
+            user=user_obj, status__name='Pending - Add').exists()
+        context['require_host_user'] = (
+            flag_enabled('LRC_ONLY') and
+            not is_lbl_employee(user_obj) and
+            needs_host(user_obj) and
+            not is_being_added_to_project)
+        if context['require_host_user']:
             selecthostform_dict = {}
             for project in context.get('project_list'):
                 selecthostform_dict[project.name] = \
                     ProjectSelectHostUserForm(project=project.name)
-
             context['selecthostform_dict'] = selecthostform_dict
 
         return context

--- a/coldfront/core/user/utils_/host_user_utils.py
+++ b/coldfront/core/user/utils_/host_user_utils.py
@@ -44,12 +44,6 @@ def lbl_email_address(user):
 
 def needs_host(user):
     """Return whether the given User needs a host user."""
-    if not isinstance(user, User):
-        raise TypeError(f'Invalid User {user}.')
+    assert isinstance(user, User)
+    return not bool(user.userprofile.host_user)
 
-    # If the user has an LBL email, they do not need a host user.
-    if is_lbl_employee(user):
-        return False
-    else:
-        # Check if the user has a host user already.
-        return user.userprofile.host_user is None


### PR DESCRIPTION
Fixes #448

**Changes**
- Updated the `needs_host` utility method to simply return whether the `User` has a `host_user`, so that even LBL employees may need a host (themselves).
- Rewrote logic for determining whether to ask the user to select a host when joining a project given this change.
- Updated logic for setting a host to set one for LBL employees who do not already have one (to themselves).
- Added and updated tests.

**Notes**
- The impetus for setting a host for LBL employees is that the LBL email address of the host is needed for all new cluster access requests, regardless of whether the user is an employee. Storing the host for all users simplifies the logic for determining the email address.