### PR TITLE
Disable Django Debug Toolbar panels by default

### DIFF
--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -162,6 +162,22 @@ if DEBUG:
     hostname, _, ips = socket.gethostbyname_ex(socket.gethostname())
     INTERNAL_IPS = [ip[: ip.rfind('.')] + '.1' for ip in ips] + ['10.0.2.2']
 
+DISABLE_PANELS = {
+    'debug_toolbar.panels.history.HistoryPanel',
+    'debug_toolbar.panels.versions.VersionsPanel',
+    'debug_toolbar.panels.timer.TimerPanel',
+    'debug_toolbar.panels.settings.SettingsPanel',
+    'debug_toolbar.panels.headers.HeadersPanel',
+    'debug_toolbar.panels.request.RequestPanel',
+    'debug_toolbar.panels.sql.SQLPanel',
+    'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+    'debug_toolbar.panels.templates.TemplatesPanel',
+    'debug_toolbar.panels.cache.CachePanel',
+    'debug_toolbar.panels.signals.SignalsPanel',
+    'debug_toolbar.panels.redirects.RedirectsPanel',
+    'debug_toolbar.panels.profiling.ProfilingPanel',
+}
+
 #------------------------------------------------------------------------------
 # django-flags settings
 #------------------------------------------------------------------------------


### PR DESCRIPTION
Basically unchecking the toolbar panels by default. Performance is bad when they're on, so it helps if we can only turn the panels on when needed.