### PR TITLE
Ensure that Supervisor and managed processes come up on boot and restart automatically

### DIFF
--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -262,6 +262,9 @@ sentry_dsn: ""
 # # The path to the parent directory containing the Git repository.
 # git_prefix: /vagrant/coldfront_app
 
+# The name of the Systemd unit responsible for mounting the codebase.
+codebase_mount_systemd_unit: vagrant-coldfront_app-coldfront.mount
+
 # # Host settings.
 # hostname: localhost
 # host_ip: localhost

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -105,6 +105,37 @@
             name: supervisor
             state: present
 
+        - name: Create a Systemd drop-in directory for overriding Supervisor configuration
+          file:
+            path: /etc/systemd/system/supervisord.service.d
+            state: directory
+            mode: 0755
+
+        - name: Create a Systemd drop-in file for overriding Supervisor configuration
+          file:
+            path: /etc/systemd/system/supervisord.service.d/override.conf
+            state: touch
+            mode: 0644
+
+        - name: Configure Systemd to only start Supervisor after the codebase has been mounted (dev only)
+          ini_file:
+            path: /etc/systemd/system/supervisord.service.d/override.conf
+            section: 'Unit'
+            option: 'After'
+            value: '{{ codebase_mount_systemd_unit }}'
+          when: codebase_mount_systemd_unit is defined
+
+        - name: Configure Systemd Supervisor ExecStop, ExecReload, and Restart behavior
+          ini_file:
+            path: /etc/systemd/system/supervisord.service.d/override.conf
+            section: 'Service'
+            option: '{{ item.option }}'
+            value: '{{ item.value }}'
+          with_items:
+            - { option: 'ExecStop', value: '/usr/bin/supervisorctl shutdown'}
+            - { option: 'ExecReload', value: '/usr/bin/supervisorctl reload'}
+            - { option: 'Restart', value: 'always'}
+
         # ini_file is included in community.general.
         - name: Set django_q command in supervisord.conf
           ini_file:
@@ -127,9 +158,17 @@
             option: 'numprocs'
             value: '1'
 
-        - name: Restart and enable Supervisord
-          service:
+        - name: Set django_q autorestart in supervisord.conf
+          ini_file:
+            path: /etc/supervisord.conf
+            section: 'program:django_q'
+            option: 'autorestart'
+            value: 'true'
+
+        - name: Reload, restart and enable Supervisord
+          systemd:
             name: supervisord
+            daemon_reload: true
             state: restarted
             enabled: true
 


### PR DESCRIPTION
**Changes**
- Adjusted Systemd behavior for Supervisor, via a drop-in file, so that it stops managed workers when stopped, reloads them when reloaded, and always restarts.
- In development environments, ensured that Supervisor only comes up after the repository has been mounted.
- Adjusted Supervisor configuration for `django_q` so that it always restarts.

**How to Test**
- Review the code changes and add comments as needed.
- Ensure that the test suite passes on GitHub Actions.
- Manual Testing
    - Add the new Ansible variable to `main.yml`.
    - Re-run the Ansible playbook.
    - Stop and restart the VM. Ensure that Supervisor and the processes it manages are up.
    - Stop Supervisor and ensure that its managed processes are also stopped.