### PR TITLE
Avoid restarting services during playbook "common tasks"; enable critical services

### DIFF
--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -72,6 +72,8 @@
               - mod_ssl
             state: present
 
+        # Install and configure Redis.
+
         - name: Install redis
           yum:
             name:
@@ -84,6 +86,14 @@
             regexp: '^requirepass '
             insertafter: '^# requirepass foobared'
             line: 'requirepass {{ redis_passwd }}'
+
+        - name: Restart and enable Redis
+          service:
+            name: redis
+            state: restarted
+            enabled: true
+
+        # Install and configure Supervisord.
 
         - name: Install Supervisor
           yum:
@@ -113,6 +123,14 @@
             option: 'numprocs'
             value: '1'
 
+        - name: Restart and enable Supervisord
+          service:
+            name: supervisord
+            state: restarted
+            enabled: true
+
+        # Configure PostgreSQL.
+
         - name: Install Postgresql packages
           yum:
             name:
@@ -122,8 +140,6 @@
               - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-test-9.6.24-1PGDG.rhel7.x86_64.rpm'
               - 'https://download.postgresql.org/pub/repos/yum/9.6/redhat/rhel-7-x86_64/postgresql96-server-9.6.24-1PGDG.rhel7.x86_64.rpm'
             state: present
-
-        # Configure PostgreSQL.
 
         - name: Check if PostgreSQL is initialized
           stat:
@@ -437,25 +453,23 @@
             src: "{{ git_prefix }}/{{ reponame }}/bootstrap/ansible/password_reset_subject_template.tmpl"
             dest: "{{ git_prefix }}/{{ reponame }}/{{ djangoprojname }}/core/user/templates/user/passwords/password_reset_subject.txt"
 
-        # Restart Services.
+        # Ensure services are updated and running. Avoid restarting them to
+        # avoid disruptions to operations.
 
-        - name: Restart and enable Redis service
+        - name: Ensure that Redis service is running
           service:
             name: redis
-            state: restarted
-            enabled: yes
+            state: started
 
-        - name: Restart and enable Supervisor service
+        - name: Ensure that Supervisord service is running
           service:
             name: supervisord
-            state: restarted
-            enabled: yes
+            state: started
 
-        - name: Restart and enable PostgreSQL service
+        - name: Reload PostgreSQL service
           service:
             name: postgresql-9.6
-            state: restarted
-            enabled: yes
+            state: reloaded
 
         # Install Django application dependencies
 
@@ -556,6 +570,8 @@
             mode: "u=rwX,g=rX,o=rX"
             group: apache
 
+        # Gracefully restart Apache so that processes handle current requests
+        # before being replaced by a new process.
         - name: Reload httpd service
           service:
             name: httpd

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -453,23 +453,26 @@
             src: "{{ git_prefix }}/{{ reponame }}/bootstrap/ansible/password_reset_subject_template.tmpl"
             dest: "{{ git_prefix }}/{{ reponame }}/{{ djangoprojname }}/core/user/templates/user/passwords/password_reset_subject.txt"
 
-        # Ensure services are updated and running. Avoid restarting them to
-        # avoid disruptions to operations.
+        # Ensure services are updated, running, and enabled. Avoid restarting
+        # them to avoid disruptions to operations.
 
-        - name: Ensure that Redis service is running
+        - name: Ensure that Redis service is running and enabled
           service:
             name: redis
             state: started
+            enabled: true
 
-        - name: Ensure that Supervisord service is running
+        - name: Ensure that Supervisord service is running and enabled
           service:
             name: supervisord
             state: started
+            enabled: true
 
-        - name: Reload PostgreSQL service
+        - name: Ensure that PostgreSQL service is reloaded and enabled
           service:
             name: postgresql-9.6
             state: reloaded
+            enabled: true
 
         # Install Django application dependencies
 

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -576,6 +576,7 @@
           service:
             name: httpd
             state: reloaded
+            enabled: true
 
         # supervisorctl is included in community.general.
         - name: Ensure that a Supervisor worker is running a django_q cluster


### PR DESCRIPTION
**Changes**
- Updated the Ansible playbook so that:
    - Services are "started" or "reloaded" instead of "restarted" so that they can continue to handle requests during non-provisioning playbook runs.
    - All critical services are enabled (either during provisioning or common tasks).

**How to Test**
- Review the code changes and add comments as needed.