### PR TITLE
Conditionally use Python package for validating LRC billing IDs

### DIFF
--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -69,6 +69,16 @@ program_name_long: "Berkeley Research Computing"
 program_name_short: "BRC"
 primary_cluster_name: "Savio"
 
+# LRC billing validation package settings (for Pip installation).
+# TODO: For LRC deployments with access to the package for billing validation
+# TODO: (e.g., production and staging), set these.
+install_billing_validation_package: false
+# Example: "gitlab.com/user/repo_name.git"
+billing_validation_repo_host: ""
+# Create or request a deploy token.
+billing_validation_repo_username: ""
+billing_validation_repo_token: ""
+
 # LRC Oracle billing database settings.
 # TODO: For LRC deployments with access to Oracle, set these.
 oracle_billing_db_dsn: ""

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -69,6 +69,12 @@ program_name_long: "Berkeley Research Computing"
 program_name_short: "BRC"
 primary_cluster_name: "Savio"
 
+# LRC Oracle billing database settings.
+# TODO: For LRC deployments with access to Oracle, set these.
+oracle_billing_db_dsn: ""
+oracle_billing_db_user: ""
+oracle_billing_db_passwd: ""
+
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""
 

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -106,6 +106,14 @@
         executable: '{{ git_prefix }}/venv/bin/pip3'
       become_user: "{{ djangooperator }}"
 
+    # TODO: If this raises an error, the token is exposed in stderr.
+    - name: Install the Python package for validating LBL billing IDs
+      pip:
+        name: 'git+https://{{ billing_validation_repo_username }}:{{ billing_validation_repo_token }}@{{ billing_validation_repo_host }}'
+        executable: '{{ git_prefix }}/venv/bin/pip3'
+      when: install_billing_validation_package
+      no_log: true
+
     - name: Check if PostgreSQL database is initialized
       stat:
         path: /var/lib/pgsql/9.6/data/PG_VERSION

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -51,12 +51,36 @@ API_LOG_PATH = '{{ log_path }}/{{ api_log_file }}'
 # A list of admin email addresses to CC when certain requests are approved.
 REQUEST_APPROVAL_CC_LIST = {{ request_approval_cc_list }}
 
+#------------------------------------------------------------------------------
+# Billing settings
+#------------------------------------------------------------------------------
+
+{% if (flag_lrc_enabled | bool) and oracle_billing_db_dsn|length %}
+# The class to use for validating billing IDs.
+BILLING_VALIDATOR_BACKEND = 'coldfront.core.billing.utils.validation.backends.oracle.OracleValidatorBackend'
+
+# Credentials for the Oracle billing database.
+ORACLE_BILLING_DB = {
+    'dsn': '{{ oracle_billing_db_dsn }}',
+    'user': '{{ oracle_billing_db_user }}',
+    'password': '{{ oracle_billing_db_passwd }}',
+}
+{% endif %}
+
+#------------------------------------------------------------------------------
+# SSL settings
+#------------------------------------------------------------------------------
+
 # Use a secure cookie for the session cookie (HTTPS only).
 {% if ssl_enabled | bool %}
 SESSION_COOKIE_SECURE = True
 {% else %}
 SESSION_COOKIE_SECURE = False
 {% endif %}
+
+#------------------------------------------------------------------------------
+# Sentry settings
+#------------------------------------------------------------------------------
 
 # Configure Sentry.
 import sentry_sdk

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -55,7 +55,7 @@ REQUEST_APPROVAL_CC_LIST = {{ request_approval_cc_list }}
 # Billing settings
 #------------------------------------------------------------------------------
 
-{% if (flag_lrc_enabled | bool) and oracle_billing_db_dsn|length %}
+{% if (flag_lrc_enabled | bool) and (install_billing_validation_package | bool) and oracle_billing_db_dsn|length %}
 # The class to use for validating billing IDs.
 BILLING_VALIDATOR_BACKEND = 'coldfront.core.billing.utils.validation.backends.oracle.OracleValidatorBackend'
 

--- a/bootstrap/development/main.copyme
+++ b/bootstrap/development/main.copyme
@@ -69,6 +69,16 @@ program_name_long: "Berkeley Research Computing"
 program_name_short: "BRC"
 primary_cluster_name: "Savio"
 
+# LRC billing validation package settings (for Pip installation).
+# TODO: For LRC deployments with access to the package for billing validation
+# TODO: (e.g., production and staging), set these.
+install_billing_validation_package: false
+# Example: "gitlab.com/user/repo_name.git"
+billing_validation_repo_host: ""
+# Create or request a deploy token.
+billing_validation_repo_username: ""
+billing_validation_repo_token: ""
+
 # LRC Oracle billing database settings.
 # TODO: For LRC deployments with access to Oracle, set these.
 oracle_billing_db_dsn: ""

--- a/bootstrap/development/main.copyme
+++ b/bootstrap/development/main.copyme
@@ -69,6 +69,12 @@ program_name_long: "Berkeley Research Computing"
 program_name_short: "BRC"
 primary_cluster_name: "Savio"
 
+# LRC Oracle billing database settings.
+# TODO: For LRC deployments with access to Oracle, set these.
+oracle_billing_db_dsn: ""
+oracle_billing_db_user: ""
+oracle_billing_db_passwd: ""
+
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""
 

--- a/bootstrap/development/playbook.yml
+++ b/bootstrap/development/playbook.yml
@@ -226,6 +226,14 @@
         executable: "{{ git_prefix }}/venv/bin/pip3"
       become_user: "{{ djangooperator }}"
 
+    # TODO: If this raises an error, the token is exposed in stderr.
+    - name: Install the Python package for validating LBL billing IDs
+      pip:
+        name: 'git+https://{{ billing_validation_repo_username }}:{{ billing_validation_repo_token }}@{{ billing_validation_repo_host }}'
+        executable: '{{ git_prefix }}/venv/bin/pip3'
+      when: install_billing_validation_package
+      no_log: true
+
     # Create a PostgreSQL database and a user for the Django application.
 
     - name: Create a new PostgreSQL database

--- a/coldfront/config/local_settings.py.sample
+++ b/coldfront/config/local_settings.py.sample
@@ -374,6 +374,13 @@ REST_FRAMEWORK = {
 TOKEN_EXPIRATION_HOURS = 24
 
 #------------------------------------------------------------------------------
+# Billing settings
+#------------------------------------------------------------------------------
+
+# The class to use for validating billing IDs.
+BILLING_VALIDATOR_BACKEND = 'coldfront.core.billing.utils.validation.backends.dummy.DummyValidatorBackend'
+
+#------------------------------------------------------------------------------
 # Multiple Email Address settings
 #------------------------------------------------------------------------------
 

--- a/coldfront/core/billing/forms.py
+++ b/coldfront/core/billing/forms.py
@@ -1,9 +1,9 @@
-from coldfront.core.billing.models import BillingActivity
-
 from django import forms
 from django.conf import settings
 from django.core.validators import MinLengthValidator
 from django.core.validators import RegexValidator
+
+from coldfront.core.billing.utils.validation import is_billing_id_valid
 
 
 # TODO: Replace this module with a directory as needed.
@@ -39,13 +39,7 @@ class BillingIDValidationForm(forms.Form):
         if it exists, and optionally, is valid. Otherwise, raise a
         ValidationError."""
         billing_id = self.cleaned_data['billing_id']
-        try:
-            billing_activity = BillingActivity.get_from_full_id(billing_id)
-        except BillingActivity.DoesNotExist:
+        if self.enforce_validity and not is_billing_id_valid(billing_id):
             raise forms.ValidationError(
-                f'Project ID {billing_id} does not currently exist.')
-        # TODO: Enforce validity. BillingActivity no longer has is_valid.
-        # if self.enforce_validity and not billing_activity.is_valid:
-        #     raise forms.ValidationError(
-        #         f'Project ID {billing_id} is not currently valid.')
-        return billing_activity
+                f'Project ID {billing_id} is not currently valid.')
+        return billing_id

--- a/coldfront/core/billing/models.py
+++ b/coldfront/core/billing/models.py
@@ -45,12 +45,3 @@ class BillingActivity(TimeStampedModel):
         """Return a string representing the fully-formed billing ID
         represented by the instance."""
         return f'{self.billing_project.identifier}-{self.identifier}'
-
-    @classmethod
-    def get_from_full_id(cls, full_id):
-        """Return the BillingActivity representing the given
-        fully-formed billing ID, which is assumed to be well-formed."""
-        project_identifier, activity_identifier = full_id.split('-')
-        return BillingActivity.objects.get(
-            billing_project__identifier=project_identifier,
-            identifier=activity_identifier)

--- a/coldfront/core/billing/utils/queries.py
+++ b/coldfront/core/billing/utils/queries.py
@@ -5,11 +5,23 @@ from flags.state import flag_enabled
 from coldfront.core.allocation.models import AllocationAttributeType
 from coldfront.core.allocation.utils import get_project_compute_allocation
 from coldfront.core.billing.models import BillingActivity
+from coldfront.core.billing.models import BillingProject
 from coldfront.core.project.models import Project
 from coldfront.core.resource.utils import get_computing_allowance_project_prefixes
 
 
 logger = logging.getLogger(__name__)
+
+
+def get_or_create_billing_activity_from_full_id(full_id):
+    """Given a fully-formed billing ID, get or create a matching
+    BillingActivity, creating a BillingProject as needed."""
+    project_identifier, activity_identifier = full_id.split('-')
+    billing_project, _ = BillingProject.objects.get_or_create(
+        identifier=project_identifier)
+    billing_activity, _ = BillingActivity.objects.get_or_create(
+        billing_project=billing_project, identifier=activity_identifier)
+    return billing_activity
 
 
 def is_project_billing_id_required_and_missing(project_obj):

--- a/coldfront/core/billing/utils/validation/__init__.py
+++ b/coldfront/core/billing/utils/validation/__init__.py
@@ -1,0 +1,22 @@
+from django.conf import settings
+from django.utils.module_loading import import_string
+
+
+"""Methods relating to billing ID validation. This module is modeled
+after django.core.mail."""
+
+
+__all__ = [
+    'get_validator',
+    'is_billing_id_valid',
+]
+
+
+def get_validator(backend=None, **kwds):
+    klass = import_string(backend or settings.BILLING_VALIDATOR_BACKEND)
+    return klass(**kwds)
+
+
+def is_billing_id_valid(billing_id, validator=None):
+    validator = validator or get_validator()
+    return validator.is_billing_id_valid(billing_id)

--- a/coldfront/core/billing/utils/validation/backends/base.py
+++ b/coldfront/core/billing/utils/validation/backends/base.py
@@ -1,0 +1,12 @@
+from abc import ABC
+from abc import abstractmethod
+
+
+class BaseValidatorBackend(ABC):
+    """An interface for checking whether billing IDs are valid using any
+    of a number of backends."""
+
+    @abstractmethod
+    def is_billing_id_valid(self, billing_id):
+        """Return whether the given billing ID is valid."""
+        pass

--- a/coldfront/core/billing/utils/validation/backends/dummy.py
+++ b/coldfront/core/billing/utils/validation/backends/dummy.py
@@ -1,0 +1,10 @@
+from coldfront.core.billing.utils.validation.backends.base import BaseValidatorBackend
+
+
+class DummyValidatorBackend(BaseValidatorBackend):
+    """A backend for testing purposes."""
+
+    def is_billing_id_valid(self, billing_id):
+        """Return whether the last digit of the given billing ID is
+        even."""
+        return int(billing_id[-1]) % 2 == 0

--- a/coldfront/core/billing/utils/validation/backends/oracle.py
+++ b/coldfront/core/billing/utils/validation/backends/oracle.py
@@ -1,0 +1,27 @@
+from django.conf import settings
+
+from lbl_project_activity_validator.backends import OracleBackend
+from lbl_project_activity_validator.project_activity import ProjectActivity
+from lbl_project_activity_validator.validator import ProjectActivityValidator
+
+from coldfront.core.billing.utils.validation.backends.base import BaseValidatorBackend
+
+
+"""This module should only be imported if lbl_project_activity_validator
+is installed."""
+
+
+class OracleValidatorBackend(BaseValidatorBackend):
+    """A backend that invokes a Python package which connects to an
+    Oracle database to validate billing IDs."""
+
+    def __init__(self):
+        db_settings = settings.ORACLE_BILLING_DB
+        backend = OracleBackend(
+            db_settings['user'], db_settings['password'], db_settings['dsn'])
+        self._validator = ProjectActivityValidator(backend)
+
+    def is_billing_id_valid(self, billing_id):
+        """Return the output of the underlying validation method."""
+        project_activity = ProjectActivity(billing_id)
+        return self._validator.is_project_activity_valid(project_activity)

--- a/coldfront/core/project/tests/test_views/test_new_project_views/test_savio_project_request_wizard.py
+++ b/coldfront/core/project/tests/test_views/test_new_project_views/test_savio_project_request_wizard.py
@@ -78,7 +78,6 @@ class TestSavioProjectRequestWizard(TestBase):
         for i, data in enumerate(form_data):
             response = self.client.post(url, data)
             if i == len(form_data) - 1:
-                print(i, data)
                 self.assertRedirects(response, reverse('home'))
             else:
                 self.assertEqual(response.status_code, HTTPStatus.OK)


### PR DESCRIPTION
Fixes #467

**Changes**
- Updated Ansible configuration so that a Python package for validating LBL billing IDs may be installed only when needed.
	- It is only intended to be installed on LRC deployments that have access to the Oracle database.
	- In other cases, nothing needs to be done.
- Introduced a billing `validation` module (modeled after `django.core.mail`):
	- Introduced a set of billing validator backends that can be used to determine whether a billing ID is currently valid.
		- `OracleValidatorBackend` uses the Python package, which connects to Oracle to determine the answer.
			- This backend should not be imported if the Python package is not installed, as an `ImportError` will be raised.
		- `DummyValidatorBackend` returns whether the last digit of the ID is even.
	- Added a higher-level method `is_billing_id_valid`, which determines the correct backend to use from settings.
		- In general, this method should be used, rather than invoking backends directly.
- Added a setting `BILLING_VALIDATOR_BACKEND` that allows the validator backend to be selected.
	- By default, it is set to the dummy validator, which is compatible with all deployments.
	- Updated Ansible configuration to allow the setting to be overridden for LRC deployments where the package is installed and Oracle credentials are given.
- In the new project request form, enforced that the user-provided billing ID is valid.
- Added a method for creating a `BillingActivity` if it does not exist, and invoked it during creation of a new project request.
- Wrapped handling in the new project request view in a transaction.

**How to Test**
- Review the code changes and add comments as needed.
- Manual Testing
	- Copy the new Ansible variables in `main.copyme` to `main.yml` as-is.
	- Re-run the Ansible playbook.
		- Ensure that the task "Install the Python package for validating LBL billing IDs" is skipped.
		- Ensure that the "Billing settings" section in the generated `dev_settings.py` is empty.
	- In the shell, ensure that billing IDs are correctly validated accordingly to the logic of the dummy backend (`True` if the last digit of the ID is even):
		```python
        >>> from coldfront.core.billing.utils.validation import is_billing_id_valid
        >>> # A billing ID adheres to the regex: "^\d{6}-\d{3}$".
        >>> is_billing_id_valid("123456-789")
		False  # Ends with an odd digit
        >>> is_billing_id_valid("123456-780")
		True  # Ends with an even digit
		```
- Ensure that the test suite passes.