### PR TITLE
Remove edit icon from Project Detail View

### DIFF
--- a/coldfront/core/project/templates/project/project_detail.html
+++ b/coldfront/core/project/templates/project/project_detail.html
@@ -131,12 +131,6 @@ Project Detail
     <p class="card-text text-justify">
       <strong>Requests to Join: </strong>
       User requests to join the project must be approved by a PI.
-      {% if is_allowed_to_update_project %}
-        <a href="{% url 'project-update' project.pk %}">
-          <span class="accessibility-link-text">Update Project settings</span>
-          <i class="fas fa-edit" aria-hidden="true"></i>
-        </a>
-      {% endif %}
     </p>
   </div>
 </div>


### PR DESCRIPTION
Cherry picked from #504, by @jjung2-oxy.

**Changes**
- Removed the edit icon next to the "Requests to Join" section of the Project Detail View, since there is already an "Update Project Information" button that does the same thing.

**How to Test**
- Review the code changes and add comments as needed.
- Ensure that the test suite passes on GitHub Actions.
- Manual Testing
    - Ensure that the icon is no longer there.