### PR TITLE
Allow ALLOW_ALL_JOBS to be configured in Ansible

### DIFF
--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -69,6 +69,10 @@ program_name_long: "Berkeley Research Computing"
 program_name_short: "BRC"
 primary_cluster_name: "Savio"
 
+# API settings.
+# If true, bypass all checks at job submission time.
+allow_all_jobs: false
+
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""
 

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -51,6 +51,11 @@ API_LOG_PATH = '{{ log_path }}/{{ api_log_file }}'
 # A list of admin email addresses to CC when certain requests are approved.
 REQUEST_APPROVAL_CC_LIST = {{ request_approval_cc_list }}
 
+{% if allow_all_jobs | bool %}
+# Allow all jobs, bypassing all checks at job submission time.
+ALLOW_ALL_JOBS = True
+{% endif %}
+
 # Use a secure cookie for the session cookie (HTTPS only).
 {% if ssl_enabled | bool %}
 SESSION_COOKIE_SECURE = True

--- a/bootstrap/development/main.copyme
+++ b/bootstrap/development/main.copyme
@@ -69,6 +69,10 @@ program_name_long: "Berkeley Research Computing"
 program_name_short: "BRC"
 primary_cluster_name: "Savio"
 
+# API settings.
+# If true, bypass all checks at job submission time.
+allow_all_jobs: false
+
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""
 

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -219,7 +219,7 @@ DECIMAL_MAX_PLACES = 2
 ALLOCATION_MIN = Decimal('0.00')
 ALLOCATION_MAX = Decimal('100000000.00')
 
-# Whether or not to allow all jobs, bypassing all checks.
+# Whether to allow all jobs, bypassing all checks at job submission time.
 ALLOW_ALL_JOBS = False
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
**Changes**
- Updated Ansible configuration to allow `ALLOW_ALL_JOBS` to be set to `True` in the generated settings file.

**How to Test**
- Review the code changes and add comments as needed.
- Manual Testing
    - Set `allow_all_jobs` to `true`/`false` in `main.yml`.
        - Ensure that the generated settings file is updated accordingly when the playbook is run.
        - Ensure that the correct settings file is observed in the shell.