### PR TITLE
Always allow jobs from departmental cluster projects

### DIFF
--- a/coldfront/api/statistics/views.py
+++ b/coldfront/api/statistics/views.py
@@ -703,7 +703,7 @@ def can_submit_job(request, job_cost, user_id, account_id):
         return client_error(message)
 
     # Allow all jobs for accounts that are not intended to have
-    # computing allowances (e.g., departmental cluster-specific projects).
+    # computing allowances (e.g., departmental cluster-specific accounts).
     computing_allowance_project_prefixes = \
         get_computing_allowance_project_prefixes()
     if not account.name.startswith(computing_allowance_project_prefixes):

--- a/coldfront/api/statistics/views.py
+++ b/coldfront/api/statistics/views.py
@@ -32,6 +32,7 @@ from coldfront.core.allocation.models import AllocationUserAttributeUsage
 from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectUser
 from coldfront.core.project.utils_.renewal_utils import get_current_allowance_year_period
+from coldfront.core.resource.utils import get_computing_allowance_project_prefixes
 from coldfront.core.resource.utils_.allowance_utils.computing_allowance import ComputingAllowance
 from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
 from coldfront.core.statistics.models import Job
@@ -700,6 +701,13 @@ def can_submit_job(request, job_cost, user_id, account_id):
     except Project.DoesNotExist:
         message = f'No account exists with account_id {account_id}.'
         return client_error(message)
+
+    # Allow all jobs for accounts that are not intended to have
+    # computing allowances (e.g., departmental cluster-specific projects).
+    computing_allowance_project_prefixes = \
+        get_computing_allowance_project_prefixes()
+    if not account.name.startswith(computing_allowance_project_prefixes):
+        return affirmative
 
     # Validate that needed accounting objects exist.
     try:

--- a/coldfront/core/resource/utils.py
+++ b/coldfront/core/resource/utils.py
@@ -1,6 +1,9 @@
 from django.conf import settings
 
 from coldfront.core.resource.models import Resource
+from coldfront.core.resource.models import ResourceAttribute
+from coldfront.core.resource.models import ResourceAttributeType
+from coldfront.core.resource.models import ResourceType
 
 
 def get_compute_resource_names():
@@ -9,6 +12,19 @@ def get_compute_resource_names():
              Resource.objects.filter(name__endswith=' Compute')
                  .values_list('name', flat=True).order_by('name')]
     return names
+
+
+def get_computing_allowance_project_prefixes():
+    """Return a tuple of prefixes (strs) that names of Projects with
+    computing allowances should begin with."""
+    resource_attribute_type = ResourceAttributeType.objects.get(name='code')
+    resource_type = ResourceType.objects.get(name='Computing Allowance')
+    resources = Resource.objects.filter(resource_type=resource_type)
+    prefixes = ResourceAttribute.objects.filter(
+        resource_attribute_type=resource_attribute_type,
+        resource__in=resources).values_list(
+            'value', flat=True)
+    return tuple(prefixes)
 
 
 def get_primary_compute_resource():


### PR DESCRIPTION
Fixes #446

**Changes**
- Added a utility method for returning a tuple of prefixes of names of `Projects` that have computing allowances.
- Updated `can_submit_job` to always allow jobs from `Projects` whose names do not start with these prefixes.
- Added a test.