### PR TITLE
Avoid instantiating UserProfileSerializer in class attribute of UserSerializer

### DIFF
--- a/coldfront/api/user/serializers.py
+++ b/coldfront/api/user/serializers.py
@@ -64,9 +64,14 @@ class UserProfileSerializer(serializers.ModelSerializer):
 class UserSerializer(serializers.ModelSerializer):
     """A serializer for the User model."""
 
-    profile = UserProfileSerializer(source='userprofile', read_only=True)
+    profile = serializers.SerializerMethodField()
 
     class Meta:
         model = User
         fields = (
             'id', 'username', 'first_name', 'last_name', 'email', 'profile')
+
+    @staticmethod
+    def get_profile(obj):
+        """Return the serialized profile of the user."""
+        return UserProfileSerializer(obj.userprofile).data


### PR DESCRIPTION
**Changes**
- Wrapped the usage of `UserProfileSerializer` in a `SerializerMethodField` so that the serializer is not instantiated during application initialization.
    - The instantiation is problematic during initial setup (e.g., the first invocation of `migrate`) because `UserProfileSerializer.__init__` calls `flag_enabled`, which depends on the table `flags_flagstate` existing, but the table does not exist until `migrate` has been called.

**Notes**
- This is similar to #395.