### PR TITLE
Configure additional CENTER_* settings in Ansible

### DIFF
--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -68,6 +68,12 @@ portal_name: "MyBRC"
 program_name_long: "Berkeley Research Computing"
 program_name_short: "BRC"
 primary_cluster_name: "Savio"
+# TODO: For MyLRC, use "https://it.lbl.gov/resource/hpc/for-users/".
+center_user_guide: "https://docs-research-it.berkeley.edu/services/high-performance-computing/user-guide/"
+# TODO: For MyLRC, use "https://it.lbl.gov/resource/hpc/for-users/getting-started/".
+center_login_guide: "https://docs-research-it.berkeley.edu/services/high-performance-computing/user-guide/logging-brc-clusters/#Logging-in"
+# TODO: For MyLRC, use "hpcshelp@lbl.gov".
+center_help_email: "brc-hpc-help@berkeley.edu"
 
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -11,6 +11,10 @@ PROGRAM_NAME_SHORT = '{{ program_name_short }}'
 PRIMARY_CLUSTER_NAME = '{{ primary_cluster_name }}'
 
 CENTER_NAME = PROGRAM_NAME_SHORT + ' HPC Resources'
+CENTER_USER_GUIDE = '{{ center_user_guide }}'
+CENTER_LOGIN_GUIDE = '{{ center_login_guide }}'
+CENTER_HELP_EMAIL = '{{ center_help_email }}'
+
 CENTER_BASE_URL = '{{ full_host_path }}'
 CENTER_HELP_URL = CENTER_BASE_URL + '/help'
 CENTER_PROJECT_RENEWAL_HELP_URL = CENTER_BASE_URL + '/help'

--- a/bootstrap/development/main.copyme
+++ b/bootstrap/development/main.copyme
@@ -68,6 +68,12 @@ portal_name: "MyBRC"
 program_name_long: "Berkeley Research Computing"
 program_name_short: "BRC"
 primary_cluster_name: "Savio"
+# TODO: For MyLRC, use "https://it.lbl.gov/resource/hpc/for-users/".
+center_user_guide: "https://docs-research-it.berkeley.edu/services/high-performance-computing/user-guide/"
+# TODO: For MyLRC, use "https://it.lbl.gov/resource/hpc/for-users/getting-started/".
+center_login_guide: "https://docs-research-it.berkeley.edu/services/high-performance-computing/user-guide/logging-brc-clusters/#Logging-in"
+# TODO: For MyLRC, use "hpcshelp@lbl.gov".
+center_help_email: "brc-hpc-help@berkeley.edu"
 
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""

--- a/coldfront/config/local_settings.py.sample
+++ b/coldfront/config/local_settings.py.sample
@@ -51,10 +51,10 @@ LBL_BILLING_ID_REGEX = "^\d{6}-\d{3}$"
 #------------------------------------------------------------------------------
 # General Center Information
 #------------------------------------------------------------------------------
-CENTER_NAME = 'BRC HPC Resources'
-CENTER_USER_GUIDE = 'https://docs-research-it.berkeley.edu/services/high-performance-computing/user-guide/'
-CENTER_LOGIN_GUIDE = 'https://docs-research-it.berkeley.edu/services/high-performance-computing/user-guide/logging-brc-clusters/#Logging-in'
-CENTER_HELP_EMAIL = 'brc-hpc-help@berkeley.edu'
+CENTER_NAME = 'HPC Resources'
+CENTER_USER_GUIDE = ''
+CENTER_LOGIN_GUIDE = ''
+CENTER_HELP_EMAIL = ''
 
 CENTER_BASE_URL = 'https://localhost'
 CENTER_HELP_URL = CENTER_BASE_URL + '/help'


### PR DESCRIPTION
**Changes**
- Moved the following variables out of `local_settings.py.sample` and into the Ansible settings template:
    - `CENTER_USER_GUIDE`
    - `CENTER_LOGIN_GUIDE`
    - `CENTER_HELP_EMAIL`
- Listed values to use for BRC and LRC in the settings template.

**How to Test**
- Review the code changes and add comments as needed.
- Manual Testing
    - Copy the new Ansible variables in `main.copyme` to `main.yml`, setting the appropriate values for the instance.
    - Re-run the Ansible playbook.
        - Ensure that the settings are empty in the generated `local_settings.py`.
        - Ensure that the settings match the Ansible variables in the generated `dev_settings.py`.
    - In the shell, ensure that the settings match the Ansible variables:
        ```python
        from django.conf import settings

        >>> settings.CENTER_USER_GUIDE
        ''  # Should match Ansible
        >>> settings.CENTER_LOGIN_GUIDE
        ''  # Should match Ansible
        >>> settings.CENTER_HELP_EMAIL
        ''  # Should match Ansible
        ```