### PR TITLE
Allow EMAIL_ADMIN_LIST to be configured in Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ that quotes need not be provided, except in the list variable.
    redis_passwd: password_here
    from_email: you@email.com
    admin_email: you@email.com
+   email_admin_list: ["you@email.com"]
    request_approval_cc_list: ["you@email.com"]
    ```
 8. Provision the VM. This should run the Ansible playbook. Expect this to take

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -133,8 +133,12 @@ common_tasks: True
 # # TODO: For LRC, use the substring 'MyLRC'.
 # email_subject_prefix: '[MyBRC-User-Portal]'
 
+# # A list of admin email addresses to be notified about new requests and other
+# # events.
+# # TODO: Set these addresses to yours.
+# email_admin_list: []
 # # A list of email addresses to CC when certain requests are processed.
-# # TODO: Set this address to yours.
+# # TODO: Set these addresses to yours.
 # request_approval_cc_list: []
 
 ###############################################################################
@@ -180,9 +184,13 @@ common_tasks: True
 # # TODO: For LRC, use the substring 'MyLRC'.
 # email_subject_prefix: '[MyBRC-User-Portal]'
 
+# # A list of admin email addresses to be notified about new requests and other
+# # events.
+# # TODO: Set these addresses to yours.
+# email_admin_list: []
 # # A list of email addresses to CC when certain requests are processed.
-# # TODO: Set this address to yours.
-# request_approval_cc_list: ['wfeinstein@lbl.gov']
+# # TODO: Set these addresses to yours.
+# request_approval_cc_list: []
 
 ###############################################################################
 # dev_settings
@@ -223,6 +231,10 @@ common_tasks: True
 # # TODO: For LRC, use the substring 'MyLRC'.
 # email_subject_prefix: '[MyBRC-User-Portal]'
 
+# # A list of admin email addresses to be notified about new requests and other
+# # events.
+# # TODO: Set these addresses to yours.
+# email_admin_list: ['you@email.com']
 # # A list of email addresses to CC when certain requests are processed.
-# # TODO: Set this address to yours.
+# # TODO: Set these addresses to yours.
 # request_approval_cc_list: ['you@email.com']

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -23,7 +23,7 @@ EMAIL_PORT = {{ email_port }}
 EMAIL_SUBJECT_PREFIX = '{{ email_subject_prefix }}'
 # A list of admin email addresses to be notified about new requests and other
 # events.
-EMAIL_ADMIN_LIST = {{ email_admin_list }}
+EMAIL_ADMIN_LIST = {{ email_admin_list }} or ['admin@{{ hostname }}']
 EMAIL_SENDER = '{{ from_email }}'
 EMAIL_TICKET_SYSTEM_ADDRESS = 'help@{{ hostname }}'
 EMAIL_DIRECTOR_EMAIL_ADDRESS = 'director@{{ hostname }}'

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -21,7 +21,9 @@ CENTER_PROJECT_RENEWAL_HELP_URL = CENTER_BASE_URL + '/help'
 
 EMAIL_PORT = {{ email_port }}
 EMAIL_SUBJECT_PREFIX = '{{ email_subject_prefix }}'
-EMAIL_ADMIN_LIST = ['admin@{{ hostname }}']
+# A list of admin email addresses to be notified about new requests and other
+# events.
+EMAIL_ADMIN_LIST = {{ email_admin_list }}
 EMAIL_SENDER = '{{ from_email }}'
 EMAIL_TICKET_SYSTEM_ADDRESS = 'help@{{ hostname }}'
 EMAIL_DIRECTOR_EMAIL_ADDRESS = 'director@{{ hostname }}'

--- a/coldfront/config/test_settings.py.sample
+++ b/coldfront/config/test_settings.py.sample
@@ -21,6 +21,8 @@ CENTER_PROJECT_RENEWAL_HELP_URL = CENTER_BASE_URL + '/help'
 
 EMAIL_PORT = 1025
 EMAIL_SUBJECT_PREFIX = '[MyBRC-User-Portal]'
+# A list of admin email addresses to be notified about new requests and other
+# events.
 EMAIL_ADMIN_LIST = ['admin@localhost']
 EMAIL_SENDER = 'test@test.test'
 EMAIL_TICKET_SYSTEM_ADDRESS = 'help@localhost'


### PR DESCRIPTION
**Changes**
- Added an Ansible setting `email_admin_list` that becomes the value of the Django setting `EMAIL_ADMIN_LIST`.
    - If the provided list is empty, the value is set to the previous default.
- Removed a hard-coded email address in favor of setting addresses on a case-by-case basis.

**How to Test**
- Review the code changes and add comments as needed.
- Ensure that the test suite passes on GitHub Actions.
- Manual Testing
    - Update `main.yml` to reflect the changes to `main.copyme`.
    - Re-run the Ansible playbook, noting any issues.
    - In the Django shell, ensure that `EMAIL_ADMIN_LIST` has the correct value (either the user-specified list, or the previous default if the former is empty).