### PR TITLE
Introduce savio4_refmlab cluster; add command for creating standalone cluster project

### DIFF
--- a/coldfront/api/allocation/tests/allocation_users/test_allocation_users.py
+++ b/coldfront/api/allocation/tests/allocation_users/test_allocation_users.py
@@ -99,7 +99,7 @@ class TestListAllocationUsers(TestAllocationBase):
 
     def test_project_filter(self):
         """Test that querying by project filters results properly."""
-        project = self.project0.name
+        project = self.fc_project0.name
 
         url = self.endpoint_url()
         query_parameters = {
@@ -125,14 +125,14 @@ class TestListAllocationUsers(TestAllocationBase):
 
     def test_resources_filter(self):
         """Test that querying by resource filters results properly."""
-        allocation = Allocation.objects.get(project=self.project0)
+        allocation = Allocation.objects.get(project=self.fc_project0)
         resource_type = ResourceType.objects.get(name='Cluster')
         resource = Resource.objects.create(
             name='Other Compute', resource_type=resource_type)
         allocation.resources.add(resource)
 
         first = allocation.pk
-        second = Allocation.objects.get(project=self.project1).pk
+        second = Allocation.objects.get(project=self.fc_project1).pk
         allocation_ids_iterator = iter([first, first, first, first,
                                         second, second, second, second])
 

--- a/coldfront/api/allocation/tests/allocations/test_allocations.py
+++ b/coldfront/api/allocation/tests/allocations/test_allocations.py
@@ -71,7 +71,7 @@ class TestListAllocations(TestAllocationBase):
 
     def test_project_filter(self):
         """Test that querying by project filters results properly."""
-        project = self.project0.name
+        project = self.fc_project0.name
 
         url = self.endpoint_url()
         query_parameters = {
@@ -97,7 +97,7 @@ class TestListAllocations(TestAllocationBase):
 
     def test_resources_filter(self):
         """Test that querying by resource filters results properly."""
-        allocation = Allocation.objects.get(project=self.project0)
+        allocation = Allocation.objects.get(project=self.fc_project0)
         resource_type = ResourceType.objects.get(name='Cluster')
         resource = Resource.objects.create(
             name='Other Compute', resource_type=resource_type)

--- a/coldfront/api/allocation/tests/allocations/test_cluster_access_requests.py
+++ b/coldfront/api/allocation/tests/allocations/test_cluster_access_requests.py
@@ -42,8 +42,9 @@ class TestClusterAccessRequestsBase(TestAllocationBase):
         status_choices = ClusterAccessRequestStatusChoice.objects.all()
         for i in range(4):
             kwargs = {
-                'allocation_user': AllocationUser.objects.get(user__username=f'user{i}',
-                                                              allocation__project__name='project0'),
+                'allocation_user': AllocationUser.objects.get(
+                    user__username=f'user{i}',
+                    allocation__project__name='fc_project0'),
                 'request_time': utc_now_offset_aware(),
             }
             if i == 0:
@@ -60,7 +61,7 @@ class TestClusterAccessRequestsBase(TestAllocationBase):
 
         self.allocation_user0 = \
             AllocationUser.objects.get(user=self.user0,
-                                       allocation__project=self.project0)
+                                       allocation__project=self.fc_project0)
 
         self.allocation_su_attr = AllocationAttribute.objects.get(
             allocation_attribute_type__name='Service Units',
@@ -193,7 +194,7 @@ class TestUpdatePatchClusterAccessRequests(TestClusterAccessRequestsBase):
         return cluster_access_attribute
 
     def _assert_complete_emails_sent(self):
-        email_body = [f'now has access to the project {self.project0.name}.',
+        email_body = [f'now has access to the project {self.fc_project0.name}.',
                       f'supercluster username is - {self.new_username}',
                       f'If this is the first time you are accessing',
                       f'start with the below Logging In page:']
@@ -209,7 +210,7 @@ class TestUpdatePatchClusterAccessRequests(TestClusterAccessRequestsBase):
         self.assertEqual(settings.EMAIL_SENDER, email.from_email)
 
     def _assert_denial_emails_sent(self):
-        email_body = [f'access request under project {self.project0.name}',
+        email_body = [f'access request under project {self.fc_project0.name}',
                       f'and allocation '
                       f'{self.allocation_user0.allocation.pk} '
                       f'has been denied.']
@@ -300,7 +301,7 @@ class TestUpdatePatchClusterAccessRequests(TestClusterAccessRequestsBase):
             'allocation_user': {'id': 12,
                                 'allocation': 3,
                                 'user': 'user3',
-                                'project': 'project0',
+                                'project': 'fc_project0',
                                 'status': 'Complete'},
             'username': 'new_username',
             'cluster_uid': '1234'

--- a/coldfront/api/allocation/tests/test_allocation_base.py
+++ b/coldfront/api/allocation/tests/test_allocation_base.py
@@ -57,8 +57,8 @@ class TestAllocationBase(TestAPIBase):
         for i in range(2):
             # Create a Project and ProjectUsers.
             project = Project.objects.create(
-                name=f'project{i}', status=project_status)
-            setattr(self, f'project{i}', project)
+                name=f'fc_project{i}', status=project_status)
+            setattr(self, f'fc_project{i}', project)
             for j in range(4):
                 ProjectUser.objects.create(
                     user=getattr(self, f'user{j}'), project=project,

--- a/coldfront/api/statistics/tests/test_job_view_set.py
+++ b/coldfront/api/statistics/tests/test_job_view_set.py
@@ -73,7 +73,7 @@ class TestJobList(TestJobBase):
         allocation_amount = Decimal('1000.00')
         for i in range(self.num_projects):
             project = Project.objects.create(
-                name=f'PROJECT_{i}', status=project_status)
+                name=f'fc_project_{i}', status=project_status)
             allocation_objects = create_project_allocation(
                 project, allocation_amount)
             allocation_objects.allocation.start_date = \
@@ -88,7 +88,7 @@ class TestJobList(TestJobBase):
         for i in range(self.num_users):
             user = User.objects.get(username=f'user{i}')
             project = Project.objects.get(
-                name=f'PROJECT_{i // self.num_projects}')
+                name=f'fc_project_{i // self.num_projects}')
             status = ProjectUserStatusChoice.objects.get(name='Active')
             ProjectUser.objects.create(
                 user=user, project=project, role=role, status=status)
@@ -212,9 +212,9 @@ class TestJobList(TestJobBase):
         self.assert_results(url, status_code, count)
         # PROJECT_0 submitted 4 jobs.
         try:
-            account = Project.objects.get(name='PROJECT_0')
+            account = Project.objects.get(name='fc_project_0')
         except Project.DoesNotExist:
-            self.fail('A Project with name "PROJECT_0" should exist.')
+            self.fail('A Project with name "fc_project_0" should exist.')
         url = TestJobList.get_url(account=account.name)
         status_code, count = 200, 4
         results_dict = self.assert_results(url, status_code, count)

--- a/coldfront/core/project/management/commands/projects.py
+++ b/coldfront/core/project/management/commands/projects.py
@@ -1,0 +1,241 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.management import CommandError
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from flags.state import flag_enabled
+
+from coldfront.core.allocation.models import Allocation
+from coldfront.core.allocation.models import AllocationAttribute
+from coldfront.core.allocation.models import AllocationAttributeType
+from coldfront.core.allocation.models import AllocationStatusChoice
+from coldfront.core.project.models import Project
+from coldfront.core.project.models import ProjectStatusChoice
+from coldfront.core.project.models import ProjectUser
+from coldfront.core.project.models import ProjectUserRoleChoice
+from coldfront.core.project.models import ProjectUserStatusChoice
+from coldfront.core.project.utils import is_primary_cluster_project
+from coldfront.core.project.utils_.new_project_user_utils import NewProjectUserRunnerFactory
+from coldfront.core.project.utils_.new_project_user_utils import NewProjectUserSource
+from coldfront.core.resource.models import Resource
+from coldfront.core.resource.utils import get_primary_compute_resource_name
+from coldfront.core.statistics.models import ProjectTransaction
+from coldfront.core.utils.common import add_argparse_dry_run_argument
+from coldfront.core.utils.common import display_time_zone_current_date
+from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.email.email_strategy import DropEmailStrategy
+
+import logging
+
+
+"""An admin command for managing projects."""
+
+
+class Command(BaseCommand):
+
+    help = 'Manage projects.'
+    logger = logging.getLogger(__name__)
+
+    def add_arguments(self, parser):
+        """Define subcommands with different functions."""
+        subparsers = parser.add_subparsers(
+            dest='subcommand',
+            help='The subcommand to run.',
+            title='subcommands')
+        subparsers.required = True
+        self._add_create_subparser(subparsers)
+
+    def handle(self, *args, **options):
+        """Call the handler for the provided subcommand."""
+        subcommand = options['subcommand']
+        if subcommand == 'create':
+            self._handle_create(*args, **options)
+
+    @staticmethod
+    def _add_create_subparser(parsers):
+        """Add a subparser for the 'create' subcommand."""
+        parser = parsers.add_parser(
+            'create',
+            help=(
+                'Create a project with an allocation to a particular compute '
+                'resource. Note: The current use case for this is to create a '
+                'project for a newly-created standalone cluster. It cannot be '
+                'used to create projects under the primary cluster (e.g., '
+                'Savio on BRC, Lawrencium on LRC), under a standalone '
+                'cluster that (a) can have at most one project and (b) '
+                'already has a project, or, for BRC, under the Vector '
+                'project.'))
+        parser.add_argument(
+            'name', help='The name of the project to create.', type=str)
+        parser.add_argument(
+            'cluster_name',
+            help=(
+                'The name of a cluster, for which a compute resource (e.g., '
+                '"{cluster_name} Compute") should exist.'))
+        parser.add_argument(
+            'pi_username',
+            help='The username of the user to make the project\'s PI.',
+            type=str)
+        add_argparse_dry_run_argument(parser)
+
+    @staticmethod
+    def _create_project_with_compute_allocation_and_pi(project_name,
+                                                       compute_resource,
+                                                       pi_user):
+        """Create a Project with the given name, with an Allocation to
+        the given compute Resource, and with the given User as a
+        Principal Investigator. Return the Project.
+
+        Some fields are set by default:
+            - The Project's status is 'Active'.
+            - The ProjectUser's status is 'Active'.
+            - The Allocation's status is 'Active'.
+            - The Allocation's start_date is today.
+            - The Allocation's end_date is None.
+            - The Allocation has the maximum number of service units.
+
+        TODO: When the command is generalized, allow these to be
+         specified.
+        """
+        with transaction.atomic():
+            project = Project.objects.create(
+                name=project_name,
+                title=project_name,
+                status=ProjectStatusChoice.objects.get(name='Active'))
+
+            project_user = ProjectUser.objects.create(
+                project=project,
+                user=pi_user,
+                role=ProjectUserRoleChoice.objects.get(
+                    name='Principal Investigator'),
+                status=ProjectUserStatusChoice.objects.get(name='Active'))
+
+            allocation = Allocation.objects.create(
+                project=project,
+                status=AllocationStatusChoice.objects.get(name='Active'),
+                start_date=display_time_zone_current_date(),
+                end_date=None)
+            allocation.resources.add(compute_resource)
+
+            num_service_units = settings.ALLOCATION_MAX
+            AllocationAttribute.objects.create(
+                allocation_attribute_type=AllocationAttributeType.objects.get(
+                    name='Service Units'),
+                allocation=allocation,
+                value=str(num_service_units))
+
+            ProjectTransaction.objects.create(
+                project=project,
+                date_time=utc_now_offset_aware(),
+                allocation=num_service_units)
+
+            runner_factory = NewProjectUserRunnerFactory()
+            runner = runner_factory.get_runner(
+                project_user, NewProjectUserSource.AUTO_ADDED,
+                email_strategy=DropEmailStrategy())
+            runner.run()
+
+            pi_user.userprofile.is_pi = True
+            pi_user.userprofile.save()
+
+        return project
+
+    def _handle_create(self, *args, **options):
+        """Handle the 'create' subcommand."""
+        cleaned_options = self._validate_create_options(options)
+        project_name = cleaned_options['project_name']
+        compute_resource = cleaned_options['compute_resource']
+        pi_user = cleaned_options['pi_user']
+
+        message_template = (
+            f'{{0}} Project "{project_name}" with Allocation to '
+            f'"{compute_resource.name}" Resource under PI '
+            f'"{pi_user.username}".')
+        if options['dry_run']:
+            message = message_template.format('Would create')
+            self.stdout.write(self.style.WARNING(message))
+            return
+
+        try:
+            self._create_project_with_compute_allocation_and_pi(
+                project_name, compute_resource, pi_user)
+        except Exception as e:
+            message = message_template.format('Failed to create')
+            self.stderr.write(self.style.ERROR(message))
+            self.logger.exception(f'{message}\n{e}')
+        else:
+            message = message_template.format('Created')
+            self.stdout.write(self.style.SUCCESS(message))
+            self.logger.info(message)
+
+    @staticmethod
+    def _validate_create_options(options):
+        """Validate the options provided to the 'create' subcommand.
+        Raise a subcommand if any are invalid or if they violate
+        business logic, else return a dict of the form:
+            {
+                'project_name': 'project_name',
+                'compute_resource': Resource,
+                'pi_user': User,
+            }
+        """
+        project_name = options['name'].lower()
+        if Project.objects.filter(name=project_name).exists():
+            raise CommandError(
+                f'A Project with name "{project_name}" already exists.')
+
+        cluster_name = options['cluster_name']
+        lowercase_cluster_name = cluster_name.lower()
+        uppercase_cluster_name = cluster_name.upper()
+
+        # TODO: When the command is generalized, enforce business logic re:
+        #  the number of certain projects a PI may have.
+        pi_username = options['pi_username']
+        try:
+            pi_user = User.objects.get(username=pi_username)
+        except User.DoesNotExist:
+            raise CommandError(
+                f'User with username "{pi_username}" does not exist.')
+
+        lowercase_primary_cluster_name = get_primary_compute_resource_name(
+            ).replace(' Compute', '').lower()
+        is_cluster_primary = (
+            lowercase_cluster_name == lowercase_primary_cluster_name)
+        if (is_primary_cluster_project(Project(name=project_name)) or
+                is_cluster_primary):
+            raise CommandError(
+                'This command may not be used to create a Project under the '
+                'primary cluster.')
+
+        # On BRC, also prevent a project from being created for the Vector
+        # cluster.
+        if flag_enabled('BRC_ONLY'):
+            # TODO: As noted in the add_accounting_defaults management command,
+            #  'Vector' should be fully-uppercase in its Resource name. Update
+            #  this when that is the case.
+            capitalized_cluster_name = cluster_name.capitalize()
+            if capitalized_cluster_name == 'Vector':
+                raise CommandError(
+                    f'This command may not be used to create a Project under '
+                    f'the {uppercase_cluster_name} cluster.')
+
+        try:
+            compute_resource = Resource.objects.get(
+                name=f'{uppercase_cluster_name} Compute')
+        except Resource.DoesNotExist:
+            raise CommandError(
+                f'Cluster {uppercase_cluster_name} does not exist.')
+
+        # TODO: When the command is generalized, allow the project name to
+        #  differ from the cluster name (within expected bounds).
+        if project_name != lowercase_cluster_name:
+            raise CommandError(
+                f'This command may not be used to create a Project whose name '
+                f'differs from the cluster name.')
+
+        return {
+            'project_name': project_name,
+            'compute_resource': compute_resource,
+            'pi_user': pi_user,
+        }

--- a/coldfront/core/project/tests/test_utils/test_project_removal_request_runners.py
+++ b/coldfront/core/project/tests/test_utils/test_project_removal_request_runners.py
@@ -71,7 +71,7 @@ class TestRemovalRequestRunnerBase(TestBase):
 
         # Create Projects.
         self.project1 = Project.objects.create(
-            name='project1', status=active_project_status)
+            name='fc_project1', status=active_project_status)
 
         # add pis
         for pi_user in [self.pi1, self.pi2]:

--- a/coldfront/core/project/tests/test_utils/test_renewal_utils/test_allocation_renewal_approval_runner.py
+++ b/coldfront/core/project/tests/test_utils/test_renewal_utils/test_allocation_renewal_approval_runner.py
@@ -159,8 +159,8 @@ class TestUnpooledToUnpooled(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.unpooled_project0,
-            post_project=self.unpooled_project0)
+            pre_project=self.fc_unpooled_project0,
+            post_project=self.fc_unpooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -182,8 +182,8 @@ class TestUnpooledToPooled(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.unpooled_project0,
-            post_project=self.pooled_project1)
+            pre_project=self.fc_unpooled_project0,
+            post_project=self.fc_pooled_project1)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -205,8 +205,8 @@ class TestPooledToPooledSame(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.pooled_project0,
-            post_project=self.pooled_project0)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_pooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -228,8 +228,8 @@ class TestPooledToPooledDifferent(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.pooled_project0,
-            post_project=self.pooled_project1)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_pooled_project1)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -251,8 +251,8 @@ class TestPooledToUnpooledOld(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.pooled_project0,
-            post_project=self.unpooled_project0)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_unpooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -276,7 +276,7 @@ class TestPooledToUnpooledNew(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.pooled_project0,
+            pre_project=self.fc_pooled_project0,
             post_project=new_project_request.project,
             new_project_request=new_project_request)
 

--- a/coldfront/core/project/tests/test_utils/test_renewal_utils/test_allocation_renewal_denial_runner.py
+++ b/coldfront/core/project/tests/test_utils/test_renewal_utils/test_allocation_renewal_denial_runner.py
@@ -152,8 +152,8 @@ class TestUnpooledToUnpooled(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.unpooled_project0,
-            post_project=self.unpooled_project0)
+            pre_project=self.fc_unpooled_project0,
+            post_project=self.fc_unpooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -175,8 +175,8 @@ class TestUnpooledToPooled(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.unpooled_project0,
-            post_project=self.pooled_project1)
+            pre_project=self.fc_unpooled_project0,
+            post_project=self.fc_pooled_project1)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -198,8 +198,8 @@ class TestPooledToPooledSame(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.pooled_project0,
-            post_project=self.pooled_project0)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_pooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -221,8 +221,8 @@ class TestPooledToPooledDifferent(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.pooled_project0,
-            post_project=self.pooled_project1)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_pooled_project1)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -244,8 +244,8 @@ class TestPooledToUnpooledOld(TestRunnerMixin, TestCase):
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.pooled_project0,
-            post_project=self.unpooled_project0)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_unpooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -269,7 +269,7 @@ class TestPooledToUnpooledNew(TestNewProjectDenialMixin, TestRunnerMixin,
                 name='Under Review'),
             computing_allowance=self.computing_allowance,
             pi=self.pi0,
-            pre_project=self.pooled_project0,
+            pre_project=self.fc_pooled_project0,
             post_project=new_project_request.project,
             new_project_request=new_project_request)
 

--- a/coldfront/core/project/tests/test_utils/test_renewal_utils/test_allocation_renewal_processing_runner.py
+++ b/coldfront/core/project/tests/test_utils/test_renewal_utils/test_allocation_renewal_processing_runner.py
@@ -1049,8 +1049,8 @@ class TestUnpooledToUnpooled(TestFutureRequestsUpdateMixin, TestRunnerMixin,
                 name='Approved'),
             pi=self.pi0,
             computing_allowance=self.computing_allowance,
-            pre_project=self.unpooled_project0,
-            post_project=self.unpooled_project0)
+            pre_project=self.fc_unpooled_project0,
+            post_project=self.fc_unpooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -1073,8 +1073,8 @@ class TestUnpooledToPooled(TestFutureRequestsUpdateMixin, TestRunnerMixin,
                 name='Approved'),
             pi=self.pi0,
             computing_allowance=self.computing_allowance,
-            pre_project=self.unpooled_project0,
-            post_project=self.pooled_project1)
+            pre_project=self.fc_unpooled_project0,
+            post_project=self.fc_pooled_project1)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -1097,8 +1097,8 @@ class TestPooledToPooledSame(TestFutureRequestsUpdateMixin, TestRunnerMixin,
                 name='Approved'),
             pi=self.pi0,
             computing_allowance=self.computing_allowance,
-            pre_project=self.pooled_project0,
-            post_project=self.pooled_project0)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_pooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -1122,8 +1122,8 @@ class TestPooledToPooledDifferent(TestFutureRequestsUpdateMixin,
                 name='Approved'),
             pi=self.pi0,
             computing_allowance=self.computing_allowance,
-            pre_project=self.pooled_project0,
-            post_project=self.pooled_project1)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_pooled_project1)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -1146,8 +1146,8 @@ class TestPooledToUnpooledOld(TestFutureRequestsUpdateMixin,
                 name='Approved'),
             pi=self.pi0,
             computing_allowance=self.computing_allowance,
-            pre_project=self.pooled_project0,
-            post_project=self.unpooled_project0)
+            pre_project=self.fc_pooled_project0,
+            post_project=self.fc_unpooled_project0)
 
     def test_pooling_preference_case(self):
         """Test that the pooling preference case for the class' renewal
@@ -1172,7 +1172,7 @@ class TestPooledToUnpooledNew(TestFutureRequestsUpdateMixin,
                 name='Approved'),
             pi=self.pi0,
             computing_allowance=self.computing_allowance,
-            pre_project=self.pooled_project0,
+            pre_project=self.fc_pooled_project0,
             post_project=new_project_request.project,
             new_project_request=new_project_request)
 

--- a/coldfront/core/project/tests/test_utils/test_renewal_utils/utils.py
+++ b/coldfront/core/project/tests/test_utils/test_renewal_utils/utils.py
@@ -101,21 +101,21 @@ class TestRunnerMixinBase(object):
             name='Principal Investigator')
 
         # Create Projects.
-        self.unpooled_project0 = Project.objects.create(
-            name='unpooled_project0', status=active_project_status)
-        self.unpooled_project1 = Project.objects.create(
-            name='unpooled_project1', status=inactive_project_status)
-        self.pooled_project0 = Project.objects.create(
-            name='pooled_project0', status=active_project_status)
-        self.pooled_project1 = Project.objects.create(
-            name='pooled_project1', status=active_project_status)
+        self.fc_unpooled_project0 = Project.objects.create(
+            name='fc_unpooled_project0', status=active_project_status)
+        self.fc_unpooled_project1 = Project.objects.create(
+            name='fc_unpooled_project1', status=inactive_project_status)
+        self.fc_pooled_project0 = Project.objects.create(
+            name='fc_pooled_project0', status=active_project_status)
+        self.fc_pooled_project1 = Project.objects.create(
+            name='fc_pooled_project1', status=active_project_status)
 
         # Add the designated PIs to each Project.
         self.projects_and_pis = {
-            self.unpooled_project0: [self.pi0],
-            self.unpooled_project1: [self.pi1],
-            self.pooled_project0: [self.pi0, self.pi1],
-            self.pooled_project1: [self.pi2, self.pi3],
+            self.fc_unpooled_project0: [self.pi0],
+            self.fc_unpooled_project1: [self.pi1],
+            self.fc_pooled_project0: [self.pi0, self.pi1],
+            self.fc_pooled_project1: [self.pi2, self.pi3],
         }
         for project, pi_users in self.projects_and_pis.items():
             for pi_user in pi_users:
@@ -208,7 +208,7 @@ class TestRunnerMixinBase(object):
         """Create a new Project, a corresponding 'CLUSTER_NAME Compute'
         Allocation, and an 'Under Review' new project request for it."""
         # Create a new Project.
-        new_project_name = 'unpooled_project2'
+        new_project_name = 'fc_unpooled_project2'
         new_project_status = ProjectStatusChoice.objects.get(name='New')
         new_project = Project.objects.create(
             name=new_project_name,

--- a/coldfront/core/user/tests/test_views/test_request_hub_view.py
+++ b/coldfront/core/user/tests/test_views/test_request_hub_view.py
@@ -69,16 +69,16 @@ class TestRequestHubView(TestBase):
         for i in range(2):
             # Create a Project and ProjectUsers.
             project = Project.objects.create(
-                name=f'project{i}', status=project_status)
-            setattr(self, f'project{i}', project)
+                name=f'fc_project{i}', status=project_status)
+            setattr(self, f'fc_project{i}', project)
             proj_user = ProjectUser.objects.create(
                 user=self.user0, project=project,
                 role=user_role, status=project_user_status)
-            setattr(self, f'project{i}_user0', proj_user)
+            setattr(self, f'fc_project{i}_user0', proj_user)
             pi_proj_user = ProjectUser.objects.create(
                 user=self.pi, project=project, role=manager_role,
                 status=project_user_status)
-            setattr(self, f'project{i}_pi', pi_proj_user)
+            setattr(self, f'fc_project{i}_pi', pi_proj_user)
 
             # Create a compute allocation for the Project.
             allocation = Decimal(f'{i + 1}000.00')
@@ -213,9 +213,9 @@ class TestRequestHubView(TestBase):
 
         # creating two cluster access requests for user0
         allocation_obj = \
-            get_accounting_allocation_objects(self.project0)
+            get_accounting_allocation_objects(self.fc_project0)
         allocation_user_obj = \
-            get_accounting_allocation_objects(self.project0, self.user0)
+            get_accounting_allocation_objects(self.fc_project0, self.user0)
 
         kwargs = {
             'allocation_user': allocation_user_obj.allocation_user,
@@ -287,8 +287,8 @@ class TestRequestHubView(TestBase):
         current_time = utc_now_offset_aware()
 
         kwargs = {
-            'project_user': self.project0_user0,
-            'requester': self.project0_pi.user,
+            'project_user': self.fc_project0_user0,
+            'requester': self.fc_project0_pi.user,
             'request_time': current_time,
         }
         pending_req = ProjectUserRemovalRequest.objects.create(
@@ -350,7 +350,7 @@ class TestRequestHubView(TestBase):
             'requester': self.user0,
             'allocation_type': 'FCA',
             'pi': self.pi,
-            'project': self.project0,
+            'project': self.fc_project0,
             'pool': False,
             'survey_answers': savio_project_request_state_schema()
         }
@@ -416,7 +416,7 @@ class TestRequestHubView(TestBase):
         kwargs = {
             'requester': self.user0,
             'pi': self.pi,
-            'project': self.project0,
+            'project': self.fc_project0,
             'state': vector_project_request_state_schema()
         }
 
@@ -483,14 +483,14 @@ class TestRequestHubView(TestBase):
             name='Pending - Add')
         user_role = ProjectUserRoleChoice.objects.get(name='User')
         pending_proj_user = ProjectUser.objects.create(
-            user=self.user1, project=self.project0,
+            user=self.user1, project=self.fc_project0,
             role=user_role, status=project_user_status)
 
         pending_req = ProjectUserJoinRequest.objects.create(
             project_user=pending_proj_user,
             reason='Request hub testing.')
         completed_req = ProjectUserJoinRequest.objects.create(
-            project_user=self.project0_user0,
+            project_user=self.fc_project0_user0,
             reason='Request hub testing.')
 
         # assert the correct requests are shown
@@ -546,8 +546,8 @@ class TestRequestHubView(TestBase):
             'pi': self.pi,
             'requester': self.user0,
             'allocation_period': get_current_allowance_year_period(),
-            'pre_project': self.project0,
-            'post_project': self.project0,
+            'pre_project': self.fc_project0,
+            'post_project': self.fc_project0,
             'num_service_units': 1000,
             'request_time': utc_now_offset_aware(),
             'state': allocation_renewal_request_state_schema()
@@ -612,7 +612,7 @@ class TestRequestHubView(TestBase):
         current_time = utc_now_offset_aware()
         kwargs = {
             'requester': self.pi,
-            'project': self.project0,
+            'project': self.fc_project0,
             'num_service_units': 1000,
             'request_time': current_time,
             'state': allocation_addition_request_state_schema()

--- a/coldfront/core/utils/management/commands/add_accounting_defaults.py
+++ b/coldfront/core/utils/management/commands/add_accounting_defaults.py
@@ -28,6 +28,8 @@ class Command(BaseCommand):
                 ('Savio Compute', 'Savio cluster compute access'),
                 ('Vector Compute', 'Vector cluster compute access'),
                 ('ABC Compute', 'ABC cluster compute access'),
+                ('SAVIO4_REFMLAB Compute',
+                 'SAVIO4_REFMLAB cluster compute access'),
             ],
             'LRC_ONLY': [
                 ('ALICE Compute', 'ALICE cluster compute access'),

--- a/coldfront/core/utils/tests/test_export_data.py
+++ b/coldfront/core/utils/tests/test_export_data.py
@@ -53,8 +53,8 @@ class TestBaseExportData(TestBase):
 
         # Create a Project and ProjectUsers.
         project = Project.objects.create(
-            name='project0', status=project_status)
-        setattr(self, 'project0', project)
+            name='fc_project0', status=project_status)
+        setattr(self, 'fc_project0', project)
         for j in range(2):
             ProjectUser.objects.create(
                 user=getattr(self, f'user{j}'), project=project,
@@ -72,7 +72,7 @@ class TestBaseExportData(TestBase):
         self.cluster_account_status = AllocationAttributeType.objects.get(
             name='Cluster Account Status')
 
-        allocation_object = get_accounting_allocation_objects(self.project0)
+        allocation_object = get_accounting_allocation_objects(self.fc_project0)
         for j, project_user in enumerate(project.projectuser_set.all()):
             if project_user.role.name != 'User':
                 continue
@@ -289,7 +289,7 @@ class TestNewClusterAccounts(TestBaseExportData):
 
         allocation_user_attr_obj = AllocationUserAttribute.objects.get(
             allocation_attribute_type=self.cluster_account_status,
-            allocation__project__name='project0',
+            allocation__project__name='fc_project0',
             allocation_user__user__username='user0',
             value='Active')
 
@@ -347,7 +347,7 @@ class TestNewClusterAccounts(TestBaseExportData):
 
         allocation_user_attr_obj = AllocationUserAttribute.objects.get(
             allocation_attribute_type=self.cluster_account_status,
-            allocation__project__name='project0',
+            allocation__project__name='fc_project0',
             allocation_user__user__username='user0',
             value='Active')
 


### PR DESCRIPTION
Fixes #496

**Changes**
- Updated the list of compute-related `Resources` to be created to include an entry for the new savio4_refmlab cluster.
- Modified the function for getting the name of the compute-related `Resource` for a particular `Project` to be more general.
- Added a management command `projects` with a `create` subcommand that allows a `Project` for a standalone cluster (e.g., savio4_refmlab) to be created.
    - The subcommand can be generalized in the future, and additional subcommands can be added.

**How to Test**
- Ensure that the test suite passes on GitHub Actions.