### PR TITLE
Add subcommand for loading in host users for existing users

### DIFF
--- a/coldfront/core/utils/management/commands/load_lrc_data.py
+++ b/coldfront/core/utils/management/commands/load_lrc_data.py
@@ -339,7 +339,7 @@ class Command(BaseCommand):
                                 matching_email_addresses.first().user
                         else:
                             # If no matching User could be found, create a new
-                            # User object.
+                            # User object, setting its host_user to itself.
                             new_host_user = User.objects.create(
                                 username=email,
                                 email=email,
@@ -351,6 +351,7 @@ class Command(BaseCommand):
                                 user=new_host_user)
                             new_host_user_profile.middle_name = user_data[
                                 'middle_name'].title()
+                            new_host_user_profile.host_user = new_host_user
                             new_host_user_profile.save()
 
             if new_host_user is not None:

--- a/coldfront/core/utils/management/commands/load_lrc_data.py
+++ b/coldfront/core/utils/management/commands/load_lrc_data.py
@@ -21,7 +21,9 @@ from coldfront.core.resource.models import Resource
 from coldfront.core.resource.utils import get_compute_resource_names
 from coldfront.core.statistics.models import ProjectTransaction
 from coldfront.core.statistics.models import ProjectUserTransaction
+from coldfront.core.user.models import EmailAddress
 from coldfront.core.user.models import UserProfile
+from coldfront.core.user.utils_.host_user_utils import is_lbl_employee
 
 from collections import defaultdict
 from decimal import Decimal
@@ -33,6 +35,7 @@ from coldfront.core.utils.common import utc_now_offset_aware
 from django.core.validators import validate_email
 
 import csv
+import json
 import logging
 import re
 
@@ -71,7 +74,9 @@ class Command(BaseCommand):
                 type=str)
 
         all_parser = subparsers.add_parser('all', help='Run all subcommands.')
-        file_names = ('passwd_file', 'project_users_file', 'billing_file')
+        file_names = (
+            'passwd_file', 'project_users_file', 'billing_file',
+            'employee_id_to_user_data_file')
         for file_name in file_names:
             add_file_argument(all_parser, file_name)
 
@@ -86,6 +91,15 @@ class Command(BaseCommand):
             'billing_ids',
             help='Load IDs to be used for monthly billing from a file.')
         add_file_argument(billing_ids_parser, 'billing_file')
+
+        host_users_parser = subparsers.add_parser(
+            'host_users',
+            help=(
+                'Load host users for users from two files: one associating '
+                'usernames with host employee IDs, and another mapping '
+                'employee IDs to user data.'))
+        add_file_argument(host_users_parser, 'billing_file')
+        add_file_argument(host_users_parser, 'employee_id_to_user_data_file')
 
         project_pis_and_managers_parser = subparsers.add_parser(
             'project_pis_and_managers',
@@ -119,6 +133,7 @@ class Command(BaseCommand):
             'project_pis_and_managers',
             'allocations',
             'billing_ids',
+            'host_users',
         ]
         for subcommand in ordered_subcommands:
             handler = getattr(self, f'handle_{subcommand}')
@@ -290,6 +305,64 @@ class Command(BaseCommand):
             self.logger.info(
                 f'Set Project {project_name}\'s default billing ID to '
                 f'{default_billing_id}.')
+
+    def handle_host_users(self, *args, **options):
+        """Handle the 'host_users' subcommand."""
+        host_employee_ids_by_username = self.get_host_employee_ids_by_username(
+            options['billing_file'])
+        user_data_by_employee_id = self.get_user_data_by_employee_id(
+            options['employee_id_to_user_data_file'])
+
+        users = User.objects.order_by('id').select_related('userprofile')
+        for user in users.iterator():
+            username = user.username
+            user_profile = user.userprofile
+            new_host_user = None
+            if is_lbl_employee(user):
+                new_host_user = user
+            elif username in host_employee_ids_by_username:
+                employee_id = host_employee_ids_by_username[username]
+                if employee_id in user_data_by_employee_id:
+                    user_data = user_data_by_employee_id[employee_id]
+                    email = user_data['email'].lower()
+                    # First, attempt to find a matching User from User.email.
+                    matching_users = User.objects.filter(email__iexact=email)
+                    if matching_users.exists():
+                        new_host_user = matching_users.first()
+                    else:
+                        # Then, attempt to find a matching User from
+                        # EmailAddress.email.
+                        matching_email_addresses = EmailAddress.objects.filter(
+                            email__iexact=email)
+                        if matching_email_addresses.exists():
+                            new_host_user = \
+                                matching_email_addresses.first().user
+                        else:
+                            # If no matching User could be found, create a new
+                            # User object.
+                            new_host_user = User.objects.create(
+                                username=email,
+                                email=email,
+                                first_name=user_data['first_name'].title(),
+                                last_name=user_data['last_name'].title())
+                            self.logger.info(
+                                f'User {new_host_user.username} was created.')
+                            new_host_user_profile = UserProfile.objects.get(
+                                user=new_host_user)
+                            new_host_user_profile.middle_name = user_data[
+                                'middle_name'].title()
+                            new_host_user_profile.save()
+
+            if new_host_user is not None:
+                if new_host_user != user_profile.host_user:
+                    user_profile.host_user = new_host_user
+                    user_profile.save()
+                    self.logger.info(
+                        f'Updated the host user for User {user.pk} to User '
+                        f'{new_host_user.pk}.')
+            else:
+                self.logger.error(
+                    f'Could not determine a host user for User {user.pk}.')
 
     def handle_project_pis_and_managers(self, *args, **options):
         """Handle the 'project_pis_and_managers' subcommand."""
@@ -531,6 +604,52 @@ class Command(BaseCommand):
             [name.lower() for name in get_compute_resource_names()])
         all_names.discard('lawrencium')
         return all_names
+
+    def get_user_data_by_employee_id(self, employee_id_to_user_data_file):
+        """Given a path to a JSON file mapping employee IDs to a dict
+        with the keys 'email' and 'full_name', return a mapping from
+        employee ID to a dict with the keys 'email', 'first_name',
+        'middle_name', and 'last_name'."""
+        with open(employee_id_to_user_data_file, 'r') as f:
+            mapping = json.load(f)
+        for employee_id, user_data in mapping.items():
+            full_name = user_data.pop('full_name', '')
+            if not self.is_full_name_valid(full_name):
+                self.logger.warning(
+                    f'The user {user_data} with employee ID {employee_id} has '
+                    f'a malformed full name. Proceeding with empty names.')
+            names = self.get_first_middle_last_names(full_name)
+            user_data['first_name'] = names['first']
+            user_data['middle_name'] = names['middle']
+            user_data['last_name'] = names['last']
+        return mapping
+
+    def get_host_employee_ids_by_username(self, billing_file_path):
+        """Given a path to a file containing usernames and host employee
+        IDs, return a mapping from username to the employee ID.
+
+        Each line in the file is colon-separated and should have eight
+        entries. The first is a username, and the sixth is the host
+        employee ID."""
+        host_employee_ids_by_username = {}
+
+        with open(billing_file_path, 'r') as billing_file:
+            for line in billing_file:
+                fields = [
+                    field.strip() for field in line.rstrip().split(':')]
+                if len(fields) != 8:
+                    self.logger.error(
+                        f'The entry {fields} does not have 8 fields.')
+                    continue
+                user_username = fields[0].strip()
+                if not user_username:
+                    self.logger.error(
+                        f'The entry {fields} is missing a username.')
+                    continue
+                host_employee_id = fields[5].strip()
+                host_employee_ids_by_username[user_username] = host_employee_id
+
+        return host_employee_ids_by_username
 
     @staticmethod
     def get_first_middle_last_names(full_name):


### PR DESCRIPTION
Fixes #447

**Changes**
- Added a subcommand to the `load_lrc_data` management command for setting the `UserProfile.host_user` field for existing `Users` in the database, using `usrdata_LRC` and a JSON mapping employee IDs of host users to details about those users (email address, full name).
    - If a `User` object with the host email address can be found, set the user's host to the existing user.
    - Otherwise, create a new `User` object and set the user's host to the newly-created user.

**Notes**
- The JSON is generated via an external script, using `usrdata_LRC` and the `ldapsearch` tool.