### PR TITLE
Consider eppn field when identifying users during CILogon auth; refactor and add tests for auth logic

### DIFF
--- a/coldfront/core/socialaccount/adapter.py
+++ b/coldfront/core/socialaccount/adapter.py
@@ -1,6 +1,5 @@
 from allauth.account.models import EmailAddress
 from allauth.account.utils import user_email as user_email_func
-from allauth.account.utils import user_field
 from allauth.account.utils import user_username
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter

--- a/coldfront/core/socialaccount/adapter.py
+++ b/coldfront/core/socialaccount/adapter.py
@@ -4,13 +4,14 @@ from allauth.account.utils import user_field
 from allauth.account.utils import user_username
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
-from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers.base import AuthProcess
 from allauth.utils import valid_email_or_none
 from coldfront.core.account.utils.login_activity import LoginActivityVerifier
 from coldfront.core.utils.context_processors import portal_and_program_names
 from collections import defaultdict
 from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.http import HttpResponseBadRequest
 from django.http import HttpResponseServerError
 from django.template.loader import render_to_string
@@ -46,15 +47,16 @@ class CILogonAccountAdapter(DefaultSocialAccountAdapter):
             user_uid = 'unknown'
 
         if provider == 'cilogon':
-            first_name = data.get('first_name', '')
-            last_name = data.get('last_name', '')
+            first_name = data.get('first_name')
+            last_name = data.get('last_name')
             email = data.get('email')
+            name = data.get('name')
 
             validated_email = valid_email_or_none(email)
             if not validated_email:
                 log_message = (
                     f'Provider {provider} did not provide an email address '
-                    f'for User with UID {user_uid}.')
+                    f'for user with UID {user_uid}.')
                 logger.error(log_message)
                 self._raise_server_error(self._get_auth_error_message())
             validated_email = validated_email.lower()
@@ -62,8 +64,9 @@ class CILogonAccountAdapter(DefaultSocialAccountAdapter):
             user = sociallogin.user
             user_username(user, validated_email)
             user_email_func(user, validated_email)
-            user_field(user, 'first_name', first_name)
-            user_field(user, 'last_name', last_name)
+            name_parts = (name or '').partition(' ')
+            user_field(user, 'first_name', first_name or name_parts[0])
+            user_field(user, 'last_name', last_name or name_parts[2])
             return user
 
         return super().populate_user(request, sociallogin, data)
@@ -80,52 +83,260 @@ class CILogonAccountAdapter(DefaultSocialAccountAdapter):
         return url
 
     def pre_social_login(self, request, sociallogin):
-        """At this point, the user is authenticated by a provider. If
-        the provider is not CILogon, do nothing. Otherwise, if this
-        provider account is not connected to a local account, attempt to
-        connect them. In particular, if there is a User with a verified
-        EmailAddress matching one of those given by the provider,
-        connect the two accounts.
+        """At this point, the user is authenticated by a provider.
+            - Log the user in if the provider is already connected to
+              a local User.
+            - If possible, connect to a single local User based on
+              provider-given information, raising errors as needed.
+            - If the user is wholly now, create a new local User.
 
         Note that login is blocked outside (after) this method if the
-        user is inactive.
+        local User is inactive.
 
         Adapted from:
         https://github.com/pennersr/django-allauth/issues/418#issuecomment-137259550
+
+        Parameters:
+            - request: HTTP request object
+            - sociallogin: django-allauth SocialLogin object
+
+        Returns: None
+
+        Raises:
+            - ImmediateHttpResponse (bad request or server error)
         """
-        # Attempt to retrieve identifying information for logging purposes.
-        try:
-            provider = sociallogin.account.provider
-        except AttributeError:
-            provider = 'unknown'
-        try:
-            user_uid = sociallogin.account.uid
-        except AttributeError:
-            user_uid = 'unknown'
-        try:
-            user_email = sociallogin.user.email
-        except AttributeError:
-            user_email = 'unknown'
+        provider = sociallogin.account.provider
+        user_uid = sociallogin.account.uid
+        user_email = sociallogin.user.email
 
         # Do nothing if the provider is not CILogon.
         if provider != 'cilogon':
             return
 
-        # If users are not allowed to have multiple emails, and the user is
-        # attempting to connect another SocialAccount to their account (as
-        # opposed to logging in with an existing one), raise an error.
+        # If users are not allowed to have multiple emails, block new
+        # SocialAccount connections to existing local accounts.
         if not self._flag_multiple_email_addresses_allowed:
-            if sociallogin.state.get('process', None) == AuthProcess.CONNECT:
-                message = (
-                    'You may not connect more than one third-party account to '
-                    'your portal account.')
-                self._raise_client_error(message)
+            self._block_social_account_connection(sociallogin)
 
         # If a SocialAccount already exists, meaning the provider account is
         # connected to a local account, proceed with login.
         if sociallogin.is_existing:
             return
 
+        # Try to identify a single user from EmailAddresses, based on
+        # information given by the provider, along with the identifying
+        # addresses.
+        user, addresses = self._identify_user_and_email_addresses(
+            sociallogin, provider, user_email, user_uid)
+
+        # No single User could be identified. Proceed with sign up.
+        if user is None:
+            return
+
+        # A single User could be identified, but all email addresses used to do
+        # so were unverified. Block the login and request email verification.
+        if not any([a.verified for a in addresses]):
+            self._block_login_for_verification(
+                request, sociallogin, provider, user, user_email, user_uid,
+                addresses)
+
+        # A single User could be identified from at least one verified email
+        # address. Connect to that User.
+        self._connect_user(
+            request, sociallogin, provider, user, user_email, user_uid)
+
+    def _block_login_for_verification(self, request, sociallogin, provider,
+                                      user, user_email, user_uid,
+                                      email_addresses):
+        """Block the login attempt and send verification emails to the
+        given EmailAddresses."""
+        log_message = (
+            f'Found only unverified email addresses associated with local User '
+            f'{user.pk} matching those given by provider {provider} for user '
+            f'with email {user_email} and UID {user_uid}.')
+        logger.warning(log_message)
+
+        try:
+            cilogon_idp = sociallogin.serialize()[
+                'account']['extra_data']['idp_name']
+            request_login_method_str = f'CILogon - {cilogon_idp}'
+        except Exception as e:
+            logger.exception(f'Failed to determine CILogon IDP. Details:\n{e}')
+            request_login_method_str = 'CILogon'
+        for email_address in email_addresses:
+            verifier = LoginActivityVerifier(
+                request, email_address, request_login_method_str)
+            verifier.send_email()
+
+        message = (
+            'You are attempting to log in using an email address associated '
+            'with an existing user, but it is unverified. Please check the '
+            'address for a verification email.')
+        self._raise_client_error(message)
+
+    def _block_social_account_connection(self, sociallogin):
+        """Raise a client error if the user is attempting to connect
+        another SocialAccount to their account (as opposed to logging in
+        with an existing one)."""
+        if sociallogin.state.get('process', None) == AuthProcess.CONNECT:
+            message = (
+                'You may not connect more than one third-party account to your '
+                'portal account.')
+            self._raise_client_error(message)
+
+    @staticmethod
+    def _connect_user(request, sociallogin, provider, user, user_email,
+                      user_uid):
+        """Connect the provider account to the User's account in the
+        database."""
+        sociallogin.connect(request, user)
+        log_message = (
+            f'Successfully connected data for user with email {user_email} and '
+            f'UID {user_uid} from provider {provider} to local User {user.pk}.')
+        logger.info(log_message)
+
+    @staticmethod
+    def _get_auth_error_message():
+        """Return the generic message the user should receive if
+        authentication-related errors occur."""
+        return (
+            f'Unexpected authentication error. Please contact '
+            f'{settings.CENTER_HELP_EMAIL} for further assistance.')
+
+    def _identify_user_and_email_addresses(self, sociallogin, provider,
+                                           user_email, user_uid):
+        """Attempt to identify a single existing User from
+        provider-given email information. If able, return the User and a
+        list of EmailAddress objects used to identify it, else (None,
+        None). Raise a server error in some unexpected cases."""
+        user_by_email, user_by_email_email_addresses = \
+            self._identify_user_by_email(
+                sociallogin, provider, user_email, user_uid)
+        user_by_eppn, user_by_eppn_email_addresses = \
+            self._identify_user_by_eppn(sociallogin)
+
+        if user_by_email and user_by_eppn:
+            if user_by_email.pk != user_by_eppn.pk:
+                log_message = (
+                    f'Found two different local Users from information '
+                    f'provided by provider {provider} for user with email '
+                    f'{user_email} and UID {user_uid} (email lookup: '
+                    f'{user_by_email.pk}, eppn lookup: {user_by_eppn.pk}).')
+                logger.error(log_message)
+                self._raise_server_error(self._get_auth_error_message())
+            else:
+                # The sets of EmailAddresses used to identify the user may be
+                # different, so return their union.
+                all_email_addresses = list(
+                    set.union(
+                        set(user_by_email_email_addresses),
+                        set(user_by_eppn_email_addresses)))
+                return user_by_email, all_email_addresses
+        elif user_by_email:
+            return user_by_email, user_by_email_email_addresses
+        elif user_by_eppn:
+            eppn = user_by_eppn_email_addresses[0].email
+            log_message = (
+                f'Found a local User ({user_by_eppn.pk}) from eppn ({eppn}), '
+                f'and not from emails, provided by provider {provider} for '
+                f'user with email {user_email} and UID {user_uid}.')
+            logger.warning(log_message)
+            return user_by_eppn, user_by_eppn_email_addresses
+        return None, None
+
+    def _identify_user_by_email(self, sociallogin, provider, user_email,
+                                user_uid):
+        """Attempt to identify a User using provider-given EmailAddress
+        objects.
+            - 0 identified: return None, None.
+            - 1 identified: return the User and a list of the matching
+              EmailAddress objects.
+            - 2+ identified: raise a server error."""
+        verified_provider_addresses = self._validate_provider_email_addresses(
+            sociallogin, provider, user_email, user_uid)
+
+        # Fetch EmailAddresses matching those given by the provider, divided by
+        # the associated User.
+        matching_addresses_by_user = defaultdict(set)
+        for address in verified_provider_addresses:
+            try:
+                email_address = EmailAddress.objects.get(
+                    email__iexact=address.email)
+            except EmailAddress.DoesNotExist:
+                continue
+            matching_addresses_by_user[email_address.user].add(email_address)
+
+        if not matching_addresses_by_user:
+            return None, None
+        elif len(matching_addresses_by_user) == 1:
+            user = next(iter(matching_addresses_by_user))
+            addresses = matching_addresses_by_user[user]
+            return user, addresses
+        else:
+            user_pks = sorted([user.pk for user in matching_addresses_by_user])
+            log_message = (
+                f'Unexpectedly found multiple Users ([{", ".join(user_pks)}]) '
+                f'that had email addresses matching those provided by '
+                f'provider {provider} for user with email {user_email} and '
+                f'UID {user_uid}.')
+            logger.error(log_message)
+            self._raise_server_error(self._get_auth_error_message())
+
+    @staticmethod
+    def _identify_user_by_eppn(sociallogin):
+        """Attempt to identify a User using an "eppn" field potentially
+        given by the provider.
+            - 0 identified: return None, None.
+            - 1 identified: return the User and a single-item list
+              containing the matching EmailAddress object
+
+        There are no guarantees that the "eppn" field is a valid email
+        address, even if it is in the format of an email address. Only
+        if it matches an existing EmailAddress object can it be assumed
+        that it is a valid address."""
+        login_extra_data = sociallogin.serialize()['account']['extra_data']
+        if 'eppn' not in login_extra_data:
+            return None, None
+        eppn = login_extra_data['eppn'].lower()
+
+        try:
+            validate_email(eppn)
+        except ValidationError:
+            return None, None
+
+        try:
+            email_address = EmailAddress.objects.get(email=eppn)
+        except EmailAddress.DoesNotExist:
+            return None, None
+
+        return email_address.user, [email_address]
+
+    def _raise_client_error(self, message):
+        """Raise an ImmediateHttpResponse with a client error and the
+        given message."""
+        self._raise_error(HttpResponseBadRequest, message)
+
+    @staticmethod
+    def _raise_error(response_class, message):
+        """Raise an ImmediateHttpResponse with an error HttpResponse
+        class (e.g., HttpResponseBadRequest or HttpResponseServerError)
+        error and the given message."""
+        template = 'error_with_message.html'
+        context = {'message': message, **portal_and_program_names(None)}
+        html = render_to_string(template, context=context)
+        response = response_class(html)
+        raise ImmediateHttpResponse(response)
+
+    def _raise_server_error(self, message):
+        """Raise an ImmediateHttpResponse with a server error and the
+        given message."""
+        self._raise_error(HttpResponseServerError, message)
+
+    def _validate_provider_email_addresses(self, sociallogin, provider,
+                                           user_email, user_uid):
+        """Process email addresses given by the provider. Raise a server
+        error if none are given, or if none are verified. Raise a list
+        of verified addresses."""
         provider_addresses = sociallogin.email_addresses
         num_provider_addresses = len(provider_addresses)
         # If the provider does not provide any addresses, raise an error.
@@ -158,110 +369,4 @@ class CILogonAccountAdapter(DefaultSocialAccountAdapter):
             logger.error(log_message)
             self._raise_server_error(self._get_auth_error_message())
 
-        # Fetch EmailAddresses matching those given by the provider, divided by
-        # the associated User.
-        matching_addresses_by_user = defaultdict(set)
-        for address in verified_provider_addresses:
-            try:
-                email_address = EmailAddress.objects.get(
-                    email__iexact=address.email)
-            except EmailAddress.DoesNotExist:
-                continue
-            matching_addresses_by_user[email_address.user].add(email_address)
-
-        # If no Users were found, proceed with signup. If exactly one was
-        # found, perform further checks. If more than one was found, raise an
-        # error.
-        if not matching_addresses_by_user:
-            return
-        elif len(matching_addresses_by_user) == 1:
-            user = next(iter(matching_addresses_by_user))
-            addresses = matching_addresses_by_user[user]
-            if any([a.verified for a in addresses]):
-                # After this, allauth.account.adapter.pre_login blocks login if
-                # the user is inactive. Regardless of that, connect the user
-                # (and trigger signals for creating EmailAddresses).
-                self._connect_user(
-                    request, sociallogin, provider, user, user_email, user_uid)
-            else:
-                self._block_login_for_verification(
-                    request, sociallogin, provider, user, user_email, user_uid,
-                    addresses)
-        else:
-            user_pks = sorted([user.pk for user in matching_addresses_by_user])
-            log_message = (
-                f'Unexpectedly found multiple Users ([{", ".join(user_pks)}]) '
-                f'that had email addresses matching those provided by '
-                f'provider {provider} for User with email {user_email} and '
-                f'UID {user_uid}.')
-            logger.error(log_message)
-            self._raise_server_error(self._get_auth_error_message())
-
-    def _block_login_for_verification(self, request, sociallogin, provider,
-                                      user, user_email, user_uid,
-                                      email_addresses):
-        """Block the login attempt and send verification emails to the
-        given EmailAddresses."""
-        log_message = (
-            f'Found only unverified email addresses associated with local User '
-            f'{user.pk} matching those given by provider {provider} for User '
-            f'with email {user_email} and UID {user_uid}.')
-        logger.warning(log_message)
-
-        try:
-            cilogon_idp = sociallogin.serialize()[
-                'account']['extra_data']['idp_name']
-            request_login_method_str = f'CILogon - {cilogon_idp}'
-        except Exception as e:
-            logger.exception(f'Failed to determine CILogon IDP. Details:\n{e}')
-            request_login_method_str = 'CILogon'
-        for email_address in email_addresses:
-            verifier = LoginActivityVerifier(
-                request, email_address, request_login_method_str)
-            verifier.send_email()
-
-        message = (
-            'You are attempting to log in using an email address associated '
-            'with an existing user, but it is unverified. Please check the '
-            'address for a verification email.')
-        self._raise_client_error(message)
-
-    @staticmethod
-    def _connect_user(request, sociallogin, provider, user, user_email,
-                      user_uid):
-        """Connect the provider account to the User's account in the
-        database."""
-        sociallogin.connect(request, user)
-        log_message = (
-            f'Successfully connected data for User with email {user_email} and '
-            f'UID {user_uid} from provider {provider} to local User {user.pk}.')
-        logger.info(log_message)
-
-    @staticmethod
-    def _get_auth_error_message():
-        """Return the generic message the user should receive if
-        authentication-related errors occur."""
-        return (
-            f'Unexpected authentication error. Please contact '
-            f'{settings.CENTER_HELP_EMAIL} for further assistance.')
-
-    def _raise_client_error(self, message):
-        """Raise an ImmediateHttpResponse with a client error and the
-        given message."""
-        self._raise_error(HttpResponseBadRequest, message)
-
-    @staticmethod
-    def _raise_error(response_class, message):
-        """Raise an ImmediateHttpResponse with an error HttpResponse
-        class (e.g., HttpResponseBadRequest or HttpResponseServerError)
-        error and the given message."""
-        template = 'error_with_message.html'
-        context = {'message': message, **portal_and_program_names(None)}
-        html = render_to_string(template, context=context)
-        response = response_class(html)
-        raise ImmediateHttpResponse(response)
-
-    def _raise_server_error(self, message):
-        """Raise an ImmediateHttpResponse with a server error and the
-        given message."""
-        self._raise_error(HttpResponseServerError, message)
+        return verified_provider_addresses

--- a/coldfront/core/socialaccount/signals.py
+++ b/coldfront/core/socialaccount/signals.py
@@ -22,18 +22,22 @@ def handle_social_account_added_or_updated(sender, **kwargs):
     """When a SocialAccount (previously-connected or otherwise) is
     connected to a user's local account, create or update EmailAddress
     instances for the addresses given by the provider, setting them as
-    verified."""
+    verified.
+
+    During sign up, SocialLogin.save() handles EmailAddress creation.
+    However, they are not created/updated when connecting SocialAccounts
+    to existing users (using AuthProcess.CONNECT or by manually calling
+    SocialLogin.connect), so they are created/updated here."""
     request = kwargs['request']
     social_login = kwargs['sociallogin']
-    if social_login.state['process'] == AuthProcess.CONNECT:
-        try:
-            set_verified_email_addresses_from_social_login(social_login)
-        except Exception as e:
-            message = (
-                'Failed to automatically create verified email addresses '
-                'from the connected account. Please do so in the User '
-                'Profile.')
-            messages.error(request, message)
+    try:
+        set_verified_email_addresses_from_social_login(social_login)
+    except Exception as e:
+        message = (
+            'Failed to automatically create verified email addresses '
+            'from the connected account. Please do so in the User '
+            'Profile.')
+        messages.error(request, message)
 
 
 def set_verified_email_addresses_from_social_login(social_login):

--- a/coldfront/core/socialaccount/tests/test_cilogon_account_adapter.py
+++ b/coldfront/core/socialaccount/tests/test_cilogon_account_adapter.py
@@ -1,0 +1,527 @@
+from copy import deepcopy
+from http import HTTPStatus
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.contrib.auth import get_user
+from django.contrib.auth.models import User
+from django.core import mail
+from django.core.validators import validate_email
+from django.test import override_settings
+from django.urls import reverse
+from django.utils.http import urlencode
+
+from allauth.account.models import EmailAddress
+from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.providers.base import AuthProcess
+from allauth.tests import MockedResponse
+from allauth.tests import mocked_response
+from flags.state import disable_flag
+from flags.state import enable_flag
+from flags.state import flag_enabled
+
+from coldfront.core.utils.tests.test_base import TestBase
+
+import json
+
+
+class TestCILogonAccountAdapter(TestBase):
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+        enable_flag('SSO_ENABLED')
+        self._cilogon_provider = 'cilogon'
+        self._assert_authenticated(negate=True)
+
+    def _assert_authenticated(self, negate=False):
+        """Assert that the current client User is or is not
+        authenticated."""
+        client_user = get_user(self.client)
+        if not negate:
+            self.assertTrue(client_user.is_authenticated)
+        else:
+            self.assertFalse(client_user.is_authenticated)
+
+    def _assert_successful_cilogin_response(self, response,
+                                            process=AuthProcess.LOGIN):
+        """Assert that the given response, resulting from the given
+        CILogon process, redirects to the expected URL and has the
+        expected messages. Provide the username """
+        if process == AuthProcess.LOGIN:
+            expected_message = (
+                f'Successfully signed in as '
+                f'{response.wsgi_request.user.username}.')
+            redirect_url = reverse('home')
+        elif process == AuthProcess.CONNECT:
+            expected_message = 'The social account has been connected.'
+            redirect_url = reverse('socialaccount_connections')
+        else:
+            raise ValueError('Unexpected auth process.')
+        self.assertRedirects(response, redirect_url)
+        messages = self.get_message_strings(response)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0], expected_message)
+
+    @staticmethod
+    def _cilogon_user_data(email=None, eppn=None, given_name=None,
+                           family_name=None, idp_name=None, sub=None):
+        """Return a dict simulating user data returned by the CILogon
+        provider, with the given fields. If a field is not given, a
+        default is used."""
+        if email is None:
+            email = 'user@email.com'
+        if eppn is None:
+            eppn = 'user@email.com'
+        if given_name is None:
+            given_name = 'First'
+        if family_name is None:
+            family_name = 'Last'
+        if idp_name is None:
+            idp_name = 'Test University'
+        if sub is None:
+            sub = 'http://cilogon.org/serverA/users/1234567'
+        return {
+            'email': email,
+            'eppn': eppn,
+            'given_name': given_name,
+            'family_name': family_name,
+            'idp_name': idp_name,
+            'sub': sub,
+        }
+
+    @staticmethod
+    def _cilogon_login_url(process=AuthProcess.LOGIN):
+        """Return the URL for authenticating via CILogon. Optionally
+        override the allauth AuthProcess."""
+        return f'{reverse("cilogon_login")}?{urlencode(dict(process=process))}'
+
+    def _simulate_cilogon_login(self, cilogon_user_data,
+                                process=AuthProcess.LOGIN):
+        """Simulate logging in with CILogon with a user having
+        attributes in the given dict.
+
+        Optionally override the allauth AuthProcess.
+
+        Adapted from allauth.socialaccount.tests.OAuth2TestsMixin.login.
+        """
+        response = self.client.post(self._cilogon_login_url(process=process))
+        p = urlparse(response['location'])
+        q = parse_qs(p.query)
+
+        headers = {'content-type': 'application/json'}
+        mock_cilogon_user_data_response = MockedResponse(
+            HTTPStatus.OK, json.dumps(cilogon_user_data), headers=headers)
+        login_response_json_str = {'uid': 'uid', 'access_token': 'access_token'}
+        mock_login_response = MockedResponse(
+            HTTPStatus.OK, json.dumps(login_response_json_str), headers=headers)
+
+        with mocked_response(
+                mock_login_response, mock_cilogon_user_data_response):
+            complete_url = reverse('cilogon_callback')
+            response = self.client.get(
+                complete_url, {'code': 'test', 'state': q['state'][0]},
+                follow=True)
+        return response
+
+    def test_connect_process_disallowed_if_flag_disabled(self):
+        """Test that, when the MULTIPLE_EMAIL_ADDRESSES_ALLOWED flag is
+        disabled, Users are not allowed to connect additional
+        SocialAccounts to an existing account."""
+        cilogon_user_data = self._cilogon_user_data()
+
+        # Sign up
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self._assert_successful_cilogin_response(response)
+
+        num_users = User.objects.count()
+        num_social_accounts = SocialAccount.objects.count()
+        num_email_addresses = EmailAddress.objects.count()
+
+        new_cilogon_user_data = self._cilogon_user_data(
+            email='newuser@email.com',
+            eppn='newuser@email.com',
+            idp_name='New Test University',
+            sub='http://cilogon.org/serverA/users/7654321')
+
+        flag_name = 'MULTIPLE_EMAIL_ADDRESSES_ALLOWED'
+
+        # Disabled
+        flags_copy = deepcopy(settings.FLAGS)
+        flags_copy[flag_name] = {'condition': 'boolean', 'value': False}
+        with override_settings(FLAGS=flags_copy):
+            disable_flag(flag_name)
+            self.assertFalse(flag_enabled(flag_name))
+            response = self._simulate_cilogon_login(
+                new_cilogon_user_data, process=AuthProcess.CONNECT)
+            self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+
+            expected_error_message = (
+                'You may not connect more than one third-party account to '
+                'your portal account.')
+            self.assertEqual(
+                response.context['message'], expected_error_message)
+
+            self.assertEqual(SocialAccount.objects.count(), num_social_accounts)
+
+        # Enabled
+        flags_copy[flag_name]['value'] = True
+        with override_settings(FLAGS=flags_copy):
+            enable_flag(flag_name)
+            self.assertTrue(flag_enabled(flag_name))
+            response = self._simulate_cilogon_login(
+                new_cilogon_user_data, process=AuthProcess.CONNECT)
+            self._assert_successful_cilogin_response(
+                response, process=AuthProcess.CONNECT)
+
+            self.assertEqual(User.objects.count(), num_users)
+            self.assertEqual(
+                SocialAccount.objects.count(), num_social_accounts + 1)
+            self.assertEqual(
+                EmailAddress.objects.count(), num_email_addresses + 1)
+
+    def test_no_user_identified(self):
+        """Test that, when no existing User could be identified from the
+        login information, a new one is created, along with associated
+        objects."""
+        self.assertEqual(User.objects.count(), 0)
+        self.assertEqual(SocialAccount.objects.count(), 0)
+        self.assertEqual(EmailAddress.objects.count(), 0)
+
+        cilogon_user_data = self._cilogon_user_data()
+        cilogon_user_data.pop('eppn')
+        email = cilogon_user_data['email'].lower()
+
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self._assert_successful_cilogin_response(response)
+
+        self.assertEqual(User.objects.count(), 1)
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            self.fail(f'A User with email {email} should exist.')
+        else:
+            self.assertEqual(user.username, email)
+            self.assertEqual(user.first_name, cilogon_user_data['given_name'])
+            self.assertEqual(user.last_name, cilogon_user_data['family_name'])
+
+        self.assertEqual(SocialAccount.objects.count(), 1)
+        try:
+            SocialAccount.objects.get(
+                user=user, uid=cilogon_user_data['sub'],
+                provider=self._cilogon_provider)
+        except SocialAccount.DoesNotExist:
+            self.fail(
+                f'A SocialAccount for User {user} should have been created.')
+
+        self.assertEqual(EmailAddress.objects.count(), 1)
+        try:
+            email_address = EmailAddress.objects.get(user=user, email=email)
+        except EmailAddress.DoesNotExist:
+            self.fail(f'An EmailAddress with email {email} should exist.')
+        else:
+            self.assertTrue(email_address.primary)
+            self.assertTrue(email_address.verified)
+
+        self._assert_authenticated()
+
+    def test_no_user_identified_invalid_eppn(self):
+        """Test that, when no existing User could be identified from the
+        login information, and the eppn given does not match a
+        EmailAddress, a new User is created, along with associated
+        objects."""
+        self.assertEqual(User.objects.count(), 0)
+
+        # An EmailAddress does not already exist for eppn.
+        eppn = 'user@subdomain.email.com'
+        validate_email(eppn)
+        self.assertFalse(EmailAddress.objects.filter(email=eppn).exists())
+
+        cilogon_user_data = self._cilogon_user_data(eppn=eppn)
+        email = cilogon_user_data['email'].lower()
+
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self._assert_successful_cilogin_response(response)
+
+        self.assertEqual(User.objects.count(), 1)
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            self.fail(f'A User with email {email} should exist.')
+        else:
+            self.assertEqual(user.username, email)
+            self.assertEqual(user.first_name, cilogon_user_data['given_name'])
+            self.assertEqual(user.last_name, cilogon_user_data['family_name'])
+
+        self.assertEqual(SocialAccount.objects.count(), 1)
+        try:
+            SocialAccount.objects.get(
+                user=user, uid=cilogon_user_data['sub'],
+                provider=self._cilogon_provider)
+        except SocialAccount.DoesNotExist:
+            self.fail(
+                f'A SocialAccount for User {user} should have been created.')
+
+        self.assertEqual(EmailAddress.objects.count(), 1)
+        try:
+            email_address = EmailAddress.objects.get(user=user, email=email)
+        except EmailAddress.DoesNotExist:
+            self.fail(f'An EmailAddress with email {email} should exist.')
+        else:
+            self.assertTrue(email_address.primary)
+            self.assertTrue(email_address.verified)
+
+        # An EmailAddress should not have been created for eppn.
+        self.assertFalse(EmailAddress.objects.filter(email=eppn).exists())
+
+        self._assert_authenticated()
+
+    def test_existent_social_account(self):
+        """Test that, when a matching SocialAccount already exists, the
+        User is signed in to the existing account."""
+        cilogon_user_data = self._cilogon_user_data()
+        email = cilogon_user_data['email'].lower()
+
+        self.assertFalse(EmailAddress.objects.filter(email=email).exists())
+
+        # Sign up
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self._assert_successful_cilogin_response(response)
+
+        self._assert_authenticated()
+
+        self.client.logout()
+
+        num_users = User.objects.count()
+        num_social_accounts = SocialAccount.objects.count()
+        num_email_addresses = EmailAddress.objects.count()
+
+        user = User.objects.get(email=email)
+        user.username = 'username'
+        user.save()
+        last_login = user.last_login
+
+        EmailAddress.objects.get(
+            user=user, email=email, verified=True, primary=True)
+
+        SocialAccount.objects.get(
+            user=user, uid=cilogon_user_data['sub'],
+            provider=self._cilogon_provider)
+
+        # Sign in
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self._assert_successful_cilogin_response(response)
+
+        self.assertEqual(User.objects.count(), num_users)
+        self.assertEqual(SocialAccount.objects.count(), num_social_accounts)
+        self.assertEqual(EmailAddress.objects.count(), num_email_addresses)
+
+        user.refresh_from_db()
+        self.assertGreater(user.last_login, last_login)
+
+        self._assert_authenticated()
+
+    def test_one_user_identified_via_email_and_eppn(self):
+        """Test that, when a single User is identified via both email
+        and eppn, the User is signed in to the existing account."""
+        email = 'user@email.com'
+        eppn = 'user@subdomain.email.com'
+        user = User.objects.create(username='username', email=email)
+        EmailAddress.objects.create(
+            user=user, email=email, verified=True, primary=True)
+        EmailAddress.objects.create(
+            user=user, email=eppn, verified=True, primary=False)
+
+        self.assertEqual(SocialAccount.objects.count(), 0)
+
+        cilogon_user_data = self._cilogon_user_data(email=email, eppn=eppn)
+
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self._assert_successful_cilogin_response(response)
+
+        try:
+            SocialAccount.objects.get(
+                user=user, uid=cilogon_user_data['sub'],
+                provider=self._cilogon_provider)
+        except SocialAccount.DoesNotExist:
+            self.fail(
+                f'A SocialAccount for User {user} should have been created.')
+
+        # A new User should not have been created.
+        self.assertEqual(User.objects.count(), 1)
+        # The number of EmailAddresses should not have increased.
+        self.assertEqual(EmailAddress.objects.count(), 2)
+
+        self._assert_authenticated()
+
+    def test_one_user_identified_via_email(self):
+        """Test that, when a single User is identified exclusively via
+        email, the User is signed in to the existing account."""
+        email = 'user@email.com'
+        eppn = 'user@subdomain.email.com'
+        user = User.objects.create(username='username', email=email)
+        EmailAddress.objects.create(
+            user=user, email=email, verified=True, primary=True)
+
+        self.assertEqual(SocialAccount.objects.count(), 0)
+
+        cilogon_user_data = self._cilogon_user_data(email=email, eppn=eppn)
+
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self._assert_successful_cilogin_response(response)
+
+        try:
+            SocialAccount.objects.get(
+                user=user, uid=cilogon_user_data['sub'],
+                provider=self._cilogon_provider)
+        except SocialAccount.DoesNotExist:
+            self.fail(
+                f'A SocialAccount for User {user} should have been created.')
+
+        # A new User should not have been created.
+        self.assertEqual(User.objects.count(), 1)
+        # The number of EmailAddresses should not have increased.
+        self.assertEqual(EmailAddress.objects.count(), 1)
+
+        # An EmailAddress should not have been created for eppn.
+        self.assertFalse(EmailAddress.objects.filter(email=eppn).exists())
+
+        self._assert_authenticated()
+
+    def test_one_user_identified_via_eppn(self):
+        """Test that, when a single User is identified exclusively via
+        eppn, the User is signed in to the existing account."""
+        email = 'user@email.com'
+        eppn = 'user@subdomain.email.com'
+        user = User.objects.create(username='username', email=eppn)
+        EmailAddress.objects.create(
+            user=user, email=eppn, verified=True, primary=True)
+
+        self.assertEqual(SocialAccount.objects.count(), 0)
+
+        cilogon_user_data = self._cilogon_user_data(email=email, eppn=eppn)
+
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self._assert_successful_cilogin_response(response)
+
+        try:
+            SocialAccount.objects.get(
+                user=user, uid=cilogon_user_data['sub'],
+                provider=self._cilogon_provider)
+        except SocialAccount.DoesNotExist:
+            self.fail(
+                f'A SocialAccount for User {user} should have been created.')
+
+        # A new User should not have been created.
+        self.assertEqual(User.objects.count(), 1)
+
+        # The number of EmailAddresses should have increased.
+        self.assertEqual(EmailAddress.objects.count(), 2)
+
+        # An EmailAddress should have been created for email.
+        self.assertTrue(
+            EmailAddress.objects.filter(
+                user=user, email=email, verified=True, primary=False).exists())
+
+        self._assert_authenticated()
+
+    def test_one_user_identified_but_inactive(self):
+        """Test that, when a single User is identified, but the User is
+        inactive, they are blocked from logging in, but database objects
+        related to the login are still created."""
+        email = 'user@email.com'
+        eppn = 'user@subdomain.email.com'
+        user = User.objects.create(username='username', email=eppn)
+        user.is_active = False
+        user.save()
+        EmailAddress.objects.create(
+            user=user, email=eppn, verified=True, primary=True)
+
+        self.assertEqual(SocialAccount.objects.count(), 0)
+
+        cilogon_user_data = self._cilogon_user_data(email=email, eppn=eppn)
+
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self.assertRedirects(response, reverse('account_inactive'))
+        self.assertContains(response, 'inactive user account')
+
+        try:
+            SocialAccount.objects.get(
+                user=user, uid=cilogon_user_data['sub'],
+                provider=self._cilogon_provider)
+        except SocialAccount.DoesNotExist:
+            self.fail(
+                f'A SocialAccount for User {user} should have been created.')
+
+        # A new User should not have been created.
+        self.assertEqual(User.objects.count(), 1)
+
+        # The number of EmailAddresses should have increased.
+        self.assertEqual(EmailAddress.objects.count(), 2)
+
+        # An EmailAddress should have been created for email.
+        self.assertTrue(
+            EmailAddress.objects.filter(
+                user=user, email=email, verified=True, primary=False).exists())
+
+        self._assert_authenticated(negate=True)
+
+    def test_two_users_identified_via_email_and_eppn(self):
+        """Test that, when two different Users are identified via email
+        and eppn, an error is raised."""
+        email = 'user@email.com'
+        email_user = User.objects.create(username='email_user', email=email)
+        EmailAddress.objects.create(
+            user=email_user, email=email, verified=True, primary=True)
+
+        eppn = 'user@subdomain.email.com'
+        eppn_user = User.objects.create(username='eppn_user', email=email)
+        EmailAddress.objects.create(
+            user=eppn_user, email=eppn, verified=True, primary=False)
+
+        self.assertEqual(SocialAccount.objects.count(), 0)
+
+        cilogon_user_data = self._cilogon_user_data(email=email, eppn=eppn)
+
+        response = self._simulate_cilogon_login(cilogon_user_data)
+        self.assertIn(
+            'Unexpected authentication error.', response.context['message'])
+
+        self.assertEqual(SocialAccount.objects.count(), 0)
+
+        self._assert_authenticated(negate=True)
+
+    def test_identifying_emails_all_unverified(self):
+        """Test that, when all the EmailAddresses used to identify the
+        User are unverified, """
+        email = 'user@email.com'
+        eppn = 'user@subdomain.email.com'
+        user = User.objects.create(username='username', email=email)
+        EmailAddress.objects.create(
+            user=user, email=email, verified=False, primary=True)
+        EmailAddress.objects.create(
+            user=user, email=eppn, verified=False, primary=False)
+
+        self.assertEqual(SocialAccount.objects.count(), 0)
+
+        cilogon_user_data = self._cilogon_user_data(email=email, eppn=eppn)
+
+        self.assertEqual(len(mail.outbox), 0)
+
+        response = self._simulate_cilogon_login(cilogon_user_data)
+
+        self.assertIn('unverified', response.context['message'])
+
+        self.assertEqual(len(mail.outbox), 2)
+        expected_from = settings.EMAIL_SENDER
+        expected_to = {email, eppn}
+        for email in mail.outbox:
+            self.assertEqual(email.from_email, expected_from)
+            self.assertEqual(len(email.to), 1)
+            to = email.to[0]
+            self.assertIn(to, expected_to)
+            expected_to.remove(to)
+            self.assertIn('has not been verified', email.body)
+
+        self._assert_authenticated(negate=True)


### PR DESCRIPTION
Refs #544

**Context**
- A Berkeley user may have both a base `@berkeley.edu` email address and a departmental email address.
- Consider a pre-existing portal user who:
    - Has a base `@berkeley.edu` email address associated with their portal account,
    - Has since added a departmental email address to their Berkeley account (not portal account), and
    - Has never logged in via CILogon (so does not have an existing `SocialAccount` object).
- When the user logs in via CalNet, CILogon provides the departmental address as the email. The system fails to look up a user with a matching `EmailAddress`, so it creates a new portal account, rather than connecting the user to their existing portal account.
- This pull request uses the fact that CILogon also provides an `eppn` field containing the base email address for Berkeley users. It uses this field as another means to connect users to existing portal accounts, handling the case above.

**Changes**
- Introduced a secondary way of identifying users: the `eppn` field given by CILogon.
    - If and only if the field matches an existing, verified `EmailAddress`, then connect to the associated user.
    - If a different user is identified from the email addresses given by the provider, raise an error.
- Refactored authentication logic across methods.
- Modified the inherited method for populating a `User` object from SSO-provided information to largely call parent class logic.
- Modified the signal for creating `EmailAddress` objects upon successful authentication to create them whenever a `SocialAccount` is created or updated (to cover the case where `SocialLogin.connect` is manually called).
- Added tests for CILogon authentication cases.

**How to Test**
- Ensure that the test suite passes on GitHub Actions.

**Notes**
- The `eppn` field appears to give the base email address for UC Berkeley users. However, `eppn` cannot be assumed to be an email address generally, so `EmailAddress` objects are _not_ created for them.
- Note that this does _not_ cover the case when a user has an existing portal account under a departmental email address, but then loses that address such that CalNet provides the base address during authentication.
    - Users who satisfy the above but who have also never logged in to the portal (and would therefore have a `SocailAccount` that could be identified) are expected to be rare.