### PR TITLE
Require Django SECRET_KEY to be configured for each deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,15 @@ of variables used by Ansible to configure the system.
    ```
    cp bootstrap/ansible/main.copyme main.yml
    ```
-7. Customize `main.yml`. In particular, uncomment everything under the `dev_settings` section, and fill in the below variables. Note
+7. Generate a key to be used as the `SECRET_KEY` for Django.
+   ```
+   # This produces two lines: condense them into one.
+   openssl rand -base64 64
+   ```
+8. Customize `main.yml`. In particular, uncomment everything under the `dev_settings` section, and fill in the below variables. Note
 that quotes need not be provided, except in the list variable.
    ```
+   django_secret_key: secret_key_from_previous_step
    db_admin_passwd: password_here
    redis_passwd: password_here
    from_email: you@email.com
@@ -56,18 +62,18 @@ that quotes need not be provided, except in the list variable.
    email_admin_list: ["you@email.com"]
    request_approval_cc_list: ["you@email.com"]
    ```
-8. Provision the VM. This should run the Ansible playbook. Expect this to take
+9. Provision the VM. This should run the Ansible playbook. Expect this to take
 a few minutes on the first run.
    ```
    vagrant up
    ```
-9. SSH into the VM.
+10. SSH into the VM.
    ```
    vagrant ssh
    ```
-10. On the host machine, navigate to `http://localhost:8880`, where the
+11. On the host machine, navigate to `http://localhost:8880`, where the
 application should be served.
-11. (Optional) Load data from a database dump file.
+12. (Optional) Load data from a database dump file.
     ```
     # Clear the Django database to avoid conflicts.
     python manage.py sqlflush | python manage.py dbshell

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -18,6 +18,10 @@ djangoprojname: coldfront
 # BRC/LRC Config
 ###############################################################################
 
+# The secret key used by Django for cryptographic signing.
+# TODO: Generate one using: `openssl rand -base64 64`.
+django_secret_key:
+
 # The name of the PostgreSQL database.
 # TODO: For LRC, set this to 'cf_lrc_db'.
 db_name: cf_brc_db

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -3,6 +3,8 @@ import os
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = {{ debug }}
 
+SECRET_KEY = '{{ django_secret_key }}'
+
 ALLOWED_HOSTS = ['0.0.0.0', '{{ hostname }}', '{{ host_ip }}']
 
 PORTAL_NAME = '{{ portal_name }}'

--- a/coldfront/config/local_settings.py.sample
+++ b/coldfront/config/local_settings.py.sample
@@ -8,7 +8,9 @@ configure logging, and ColdFront plugins.
 # Secret Key -- Generate new key using: https://www.miniwebtool.com/django-secret-key-generator/
 # and replace
 #------------------------------------------------------------------------------
-SECRET_KEY = 'vtri&lztlbinerr4+yg1yzm23ez@+ub6=4*63z1%d!)fg(g4x$' # REPLACE
+# Instead of defining this here, it is imported from the deployment-specific
+# settings file below.
+# SECRET_KEY = 'vtri&lztlbinerr4+yg1yzm23ez@+ub6=4*63z1%d!)fg(g4x$' # REPLACE
 
 #------------------------------------------------------------------------------
 # Enable debugging. WARNING: These should be set to False in production
@@ -16,9 +18,9 @@ SECRET_KEY = 'vtri&lztlbinerr4+yg1yzm23ez@+ub6=4*63z1%d!)fg(g4x$' # REPLACE
 DEBUG = True
 DEVELOP = True
 
-if DEBUG is False and SECRET_KEY == 'vtri&lztlbinerr4+yg1yzm23ez@+ub6=4*63z1%d!)fg(g4x$':
-    from django.core.exceptions import ImproperlyConfigured
-    raise ImproperlyConfigured("The SECRET_KEY setting is using the preset value. Please update it!")
+# if DEBUG is False and SECRET_KEY == 'vtri&lztlbinerr4+yg1yzm23ez@+ub6=4*63z1%d!)fg(g4x$':
+#     from django.core.exceptions import ImproperlyConfigured
+#     raise ImproperlyConfigured("The SECRET_KEY setting is using the preset value. Please update it!")
 
 #------------------------------------------------------------------------------
 # Session settings


### PR DESCRIPTION
**Changes**
- Added an Ansible variable `django_secret_key` that configures the `SECRET_KEY` setting. It must be set in `main.copyme`.
- Updated `README.md` to describe how to generate a key.

**How to Test**
- Ensure that the test suite passes on Jenkins.

**Notes**
- The key has been rotated on production and staging machines.