### PR TITLE
Ensure users are directed to the correct page after clicking on a link and having to login

### DIFF
--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -55,11 +55,3 @@ if ('allauth.account.auth_backends.AuthenticationBackend' in
         ])
     for prefix, module_path in prefixes_and_module_paths:
         urlpatterns.append(path(prefix, include(module_path)))
-
-
-
-# TODO
-# NOTE: THE viz dir on the BRC repo has been updated. Copy it over.
-urlpatterns += [
-    path('viz/', include('coldfront.core.viz.urls')),
-]

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -55,3 +55,11 @@ if ('allauth.account.auth_backends.AuthenticationBackend' in
         ])
     for prefix, module_path in prefixes_and_module_paths:
         urlpatterns.append(path(prefix, include(module_path)))
+
+
+
+# TODO
+# NOTE: THE viz dir on the BRC repo has been updated. Copy it over.
+urlpatterns += [
+    path('viz/', include('coldfront.core.viz.urls')),
+]

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -1100,7 +1100,6 @@ class AllocationAttributeDeleteView(LoginRequiredMixin, UserPassesTestMixin, Tem
 
 class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     template_name = 'allocation/allocation_request_list.html'
-    login_url = '/'
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""
@@ -1121,7 +1120,6 @@ class AllocationRequestListView(LoginRequiredMixin, UserPassesTestMixin, Templat
 
 
 class AllocationActivateRequestView(LoginRequiredMixin, UserPassesTestMixin, View):
-    login_url = '/'
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""
@@ -1186,7 +1184,6 @@ class AllocationActivateRequestView(LoginRequiredMixin, UserPassesTestMixin, Vie
 
 
 class AllocationDenyRequestView(LoginRequiredMixin, UserPassesTestMixin, View):
-    login_url = '/'
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""

--- a/coldfront/core/allocation/views_/cluster_access_views.py
+++ b/coldfront/core/allocation/views_/cluster_access_views.py
@@ -128,7 +128,6 @@ class AllocationClusterAccountRequestListView(LoginRequiredMixin,
                                               UserPassesTestMixin,
                                               ListView):
     template_name = 'allocation/allocation_cluster_account_request_list.html'
-    login_url = '/'
     completed = False
     paginate_by = 30
     context_object_name = "cluster_request_list"
@@ -261,7 +260,6 @@ class AllocationClusterAccountUpdateStatusView(LoginRequiredMixin,
                                                UserPassesTestMixin,
                                                FormView):
     form_class = AllocationClusterAccountUpdateStatusForm
-    login_url = '/'
     template_name = (
         'allocation/allocation_update_cluster_account_status.html')
 
@@ -330,7 +328,6 @@ class AllocationClusterAccountActivateRequestView(LoginRequiredMixin,
                                                   UserPassesTestMixin,
                                                   FormView):
     form_class = AllocationClusterAccountRequestActivationForm
-    login_url = '/'
     template_name = (
         'allocation/allocation_activate_cluster_account_request.html')
 
@@ -428,7 +425,6 @@ class AllocationClusterAccountActivateRequestView(LoginRequiredMixin,
 class AllocationClusterAccountDenyRequestView(LoginRequiredMixin,
                                               UserPassesTestMixin,
                                               View):
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""

--- a/coldfront/core/allocation/views_/secure_dir_views.py
+++ b/coldfront/core/allocation/views_/secure_dir_views.py
@@ -782,7 +782,6 @@ class SecureDirRequestLandingView(LoginRequiredMixin,
 
     template_name = \
         'secure_dir/secure_dir_request/secure_dir_request_landing.html'
-    login_url = '/'
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -1067,7 +1066,6 @@ class SecureDirRequestListView(LoginRequiredMixin,
                                TemplateView):
 
     template_name = 'secure_dir/secure_dir_request/secure_dir_request_list.html'
-    login_url = '/'
     # Show completed requests if True; else, show pending requests.
     completed = False
 
@@ -1166,7 +1164,6 @@ class SecureDirRequestDetailView(LoginRequiredMixin,
     model = SecureDirRequest
     template_name = \
         'secure_dir/secure_dir_request/secure_dir_request_detail.html'
-    login_url = '/'
     context_object_name = 'secure_dir_request'
 
     logger = logging.getLogger(__name__)
@@ -1353,7 +1350,6 @@ class SecureDirRequestReviewRDMConsultView(LoginRequiredMixin,
     form_class = SecureDirRDMConsultationReviewForm
     template_name = (
         'secure_dir/secure_dir_request/secure_dir_consult_rdm.html')
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -1425,7 +1421,6 @@ class SecureDirRequestReviewMOUView(LoginRequiredMixin,
     form_class = ReviewStatusForm
     template_name = (
         'secure_dir/secure_dir_request/secure_dir_mou.html')
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -1493,7 +1488,6 @@ class SecureDirRequestReviewSetupView(LoginRequiredMixin,
     form_class = SecureDirSetupForm
     template_name = (
         'secure_dir/secure_dir_request/secure_dir_setup.html')
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -1568,7 +1562,6 @@ class SecureDirRequestReviewDenyView(LoginRequiredMixin, UserPassesTestMixin,
     form_class = ReviewDenyForm
     template_name = (
         'secure_dir/secure_dir_request/secure_dir_review_deny.html')
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -1631,7 +1624,6 @@ class SecureDirRequestUndenyRequestView(LoginRequiredMixin,
                                         UserPassesTestMixin,
                                         SecureDirRequestMixin,
                                         View):
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""

--- a/coldfront/core/grant/views.py
+++ b/coldfront/core/grant/views.py
@@ -198,7 +198,6 @@ class GrantReportView(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
 
 class GrantDownloadView(LoginRequiredMixin, UserPassesTestMixin, View):
-    login_url = "/"
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -1210,7 +1210,6 @@ def project_update_email_notification(request):
 
 class ProjectReviewView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
     template_name = 'project/project_review.html'
-    login_url = "/"  # redirect URL if fail test_func
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""
@@ -1320,7 +1319,6 @@ class ProjectReviewListView(LoginRequiredMixin, UserPassesTestMixin, ListView):
 
 
 class ProjectReviewCompleteView(LoginRequiredMixin, UserPassesTestMixin, View):
-    login_url = "/"
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""
@@ -1354,7 +1352,6 @@ class ProjectReviewCompleteView(LoginRequiredMixin, UserPassesTestMixin, View):
 class ProjectReivewEmailView(LoginRequiredMixin, UserPassesTestMixin, FormView):
     form_class = ProjectReviewEmailForm
     template_name = 'project/project_review_email.html'
-    login_url = "/"
 
     def test_func(self):
         """ UserPassesTestMixin Tests"""

--- a/coldfront/core/project/views_/addition_views/approval_views.py
+++ b/coldfront/core/project/views_/addition_views/approval_views.py
@@ -40,7 +40,6 @@ class AllocationAdditionRequestDetailView(LoginRequiredMixin,
 
     model = AllocationAdditionRequest
     template_name = 'project/project_allocation_addition/request_detail.html'
-    login_url = '/'
     context_object_name = 'addition_request'
 
     request_obj = None
@@ -196,7 +195,6 @@ class AllocationAdditionRequestListView(LoginRequiredMixin,
     Service Units under Projects."""
 
     template_name = 'project/project_allocation_addition/request_list.html'
-    login_url = '/'
     completed = False
 
     def get_context_data(self, **kwargs):
@@ -271,7 +269,6 @@ class AllocationAdditionReviewBase(LoginRequiredMixin, UserPassesTestMixin,
     """A base class for views for reviewing an
     AllocationAdditionRequest."""
 
-    login_url = '/'
 
     error_message = 'Unexpected failure. Please contact an administrator.'
     request_obj = None

--- a/coldfront/core/project/views_/addition_views/request_views.py
+++ b/coldfront/core/project/views_/addition_views/request_views.py
@@ -44,7 +44,6 @@ class AllocationAdditionRequestLandingView(LoginRequiredMixin,
     Recharge."""
 
     template_name = 'project/project_allocation_addition/request_landing.html'
-    login_url = '/'
 
     project_obj = None
 
@@ -131,7 +130,6 @@ class AllocationAdditionRequestView(LoginRequiredMixin, UserPassesTestMixin,
 
     form_class = SavioProjectRechargeExtraFieldsForm
     template_name = 'project/project_allocation_addition/request_form.html'
-    login_url = '/'
 
     project_obj = None
 

--- a/coldfront/core/project/views_/join_views/request_views.py
+++ b/coldfront/core/project/views_/join_views/request_views.py
@@ -35,7 +35,6 @@ logger = logging.getLogger(__name__)
 
 
 class ProjectJoinView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
-    login_url = '/'
 
     logger = logging.getLogger(__name__)
 

--- a/coldfront/core/project/views_/new_project_views/approval_views.py
+++ b/coldfront/core/project/views_/new_project_views/approval_views.py
@@ -56,7 +56,6 @@ import logging
 
 class SavioProjectRequestListView(LoginRequiredMixin, TemplateView):
     template_name = 'project/project_request/savio/project_request_list.html'
-    login_url = '/'
     # Show completed requests if True; else, show pending requests.
     completed = False
 
@@ -196,7 +195,6 @@ class SavioProjectRequestDetailView(LoginRequiredMixin, UserPassesTestMixin,
                                     SavioProjectRequestMixin, DetailView):
     model = SavioProjectAllocationRequest
     template_name = 'project/project_request/savio/project_request_detail.html'
-    login_url = '/'
 
     logger = logging.getLogger(__name__)
 
@@ -484,7 +482,6 @@ class SavioProjectReviewEligibilityView(LoginRequiredMixin,
     form_class = ReviewStatusForm
     template_name = (
         'project/project_request/savio/project_review_eligibility.html')
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -552,7 +549,6 @@ class SavioProjectReviewReadinessView(LoginRequiredMixin, UserPassesTestMixin,
     form_class = ReviewStatusForm
     template_name = (
         'project/project_request/savio/project_review_readiness.html')
-    login_url = '/'
 
     logger = logging.getLogger(__name__)
 
@@ -630,7 +626,6 @@ class SavioProjectReviewMemorandumSignedView(LoginRequiredMixin,
     form_class = MemorandumSignedForm
     template_name = (
         'project/project_request/savio/project_review_memorandum_signed.html')
-    login_url = '/'
 
     logger = logging.getLogger(__name__)
 
@@ -699,7 +694,6 @@ class SavioProjectReviewSetupView(LoginRequiredMixin, UserPassesTestMixin,
                                   SavioProjectRequestMixin, FormView):
     form_class = SavioProjectReviewSetupForm
     template_name = 'project/project_request/savio/project_review_setup.html'
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -785,7 +779,6 @@ class SavioProjectReviewDenyView(LoginRequiredMixin, UserPassesTestMixin,
     form_class = ReviewDenyForm
     template_name = (
         'project/project_request/savio/project_review_deny.html')
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -844,7 +837,6 @@ class SavioProjectReviewDenyView(LoginRequiredMixin, UserPassesTestMixin,
 
 class SavioProjectUndenyRequestView(LoginRequiredMixin, UserPassesTestMixin,
                                     SavioProjectRequestMixin, View):
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -905,7 +897,6 @@ class SavioProjectUndenyRequestView(LoginRequiredMixin, UserPassesTestMixin,
 
 class VectorProjectRequestListView(LoginRequiredMixin, TemplateView):
     template_name = 'project/project_request/vector/project_request_list.html'
-    login_url = '/'
     # Show completed requests if True; else, show pending requests.
     completed = False
 
@@ -995,7 +986,6 @@ class VectorProjectRequestDetailView(LoginRequiredMixin, UserPassesTestMixin,
     model = VectorProjectAllocationRequest
     template_name = (
         'project/project_request/vector/project_request_detail.html')
-    login_url = '/'
     context_object_name = 'vector_request'
 
     logger = logging.getLogger(__name__)
@@ -1125,7 +1115,6 @@ class VectorProjectReviewEligibilityView(LoginRequiredMixin,
     form_class = ReviewStatusForm
     template_name = (
         'project/project_request/vector/project_review_eligibility.html')
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -1190,7 +1179,6 @@ class VectorProjectReviewSetupView(LoginRequiredMixin, UserPassesTestMixin,
                                    VectorProjectRequestMixin, FormView):
     form_class = VectorProjectReviewSetupForm
     template_name = 'project/project_request/vector/project_review_setup.html'
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -1272,7 +1260,6 @@ class VectorProjectReviewSetupView(LoginRequiredMixin, UserPassesTestMixin,
 
 class VectorProjectUndenyRequestView(LoginRequiredMixin, UserPassesTestMixin,
                                      VectorProjectRequestMixin, View):
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""

--- a/coldfront/core/project/views_/new_project_views/request_views.py
+++ b/coldfront/core/project/views_/new_project_views/request_views.py
@@ -645,7 +645,6 @@ class VectorProjectRequestView(LoginRequiredMixin, UserPassesTestMixin,
                                FormView):
     form_class = VectorProjectDetailsForm
     template_name = 'project/project_request/vector/project_details.html'
-    login_url = '/'
 
     logger = logging.getLogger(__name__)
 

--- a/coldfront/core/project/views_/removal_views.py
+++ b/coldfront/core/project/views_/removal_views.py
@@ -203,7 +203,6 @@ class ProjectRemovalRequestListView(LoginRequiredMixin,
                                     UserPassesTestMixin,
                                     ListView):
     template_name = 'project/project_removal/project_removal_request_list.html'
-    login_url = '/'
     completed = False
     paginate_by = 30
     context_object_name = "project_removal_request_list"
@@ -345,7 +344,6 @@ class ProjectRemovalRequestListView(LoginRequiredMixin,
 class ProjectRemovalRequestUpdateStatusView(LoginRequiredMixin,
                                             UserPassesTestMixin, FormView):
     form_class = ProjectRemovalRequestUpdateStatusForm
-    login_url = '/'
     template_name = \
         'project/project_removal/project_removal_request_update_status.html'
 
@@ -408,7 +406,6 @@ class ProjectRemovalRequestCompleteStatusView(LoginRequiredMixin,
                                               UserPassesTestMixin,
                                               FormView):
     form_class = ProjectRemovalRequestCompletionForm
-    login_url = '/'
     template_name = \
         'project/project_removal/project_removal_request_complete_status.html'
 

--- a/coldfront/core/project/views_/renewal_views/approval_views.py
+++ b/coldfront/core/project/views_/renewal_views/approval_views.py
@@ -43,7 +43,6 @@ logger = logging.getLogger(__name__)
 
 class AllocationRenewalRequestListView(LoginRequiredMixin, TemplateView):
     template_name = 'project/project_renewal/project_renewal_request_list.html'
-    login_url = '/'
     completed = False
 
     def get_queryset(self):
@@ -138,7 +137,6 @@ class AllocationRenewalRequestDetailView(LoginRequiredMixin,
     model = AllocationRenewalRequest
     template_name = (
         'project/project_renewal/project_renewal_request_detail.html')
-    login_url = '/'
 
     error_message = 'Unexpected failure. Please contact an administrator.'
     request_obj = None
@@ -335,7 +333,6 @@ class AllocationRenewalRequestReviewEligibilityView(LoginRequiredMixin,
                                                     FormView):
     form_class = ReviewStatusForm
     template_name = 'project/project_renewal/review_eligibility.html'
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -411,7 +408,6 @@ class AllocationRenewalRequestReviewDenyView(LoginRequiredMixin,
                                              FormView):
     form_class = ReviewDenyForm
     template_name = 'project/project_renewal/review_deny.html'
-    login_url = '/'
 
     def test_func(self):
         """UserPassesTestMixin tests."""
@@ -488,7 +484,6 @@ class AllocationRenewalRequestReviewDenyView(LoginRequiredMixin,
 #                                          UserPassesTestMixin,
 #                                          AllocationRenewalRequestMixin,
 #                                          View):
-#     login_url = '/'
 #
 #     def test_func(self):
 #         """UserPassesTestMixin tests."""

--- a/coldfront/core/statistics/views.py
+++ b/coldfront/core/statistics/views.py
@@ -29,7 +29,6 @@ DATE_FORMAT = '%m/%d/%Y, %H:%M:%S'
 class SlurmJobListView(LoginRequiredMixin,
                        ListView):
     template_name = 'job_list.html'
-    login_url = '/'
     paginate_by = 30
     context_object_name = 'job_list'
 

--- a/coldfront/core/user/views.py
+++ b/coldfront/core/user/views.py
@@ -865,7 +865,6 @@ class UpdatePrimaryEmailAddressView(LoginRequiredMixin, FormView):
 
     form_class = PrimaryEmailAddressSelectionForm
     template_name = 'user/user_update_primary_email_address.html'
-    login_url = '/'
 
     error_message = 'Unexpected failure. Please contact an administrator.'
 
@@ -946,7 +945,6 @@ class UserNameExistsView(View):
 
 @method_decorator(login_required, name='dispatch')
 class IdentityLinkingRequestView(UserPassesTestMixin, View):
-    login_url = '/'
     pending_status = None
 
     def test_func(self):

--- a/coldfront/core/user/views.py
+++ b/coldfront/core/user/views.py
@@ -546,28 +546,46 @@ class CustomPasswordChangeView(PasswordChangeView):
 
 class UserLoginView(View):
     """Redirect to the Basic Auth. login view or the SSO login view
-    based on enabled flags."""
+    based on enabled flags, retaining any provided next URL. If the user
+    is authenticated, redirect to the next URL or the home page."""
 
     def dispatch(self, request, *args, **kwargs):
-        basic_auth_enabled = 'BASIC_AUTH_ENABLED'
-        if flag_enabled(basic_auth_enabled):
-            return redirect(reverse('basic-auth-login'))
-        sso_enabled = 'SSO_ENABLED'
-        if flag_enabled(sso_enabled):
-            return redirect(reverse('sso-login'))
-        raise ImproperlyConfigured(
-            f'One of the following flags must be enabled: '
-            f'{basic_auth_enabled}, {sso_enabled}.')
+        next_url = request.GET.get('next')
+
+        if request.user.is_authenticated:
+            return redirect(next_url or reverse('home'))
+
+        basic_auth_enabled = flag_enabled('BASIC_AUTH_ENABLED')
+        sso_enabled = flag_enabled('SSO_ENABLED')
+        if not basic_auth_enabled ^ sso_enabled:
+            raise ImproperlyConfigured(
+                'One of the following flags must be enabled: '
+                'BASIC_AUTH_ENABLED, SSO_ENABLED.')
+        if basic_auth_enabled:
+            redirect_url = reverse('basic-auth-login')
+        else:
+            redirect_url = reverse('sso-login')
+
+        if next_url:
+            redirect_url = self._url_with_next(redirect_url, next_url)
+        return redirect(redirect_url)
+
+    @staticmethod
+    def _url_with_next(url, next_url):
+        """Return the given URL, with a next parameter set to the given
+        next URL."""
+        return f'{url}?next={next_url}'
 
 
 class SSOLoginView(TemplateView):
     """Display the template for SSO login. If the user is authenticated,
-    redirect to the home page."""
+    redirect to the provided next URL or the home page."""
     template_name = 'user/sso_login.html'
 
     def dispatch(self, request, *args, **kwargs):
         if request.user.is_authenticated:
-            return redirect(reverse('home'))
+            redirect_url = request.GET.get('next') or reverse('home')
+            return redirect(redirect_url)
         return super().dispatch(request, *args, **kwargs)
 
 


### PR DESCRIPTION
Fixes #406

**Changes**
- Updated the login view:
    - If the user is already authenticated, redirect to the provided `next` URL (or the home page).
    - Otherwise, redirect to the Basic Auth. or SSO login page, propagating the provided `next` URL so that the user is redirected there after login.
- Removed `login_url` across all views, so that unauthenticated users are always redirected to the login view, with `next` set to the view.

**How to Test**
- Ensure that the test suite passes on GitHub Actions.
- Manual Testing
    - This has been deployed to the staging servers.