### PR TITLE
Display correct SU amount on renewal request detail page for all allowance types

### DIFF
--- a/coldfront/core/project/views_/renewal_views/approval_views.py
+++ b/coldfront/core/project/views_/renewal_views/approval_views.py
@@ -110,9 +110,11 @@ class AllocationRenewalRequestMixin(object):
         num_service_units = Decimal(
             ComputingAllowanceInterface().service_units_from_name(
                 self.computing_allowance_obj.get_name()))
-        return prorated_allocation_amount(
-            num_service_units, self.request_obj.request_time,
-            self.allocation_period_obj)
+        if self.computing_allowance_obj.are_service_units_prorated():
+            num_service_units = prorated_allocation_amount(
+                num_service_units, self.request_obj.request_time,
+                self.allocation_period_obj)
+        return num_service_units
 
     def set_common_context_data(self, context):
         """Given a dictionary of context variables to include in the


### PR DESCRIPTION
Fixes #517

**Changes**
- Updated the method for getting the amount of SUs to allocate to a renewed project to only perform prorating for allowances to which prorating is applicable.
    - This resolves the issue with ICA renewals (generated on the back end) on MyBRC showing the wrong amount.
    - When ICA and PCA renewals on MyBRC are formally supported on the front end, the correct amount will be set in any created request (it would not have been prior to this change).