### PR TITLE
Require authentication for all endpoints

### DIFF
--- a/coldfront/api/permissions.py
+++ b/coldfront/api/permissions.py
@@ -1,12 +1,18 @@
-from rest_framework.permissions import BasePermission, SAFE_METHODS
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import SAFE_METHODS
 
 
-class IsAdminUserOrReadOnly(BasePermission):
+class IsAdminUserOrReadOnly(IsAuthenticated):
     """
     Allows access only to admin users, or is a read-only request.
+
+    Disallows unauthenticated users.
     """
 
     def has_permission(self, request, view):
+        is_authenticated = super().has_permission(request, view)
+        if not is_authenticated:
+            return False
         return bool(
             request.method in SAFE_METHODS or
             request.user and
@@ -15,12 +21,17 @@ class IsAdminUserOrReadOnly(BasePermission):
         )
 
 
-class IsSuperuserOrStaff(BasePermission):
+class IsSuperuserOrStaff(IsAuthenticated):
     """
     Allows write access to superusers, read access to staff, and no
     access to other users.
+
+    Disallows unauthenticated users.
     """
     def has_permission(self, request, view):
+        is_authenticated = super().has_permission(request, view)
+        if not is_authenticated:
+            return False
         user = request.user
         if not user:
             return False

--- a/coldfront/api/statistics/views.py
+++ b/coldfront/api/statistics/views.py
@@ -586,6 +586,8 @@ response_400 = openapi.Response(
         200: response_200,
         400: response_400
     })
+# Note: This endpoint should require authentication. Currently, it is
+# enforced by REST_FRAMEWORK['DEFAULT_PERMISSION_CLASSES'].
 @api_view(['GET'])
 @transaction.atomic
 def can_submit_job(request, job_cost, user_id, account_id):

--- a/coldfront/api/utils/urls.py
+++ b/coldfront/api/utils/urls.py
@@ -10,7 +10,7 @@ schema_view = get_schema_view(
         default_version='v1',
         description='REST API for MyBRC'),
     public=True,
-    permission_classes=(permissions.AllowAny,))
+    permission_classes=(permissions.IsAuthenticated,))
 
 urlpatterns = [
     url(


### PR DESCRIPTION
**Changes**
- Updated API permission classes to inherit from `IsAuthenticated` so that all views using them require that the user be authenticated (e.g., by giving an API token).
- Added a note to `can_submit_job` explaining that it uses the default permission class.
- Added and updated tests.

**How to Test**
- Ensure that the API tests, which already test authorization for varyingly privileged users, pass.