### PR TITLE
Configure Apache based on whether Cloudflare is enabled/disabled; clean up playbook

### DIFF
--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -36,6 +36,32 @@ wsgi_conf_file_name: cf_mybrc_wsgi.conf
 # TODO: For LRC, use the substring 'cf_lrc'.
 wsgi_conf_log_prefix: cf_brc
 
+# LRC Cloudflare settings.
+# Whether the web server is behind Cloudflare.
+# TODO: For the LRC production deployment, enable Cloudflare, since LBL
+# TODO: requires that web servers visible to the Internet be placed behind it.
+# TODO: https://commons.lbl.gov/display/cpp/Open+Web+Server+Requirements
+cloudflare_enabled: false
+# A list of Cloudflare's IP ranges.
+# TODO: Keep it up-to-date with: https://www.cloudflare.com/ips/.
+cloudflare_ip_ranges: [
+    103.21.244.0/22,
+    103.22.200.0/22,
+    103.31.4.0/22,
+    104.16.0.0/13,
+    104.24.0.0/14,
+    108.162.192.0/18,
+    131.0.72.0/22,
+    141.101.64.0/18,
+    162.158.0.0/15,
+    172.64.0.0/13,
+    173.245.48.0/20,
+    188.114.96.0/20,
+    190.93.240.0/20,
+    197.234.240.0/22,
+    198.41.128.0/17
+]
+
 # CILogon client settings.
 # TODO: Set these, needed only if SSO should be enabled.
 cilogon_app_client_id: ""
@@ -120,9 +146,11 @@ common_tasks: True
 # ssl_enabled: false
 # ssl_certificate_file: /etc/ssl/ssl_certificate.file
 # ssl_certificate_key_file: /etc/ssl/ssl_certificate_key.file
+# # An optional chain file.
 # ssl_certificate_chain_file: /etc/ssl/ssl_certification_chain.file
 
-# # An IP range, in CIDR notation, to which the REST API is accessible.
+# # Zero or more space-separated IP ranges, in CIDR notation, to which the REST
+# # API is accessible. If none are given, API access is not restricted.
 # ip_range_with_api_access: 0.0.0.0/24
 
 # # Email settings.
@@ -166,10 +194,11 @@ common_tasks: True
 # ssl_enabled: true
 # ssl_certificate_file: /etc/ssl/ssl_certificate.file
 # ssl_certificate_key_file: /etc/ssl/ssl_certificate_key.file
+# # An optional chain file.
 # ssl_certificate_chain_file: /etc/ssl/ssl_certification_chain.file
 
-# # One or more space-separated IP ranges, in CIDR notation, to which the REST
-# # API is accessible.
+# # Zero or more space-separated IP ranges, in CIDR notation, to which the REST
+# # API is accessible. If none are given, API access is not restricted.
 # ip_range_with_api_access: 10.0.0.0/8
 
 # # Email settings.
@@ -210,9 +239,11 @@ common_tasks: True
 # ssl_enabled: false
 # ssl_certificate_file: /etc/ssl/ssl_certificate.file
 # ssl_certificate_key_file: /etc/ssl/ssl_certificate_key.file
+# # An optional chain file.
 # ssl_certificate_chain_file: /etc/ssl/ssl_certification_chain.file
 
-# # An IP range, in CIDR notation, to which the REST API is accessible.
+# # Zero or more space-separated IP ranges, in CIDR notation, to which the REST
+# # API is accessible. If none are given, API access is not restricted.
 # ip_range_with_api_access: 0.0.0.0/0
 
 # # Email settings.

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -160,7 +160,7 @@ sentry_dsn: ""
 
 # # Zero or more space-separated IP ranges, in CIDR notation, to which the REST
 # # API is accessible. If none are given, API access is not restricted.
-# ip_range_with_api_access: 0.0.0.0/24
+# ip_range_with_api_access:
 
 # # Email settings.
 # email_port: 25
@@ -253,7 +253,7 @@ sentry_dsn: ""
 
 # # Zero or more space-separated IP ranges, in CIDR notation, to which the REST
 # # API is accessible. If none are given, API access is not restricted.
-# ip_range_with_api_access: 0.0.0.0/24
+# ip_range_with_api_access:
 
 # # Email settings.
 # email_port: 1025

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -61,6 +61,11 @@ cloudflare_ip_ranges: [
     197.234.240.0/22,
     198.41.128.0/17
 ]
+# The name of the server, which should differ from the name of the website.
+# Source: See Open Web Server Requirements link above.
+# TODO: Set this to e.g., mylrc-local.lbl.gov for mylrc.lbl.gov if Cloudflare
+# TODO: is enabled.
+cloudflare_local_server_name:
 
 # CILogon client settings.
 # TODO: Set these, needed only if SSO should be enabled.

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -249,7 +249,7 @@ common_tasks: True
 
 # # Zero or more space-separated IP ranges, in CIDR notation, to which the REST
 # # API is accessible. If none are given, API access is not restricted.
-# ip_range_with_api_access: 0.0.0.0/0
+# ip_range_with_api_access: 0.0.0.0/24
 
 # # Email settings.
 # email_port: 1025

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -122,8 +122,8 @@ allow_all_jobs: false
 sentry_dsn: ""
 
 # Types of Ansible tasks to run by default.
-provisioning_tasks: True
-common_tasks: True
+provisioning_tasks: true
+common_tasks: true
 
 ###############################################################################
 # staging_settings

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -1,4 +1,12 @@
 ###############################################################################
+# Ansible Settings
+###############################################################################
+
+# Types of Ansible tasks to run by default.
+provisioning_tasks: true
+common_tasks: true
+
+###############################################################################
 # General Settings
 ###############################################################################
 
@@ -120,10 +128,6 @@ allow_all_jobs: false
 
 # The URL of the Sentry instance to send errors to.
 sentry_dsn: ""
-
-# Types of Ansible tasks to run by default.
-provisioning_tasks: true
-common_tasks: true
 
 ###############################################################################
 # staging_settings

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -309,69 +309,64 @@
                 state: enabled
                 permanent: yes
 
-            # 443/tcp should only be allowed in Cloudflare IP ranges.
-            # https://commons.lbl.gov/pages/viewpage.action?pageId=203489943
+            - name: Run Cloudflare Tasks
+              block:
+                # 443/tcp should only be allowed in Cloudflare IP ranges.
+                # https://commons.lbl.gov/pages/viewpage.action?pageId=203489943
+                - name: Do not permit https traffic in public zone
+                  ansible.posix.firewalld:
+                    zone: public
+                    service: https
+                    state: disabled
+                    permanent: yes
 
-            - name: Do not permit https traffic in public zone
-              ansible.posix.firewalld:
-                zone: public
-                service: https
-                state: disabled
-                permanent: yes
+                - name: Deny 443/tcp in public zone
+                  ansible.posix.firewalld:
+                    zone: public
+                    port: 443/tcp
+                    state: disabled
+                    permanent: yes
 
-            - name: Deny 443/tcp in public zone
-              ansible.posix.firewalld:
-                zone: public
-                port: 443/tcp
-                state: disabled
-                permanent: yes
+                - name: Create firewalld zone for Cloudflare IP ranges
+                  ansible.posix.firewalld:
+                    zone: cloudflare
+                    state: present
+                    permanent: yes
 
-            - name: Create firewalld zone for Cloudflare IP ranges
-              ansible.posix.firewalld:
-                zone: cloudflare
-                state: present
-                permanent: yes
+                # Firewalld must be reloaded after zone transactions.
+                # https://docs.ansible.com/ansible/latest/collections/ansible/posix/firewalld_module.html#notes
+                - name: Reload firewalld service
+                  service:
+                    name: firewalld
+                    state: reloaded
 
-            # Firewalld must be reloaded after zone transactions.
-            # https://docs.ansible.com/ansible/latest/collections/ansible/posix/firewalld_module.html#notes
-            - name: Reload firewalld service
-              service:
-                name: firewalld
-                state: reloaded
+                - name: Add Cloudflare IP ranges to Cloudflare zone
+                  ansible.posix.firewalld:
+                    zone: cloudflare
+                    source: "{{ item }}"
+                    permanent: yes
+                    state: enabled
+                  loop: "{{ cloudflare_ip_ranges }}"
 
-            - name: Add Cloudflare IP ranges to Cloudflare zone
-              ansible.posix.firewalld:
-                zone: cloudflare
-                source: "{{ item }}"
-                permanent: yes
-                state: enabled
-              loop:
-                # https://www.cloudflare.com/ips/
-                - 103.21.244.0/22
-                - 103.22.200.0/22
-                - 103.31.4.0/22
-                - 104.16.0.0/13
-                - 104.24.0.0/14
-                - 108.162.192.0/18
-                - 131.0.72.0/22
-                - 141.101.64.0/18
-                - 162.158.0.0/15
-                - 172.64.0.0/13
-                - 173.245.48.0/20
-                - 188.114.96.0/20
-                - 190.93.240.0/20
-                - 197.234.240.0/22
-                - 198.41.128.0/17
+                - name: Permit http and https traffic in Cloudflare zone
+                  ansible.posix.firewalld:
+                    zone: cloudflare
+                    service: "{{ item }}"
+                    state: enabled
+                    permanent: yes
+                  loop:
+                    - http
+                    - https
 
-            - name: Permit http and https traffic in Cloudflare zone
-              ansible.posix.firewalld:
-                zone: cloudflare
-                service: "{{ item }}"
-                state: enabled
-                permanent: yes
-              loop:
-                - http
-                - https
+                # Log the original client IP address of each request instead of the Cloudflare IP.
+                # Source: https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs#C5XWe97z77b3XZV
+                - name: Update httpd combined LogFormat in accordance with mod_remoteip
+                  lineinfile:
+                    path: /etc/httpd/conf/httpd.conf
+                    regexp: '^    LogFormat .+ combined$'
+                    line: '    LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined'
+
+              when: cloudflare_enabled
 
             - name: Reload firewalld service
               service:

--- a/bootstrap/ansible/wsgi_conf_ssl.tmpl
+++ b/bootstrap/ansible/wsgi_conf_ssl.tmpl
@@ -9,8 +9,13 @@ WSGIPassAuthorization On
 
 <VirtualHost 0.0.0.0:443>
 
+    {% if cloudflare_enabled | bool %}
+    ServerName {{ cloudflare_local_server_name }}
+    ServerAlias {{ cloudflare_local_server_name }}
+    {% else %}
     ServerName {{ hostname }}
     ServerAlias {{ hostname }}
+    {% endif %}
 
     {% if cloudflare_enabled | bool %}
     # Source: https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs#C5XWe97z77b3XZV
@@ -57,7 +62,12 @@ WSGIPassAuthorization On
 
 <VirtualHost {{ host_ip }}:80>
 
+    {% if cloudflare_enabled | bool %}
+    ServerName {{ cloudflare_local_server_name }}
+    Redirect permanent "/" "https://{{ cloudflare_local_server_name }}"
+    {% else %}
     ServerName {{ hostname }}
     Redirect permanent "/" "{{ full_host_path }}"
+    {% endif %}
 
 </VirtualHost>

--- a/bootstrap/ansible/wsgi_conf_ssl.tmpl
+++ b/bootstrap/ansible/wsgi_conf_ssl.tmpl
@@ -2,6 +2,7 @@ WSGISocketPrefix /var/run/wsgi
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule authz_user_module modules/mod_authz_user.so
 LoadModule headers_module modules/mod_headers.so
+{% if cloudflare_enabled | bool %}LoadModule remoteip_module modules/mod_remoteip.so{% endif %}
 LoadModule ssl_module modules/mod_ssl.so
 
 WSGIPassAuthorization On
@@ -10,6 +11,14 @@ WSGIPassAuthorization On
 
     ServerName {{ hostname }}
     ServerAlias {{ hostname }}
+
+    {% if cloudflare_enabled | bool %}
+    # Source: https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs#C5XWe97z77b3XZV
+    RemoteIPHeader CF-Connecting-IP
+    {% for cloudflare_ip_range in cloudflare_ip_ranges %}
+    RemoteIPTrustedProxy {{ cloudflare_ip_range }}
+    {% endfor %}
+    {% endif %}
 
     Alias /static/ {{ git_prefix }}/{{ reponame }}/static_root/
     <Directory {{ git_prefix }}/{{ reponame }}/static_root/>
@@ -31,7 +40,9 @@ WSGIPassAuthorization On
     SSLProtocol all -SSLv2 -SSLv3
     SSLCertificateFile {{ ssl_certificate_file }}
     SSLCertificateKeyFile {{ ssl_certificate_key_file }}
+    {% if ssl_certificate_chain_file %}
     SSLCertificateChainFile {{ ssl_certificate_chain_file }}
+    {% endif %}
 
     ErrorLog /var/log/httpd/{{ wsgi_conf_log_prefix }}.error.log
     CustomLog /var/log/httpd/{{ wsgi_conf_log_prefix }}.custom.log combined

--- a/bootstrap/ansible/wsgi_conf_ssl.tmpl
+++ b/bootstrap/ansible/wsgi_conf_ssl.tmpl
@@ -2,7 +2,9 @@ WSGISocketPrefix /var/run/wsgi
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule authz_user_module modules/mod_authz_user.so
 LoadModule headers_module modules/mod_headers.so
-{% if cloudflare_enabled | bool %}LoadModule remoteip_module modules/mod_remoteip.so{% endif %}
+{% if cloudflare_enabled | bool %}
+LoadModule remoteip_module modules/mod_remoteip.so
+{% endif %}
 LoadModule ssl_module modules/mod_ssl.so
 
 WSGIPassAuthorization On


### PR DESCRIPTION
**Changes**
- Added Cloudflare-related Ansible settings:
    - When Cloudflare is enabled (LRC production only at the moment):
        - Update `firewalld`,
        - Update the Apache `LogFormat` so that the original IP address of the client (not a Cloudflare IP address) is logged,
        - Restrict access to the web server to a pre-defined set of IP addresses, and
        - Update the name of the server in Apache.
- Made the SSL certificate chain file optional.
- Allowed the list of IP ranges that have access to the API to be empty.

**How to Test**
- Review the code changes and add comments as needed.
- Ensure that the test suite passes on GitHub Actions.
- Manual Testing
    - Update `main.yml` to reflect the changes to `main.copyme`.
    - Re-run the Ansible playbook, noting any issues.

**Notes**
- This has been tested on both BRC and LRC development VMs, as well as both BRC and LRC staging instances.
- The LRC production Apache configuration file (`cf_mylrc_wsgi.conf`) was generated on an LRC development VM by using production-like variables, and appeared correct.
- The LRC production `firewalld` tasks in the playbook were tested on an LRC development VM, and appeared correct.