### PR TITLE
Fix error raised during SSO when first/last name not given by CILogon

### DIFF
--- a/coldfront/core/socialaccount/adapter.py
+++ b/coldfront/core/socialaccount/adapter.py
@@ -35,8 +35,8 @@ class CILogonAccountAdapter(DefaultSocialAccountAdapter):
             user_uid = 'unknown'
 
         if provider == 'cilogon':
-            first_name = data.get('first_name')
-            last_name = data.get('last_name')
+            first_name = data.get('first_name', '')
+            last_name = data.get('last_name', '')
             email = data.get('email')
 
             validated_email = valid_email_or_none(email)


### PR DESCRIPTION
Fixes #523

**Changes**
- Updated the logic for retrieving first/last name information from CILogon-provided data to default to the empty string instead of `None`, preventing the violation of a not-null constraint when creating a `User`.