### PR TITLE
Issue 494: Upgrading Postgres 9.6 -> 15

### DIFF
--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest # Default github actions environment for Linux
+    runs-on: ubuntu-20.04 # Default github actions environment for Linux
 
     services:
       postgres: # Set up a database container with the following specifications

--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres: # Set up a database container with the following specifications
-        image: postgres:10.23-alpine3.16
+        image: postgres:15.2-alpine3.17
         env:
           POSTGRES_DB: cf_brc_db
           POSTGRES_PASSWORD: test

--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     services:
       postgres: # Set up a database container with the following specifications
-        image: postgres:9.6.24-alpine3.15
+        image: postgres:10.23-alpine3.16
         env:
           POSTGRES_DB: cf_brc_db
           POSTGRES_PASSWORD: test

--- a/README.md
+++ b/README.md
@@ -118,14 +118,6 @@ which can be done with:
 
 - Any custom Django settings can be applied by modifying `dev_settings.py`.
 Note that running the Ansible playbook will overwrite these.
-- It may be convenient to add the following to `/home/vagrant/.bashrc`:
-  ```
-  # Upon login, navigate to the ColdFront directory and source the virtual environment.
-  cd /vagrant/coldfront_app/coldfront
-  source /vagrant/coldfront_app/venv/bin/activate
-  # Restart Apache with a keyword.
-  alias reload="sudo service httpd restart"
-  ```
 
 #### Emails
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,9 +14,9 @@ Vagrant.configure("2") do |config|
   config.vm.provision "ansible_local" do |ansible|
     ansible.playbook = "coldfront_app/coldfront/bootstrap/ansible/playbook.yml"
     ansible.galaxy_role_file = "coldfront_app/coldfront/bootstrap/ansible/requirements.yml"
-    ansible.galaxy_roles_path = "/home/vagrant/.ansible"
+    ansible.galaxy_roles_path = "/home/vagrant/.ansible/roles"
     # https://github.com/hashicorp/vagrant/issues/10958#issuecomment-724431455
-    ansible.galaxy_command = "ansible-galaxy collection install --requirements-file %{role_file} --collections-path %{roles_path}/collections --force && ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force"
+    ansible.galaxy_command = "ansible-galaxy collection install --requirements-file %{role_file} --collections-path /home/vagrant/.ansible/collections --force && ansible-galaxy install --role-file=%{role_file} --roles-path=%{roles_path} --force"
   end
 
   config.vm.network :forwarded_port, host: 8880, guest: 80

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -230,8 +230,6 @@
             requirements: "{{ git_prefix }}/{{ reponame }}/requirements.txt"
             executable: "{{ git_prefix }}/venv/bin/pip3"
           become_user: "{{ djangooperator }}"
-          environment: # needed as pg_config isn't in PATH by default
-            PATH: "{{ ansible_env.PATH }}:/usr/pgsql-{{ postgres_version }}/bin"
 
         # TODO: If this raises an error, the token is exposed in stderr.
         - name: Install the Python package for validating LBL billing IDs

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -482,8 +482,6 @@
             requirements: "{{ git_prefix }}/{{ reponame }}/requirements.txt"
             executable: "{{ git_prefix }}/venv/bin/pip3"
           become_user: "{{ djangooperator }}"
-          environment: # needed as pg_config isn't in PATH by default
-            PATH: "{{ ansible_env.PATH }}:/usr/pgsql-{{ postgres_version }}/bin"
 
         # Run Django management commands.
 

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: MyBRC/LRC User Portal VM Playbook
-  gather_facts: false
+  gather_facts: true
   hosts:
     - all
     - "{{ domain }}"
@@ -15,7 +15,7 @@
     common_tasks: true
 
     python_version: 3.6
-    postgres_version: 10
+    postgres_version: 15
     python_version_dotless: "{{ python_version | regex_replace('\\.','') }}"
     postgres_version_dotless: "{{ postgres_version | regex_replace('\\.','') }}"
 
@@ -53,7 +53,12 @@
               - openssl-devel
               - git-core
               - gcc-c++
+              - libffi-devel
             state: present
+
+        - name: Install SCL
+          include_role:
+            role: smbambling.scl
 
         - name: Install required Python packages
           yum:
@@ -111,6 +116,8 @@
             section: 'program:django_q'
             option: 'numprocs'
             value: '1'
+
+        # Install and configure PostgreSQL.
 
         - name: Add Postgres yum repository
           yum_repository:
@@ -230,6 +237,8 @@
             requirements: "{{ git_prefix }}/{{ reponame }}/requirements.txt"
             executable: "{{ git_prefix }}/venv/bin/pip3"
           become_user: "{{ djangooperator }}"
+          environment: # needed as pg_config isn't in PATH by default
+            PATH: "{{ ansible_env.PATH }}:/usr/pgsql-{{ postgres_version }}/bin"
 
         # TODO: If this raises an error, the token is exposed in stderr.
         - name: Install the Python package for validating LBL billing IDs
@@ -239,22 +248,21 @@
           when: install_billing_validation_package
           no_log: true
 
-        # Create a PostgreSQL database and a user for the Django application.
+        # Create a PostgreSQL user and database for the Django application.
 
-        - name: Create a new PostgreSQL database
-          postgresql_db:
-            name: "{{ db_name }}"
+        - name: Create a PostgreSQL admin user
+          postgresql_user:
+            name: "{{ db_admin_user }}"
+            password: "{{ db_admin_passwd }}"
+            role_attr_flags: CREATEDB
           become_user: postgres
           vars:
             ansible_python_interpreter: "{{ git_prefix }}/venv/bin/python3"
 
-        - name: Create a PostgreSQL admin user and grant permissions
-          postgresql_user:
-            name: "{{ db_admin_user }}"
-            db: "{{ db_name }}"
-            priv: ALL
-            password: "{{ db_admin_passwd }}"
-            role_attr_flags: CREATEDB
+        - name: Create a new PostgreSQL database under the admin user
+          postgresql_db:
+            name: "{{ db_name }}"
+            owner: "{{ db_admin_user }}"
           become_user: postgres
           vars:
             ansible_python_interpreter: "{{ git_prefix }}/venv/bin/python3"

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -406,6 +406,16 @@
             name: vim
             state: present
 
+        - name: Add dev QOL lines to .bashrc
+          blockinfile:
+            path: /home/{{ djangooperator }}/.bashrc
+            block: |
+            # Upon login, navigate to the ColdFront directory and source the virtual environment.
+            cd {{ git_prefix }}/{{ reponame }}
+            source ../venv/bin/activate
+            # Restart Apache with a keyword.
+            alias reload="sudo service httpd reload"
+
         - name: Modify .bashrc to start in application directory by default
           lineinfile:
             path: /home/{{ djangooperator }}/.bashrc

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -410,11 +410,11 @@
           blockinfile:
             path: /home/{{ djangooperator }}/.bashrc
             block: |
-            # Upon login, navigate to the ColdFront directory and source the virtual environment.
-            cd {{ git_prefix }}/{{ reponame }}
-            source ../venv/bin/activate
-            # Restart Apache with a keyword.
-            alias reload="sudo service httpd reload"
+              # Upon login, navigate to the ColdFront directory and source the virtual environment.
+              cd {{ git_prefix }}/{{ reponame }}
+              source ../venv/bin/activate
+              # Restart Apache with a keyword.
+              alias reload="sudo service httpd reload"
 
         - name: Modify .bashrc to start in application directory by default
           lineinfile:

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -14,6 +14,11 @@
     provisioning_tasks: true
     common_tasks: true
 
+    python_version: 3.6
+    postgres_version: 10
+    python_version_dotless: "{{ python_version | regex_replace('\\.','') }}"
+    postgres_version_dotless: "{{ postgres_version | regex_replace('\\.','') }}"
+
   vars_files:
     - "../../main.yml"
 
@@ -25,7 +30,7 @@
           service:
             name: NetworkManager
             state: stopped
-            enabled: no
+            enabled: false
 
         - name: Disable SELinux
           ansible.posix.selinux:
@@ -34,14 +39,10 @@
 
         # Install yum packages.
 
-        - name: Install curl
-          yum:
-            name: curl
-            state: present
-
-        - name: Install required OS packages
+        - name: Install required packages
           yum:
             name:
+              - curl
               - texinfo
               - ntp
               - zlib-devel
@@ -72,13 +73,12 @@
               - mod_ssl
             state: present
 
-        - name: Install redis
+        - name: Install Redis
           yum:
-            name:
-              - redis
+            name: redis
             state: present
 
-        - name: Set redis password
+        - name: Set Redis password
           lineinfile:
             path: /etc/redis.conf
             regexp: '^requirepass '
@@ -87,8 +87,7 @@
 
         - name: Install Supervisor
           yum:
-            name:
-              - supervisor
+            name: supervisor
             state: present
 
         # ini_file is included in community.general.
@@ -113,53 +112,58 @@
             option: 'numprocs'
             value: '1'
 
+        - name: Add Postgres yum repository
+          yum_repository:
+            name: postgres-repository
+            description: postgres repository
+            baseurl: https://download.postgresql.org/pub/repos/yum/{{ postgres_version }}/redhat/rhel-7-x86_64/
+            gpgkey: http://yum.postgresql.org/RPM-GPG-KEY-PGDG-94
+            
         - name: Install Postgresql packages
           yum:
             name:
-              - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-9.6.24-1PGDG.rhel7.x86_64.rpm'
-              - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-libs-9.6.24-1PGDG.rhel7.x86_64.rpm'
-              - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-devel-9.6.24-1PGDG.rhel7.x86_64.rpm'
-              - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-test-9.6.24-1PGDG.rhel7.x86_64.rpm'
-              - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.24-1PGDG.rhel7.x86_64.rpm'
+              - 'postgresql{{ postgres_version }}'
+              - 'postgresql{{ postgres_version }}-libs'
+              - 'postgresql{{ postgres_version }}-devel'
+              - 'postgresql{{ postgres_version }}-test'
+              - 'postgresql{{ postgres_version }}-server'
             state: present
-
-        # Configure PostgreSQL.
 
         - name: Check if PostgreSQL is initialized
           stat:
-            path: /var/lib/pgsql/9.6/data/PG_VERSION
+            path: /var/lib/pgsql/{{ postgres_version }}/data/PG_VERSION
           register: pgdata_dir_version
 
         - name: Initialize PostgreSQL if not already initialized
-          command: /usr/pgsql-9.6/bin/postgresql96-setup initdb
+          command: /usr/pgsql-{{ postgres_version }}/bin/postgresql-{{ postgres_version_dotless }}-setup initdb
           when: not pgdata_dir_version.stat.exists
 
         - name: Start and enable PostgreSQL service
           service:
-            name: postgresql-9.6
+            name: postgresql-{{ postgres_version }}
             state: started
-            enabled: yes
+            enabled: true
 
         - name: Update pg_hba.conf to change host auth from ident to md5 (1/2)
           postgresql_pg_hba:
-            dest: /var/lib/pgsql/9.6/data/pg_hba.conf
-            backup: yes
+            dest: /var/lib/pgsql/{{ postgres_version }}/data/pg_hba.conf
+            backup: true
             method: md5
             contype: host
             source: ::1
 
         - name: Update pg_hba.conf to change host auth from ident to md5 (2/2)
           postgresql_pg_hba:
-            dest: /var/lib/pgsql/9.6/data/pg_hba.conf
-            backup: yes
+            dest: /var/lib/pgsql/{{ postgres_version }}/data/pg_hba.conf
+            backup: true
             method: md5
             contype: host
             source: 127.0.0.1/32
 
         - name: Update pg_hba.conf to set authentication for all to md5
           postgresql_pg_hba:
-            dest: /var/lib/pgsql/9.6/data/pg_hba.conf
-            backup: yes
+            dest: /var/lib/pgsql/{{ postgres_version }}/data/pg_hba.conf
+            backup: true
             method: md5
             contype: host
             source: "0.0.0.0/0"
@@ -177,7 +181,7 @@
         - name: Create a log file for Django portal logs
           copy:
             content: ""
-            force: no
+            force: false
             dest: "{{ log_path }}/{{ portal_log_file }}"
             mode: 0660
             owner: "{{ djangooperator }}"
@@ -186,7 +190,7 @@
         - name: Create a log file for Django API logs
           copy:
             content: ""
-            force: no
+            force: false
             dest: "{{ log_path }}/{{ api_log_file }}"
             mode: 0660
             owner: "{{ djangooperator }}"
@@ -205,11 +209,17 @@
         - name: Initialize Python virtual environment
           shell: >
               test -f {{ git_prefix }}/venv/bin/activate
-              || (python3.6 -m venv {{ git_prefix }}/venv
+              || (python{{ python_version }} -m venv {{ git_prefix }}/venv
               && echo created)
           register: venv_register
           become_user: "{{ djangooperator }}"
           changed_when: venv_register.stdout == "created"
+        
+        - name: Upgrade pip
+          pip:
+            name: pip
+            executable: "{{ git_prefix }}/venv/bin/pip3"
+            state: latest
 
         # Install Django application dependencies, including psycopg2,
         # required to create the PostgreSQL database and user, and mod-wsgi,
@@ -220,6 +230,8 @@
             requirements: "{{ git_prefix }}/{{ reponame }}/requirements.txt"
             executable: "{{ git_prefix }}/venv/bin/pip3"
           become_user: "{{ djangooperator }}"
+          environment: # needed as pg_config isn't in PATH by default
+            PATH: "{{ ansible_env.PATH }}:/usr/pgsql-{{ postgres_version }}/bin"
 
         # TODO: If this raises an error, the token is exposed in stderr.
         - name: Install the Python package for validating LBL billing IDs
@@ -251,12 +263,12 @@
 
         # Configure Apache.
 
-        - name: Check if the mod_wsgi module from Python 3.6 is installed to Apache
+        - name: Check if the mod_wsgi module from Python {{ python_version }} is installed to Apache
           stat:
             path: /etc/httpd/conf.modules.d/02-wsgi.conf
           register: mod_wsgi_installed
 
-        - name: Install the mod_wsgi module from Python 3.6 to Apache
+        - name: Install the mod_wsgi module from Python {{ python_version }} to Apache
           shell: "{{ git_prefix }}/venv/bin/mod_wsgi-express install-module --modules-directory /etc/httpd/modules > /etc/httpd/conf.modules.d/02-wsgi.conf"
           when: not mod_wsgi_installed.stat.exists
 
@@ -292,7 +304,7 @@
               service:
                 name: rsyslog
                 state: restarted
-                enabled: yes
+                enabled: true
 
             # Configure the firewall.
 
@@ -300,14 +312,14 @@
               service:
                 name: firewalld
                 state: started
-                enabled: yes
+                enabled: true
 
             - name: Permit http traffic in public zone
               ansible.posix.firewalld:
                 zone: public
                 service: http
                 state: enabled
-                permanent: yes
+                permanent: true
 
             - name: Run Cloudflare Tasks
               block:
@@ -318,20 +330,20 @@
                     zone: public
                     service: https
                     state: disabled
-                    permanent: yes
+                    permanent: true
 
                 - name: Deny 443/tcp in public zone
                   ansible.posix.firewalld:
                     zone: public
                     port: 443/tcp
                     state: disabled
-                    permanent: yes
+                    permanent: true
 
                 - name: Create firewalld zone for Cloudflare IP ranges
                   ansible.posix.firewalld:
                     zone: cloudflare
                     state: present
-                    permanent: yes
+                    permanent: true
 
                 # Firewalld must be reloaded after zone transactions.
                 # https://docs.ansible.com/ansible/latest/collections/ansible/posix/firewalld_module.html#notes
@@ -344,7 +356,7 @@
                   ansible.posix.firewalld:
                     zone: cloudflare
                     source: "{{ item }}"
-                    permanent: yes
+                    permanent: true
                     state: enabled
                   loop: "{{ cloudflare_ip_ranges }}"
 
@@ -353,7 +365,7 @@
                     zone: cloudflare
                     service: "{{ item }}"
                     state: enabled
-                    permanent: yes
+                    permanent: true
                   loop:
                     - http
                     - https
@@ -390,10 +402,18 @@
     # Development only provisioning tasks.
     - name: Run Development Provisioning Tasks
       block:
-        # Don't do anything as there aren't any development-specific tasks yet.
-        - meta: noop
-      # Uncomment when tasks are added.
-      # when: provisioning_tasks == true and deployment == "dev"
+
+        - name: Install vim
+          yum:
+            name: vim
+            state: present
+
+        - name: Modify .bashrc to start in application directory by default
+          lineinfile:
+            path: /home/{{ djangooperator }}/.bashrc
+            line: cd {{ git_prefix }}/{{ reponame }} && source ../venv/bin/activate
+
+      when: provisioning_tasks == true and deployment == "dev"
       tags: provisioning
 
     # Non-provisioning tasks common to development and production.
@@ -443,19 +463,19 @@
           service:
             name: redis
             state: restarted
-            enabled: yes
+            enabled: true
 
         - name: Restart and enable Supervisor service
           service:
             name: supervisord
             state: restarted
-            enabled: yes
+            enabled: true
 
         - name: Restart and enable PostgreSQL service
           service:
-            name: postgresql-9.6
+            name: postgresql-{{ postgres_version }}
             state: restarted
-            enabled: yes
+            enabled: true
 
         # Install Django application dependencies
 
@@ -464,6 +484,8 @@
             requirements: "{{ git_prefix }}/{{ reponame }}/requirements.txt"
             executable: "{{ git_prefix }}/venv/bin/pip3"
           become_user: "{{ djangooperator }}"
+          environment: # needed as pg_config isn't in PATH by default
+            PATH: "{{ ansible_env.PATH }}:/usr/pgsql-{{ postgres_version }}/bin"
 
         # Run Django management commands.
 
@@ -552,7 +574,7 @@
           file:
             path: "{{ git_prefix }}/{{ reponame }}"
             state: directory
-            recurse: yes
+            recurse: true
             mode: "u=rwX,g=rX,o=rX"
             group: apache
 

--- a/bootstrap/ansible/requirements.yml
+++ b/bootstrap/ansible/requirements.yml
@@ -1,4 +1,6 @@
 ---
+roles:
+  - name: smbambling.scl
 collections:
   - name: ansible.posix
   - name: community.general

--- a/bootstrap/development/load_database_backup.sh
+++ b/bootstrap/development/load_database_backup.sh
@@ -8,7 +8,7 @@
 DB_NAME=${@:(-2):1}
 DUMP_FILE=${@: -1}
 
-BIN=/usr/pgsql-9.6/bin/pg_restore
+BIN=/usr/pgsql-10/bin/pg_restore
 
 if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]] ; then
     echo "Usage: `basename $0` [OPTION] name-of-database absolute-path-to-dump-file"

--- a/bootstrap/development/load_database_backup.sh
+++ b/bootstrap/development/load_database_backup.sh
@@ -6,9 +6,10 @@
 
 # Store second last and last arguments.
 DB_NAME=${@:(-2):1}
+DB_OWNER=admin
 DUMP_FILE=${@: -1}
 
-BIN=/usr/pgsql-10/bin/pg_restore
+BIN=/usr/pgsql-15/bin/pg_restore
 
 if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]] ; then
     echo "Usage: `basename $0` [OPTION] name-of-database absolute-path-to-dump-file"
@@ -30,10 +31,11 @@ if [[ "$1" == "-k" || "$1" == "--kill-connections" ]] ; then
 fi
 
 sudo -u postgres /bin/bash -c "echo DROPPING DATABASE... \
-                        && psql -c 'DROP DATABASE $DB_NAME;'; \
-                        \
-                        echo RECREATING DATABASE... \
-                        && psql -c 'CREATE DATABASE $DB_NAME;' \
-                        \
-                        && echo LOADING DATABASE... \
-                        && $BIN -d $DB_NAME $DUMP_FILE"
+                    && psql -c 'DROP DATABASE $DB_NAME;'; \
+                    \
+                    echo RECREATING DATABASE... \
+                    && psql -c 'CREATE DATABASE $DB_NAME OWNER $DB_OWNER;' \
+                    \
+                    && echo LOADING DATABASE... \
+                    && $BIN -d $DB_NAME $DUMP_FILE; \
+                    psql -c 'ALTER SCHEMA public OWNER TO $DB_OWNER;' $DB_NAME;"


### PR DESCRIPTION
Upgraded postgres version to 15.
Removed all hardcoded python and postgres versions in ansible playbook with variables
Some QOL stuff added to .bashrc by ansible

Notes (I have no idea why the following 2 are the case):

The 'Upgrade pip' task isn't needed with python 3.8

When upgrading to python 3.8 via SCL, the following has to be added to the 'install django application dependencies' task:
`environment: # needed as pg_config isn't in PATH by default
    PATH: "{{ ansible_env.PATH }}:/usr/pgsql-{{ postgres_version }}/bin"`

@matthew-li also made the following changes:
- Incorporated @Hzaakk's Postgres-related changes from #493.
- Removed Ansible tasks to change the Postgres authentication method from `ident` to `md5`, since Postgres now uses `scram-sha-256` by default.
    - Note: When upgrading a 9.6 deployment to 15, any Postgres user passwords need to be reset so that they are re-encrypted using the new algorithm.
- Upgraded `psycopg2-binary` from `2.8.3` to `2.9.5`.