### PR TITLE
Add rudimentary command-line tool for merging two users

### DIFF
--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -233,6 +233,4 @@ def higher_project_user_role(role_1, role_2):
     assert role_2.name in roles_ascending
     role_1_index = roles_ascending.index(role_1.name)
     role_2_index = roles_ascending.index(role_2.name)
-    if roles_ascending[role_1_index] >= roles_ascending[role_2_index]:
-        return role_1
-    return role_2
+    return role_1 if role_1_index >= role_2_index else role_2

--- a/coldfront/core/project/utils.py
+++ b/coldfront/core/project/utils.py
@@ -7,6 +7,7 @@ from coldfront.core.allocation.utils import get_project_compute_resource_name
 from coldfront.core.allocation.utils_.accounting_utils import set_service_units
 from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectStatusChoice
+from coldfront.core.project.models import ProjectUserRoleChoice
 from coldfront.core.resource.utils import get_compute_resource_names
 from coldfront.core.resource.utils import get_primary_compute_resource_name
 from coldfront.core.utils.common import display_time_zone_current_date
@@ -220,3 +221,18 @@ def is_primary_cluster_project(project):
     project_compute_resource_name = get_project_compute_resource_name(project)
     primary_cluster_resource_name = get_primary_compute_resource_name()
     return project_compute_resource_name == primary_cluster_resource_name
+
+
+def higher_project_user_role(role_1, role_2):
+    """Given two ProjectUserRoleChoices, return the "higher" (more
+    privileged) of the two."""
+    assert isinstance(role_1, ProjectUserRoleChoice)
+    assert isinstance(role_2, ProjectUserRoleChoice)
+    roles_ascending = ['User', 'Manager', 'Principal Investigator']
+    assert role_1.name in roles_ascending
+    assert role_2.name in roles_ascending
+    role_1_index = roles_ascending.index(role_1.name)
+    role_2_index = roles_ascending.index(role_2.name)
+    if roles_ascending[role_1_index] >= roles_ascending[role_2_index]:
+        return role_1
+    return role_2

--- a/coldfront/core/user/management/commands/merge_users.py
+++ b/coldfront/core/user/management/commands/merge_users.py
@@ -63,18 +63,30 @@ class Command(BaseCommand):
             user_1, user_2, reporting_strategies=reporting_strategies)
 
         src_user = user_merge_runner.src_user
+        src_user_str = (
+            f'{src_user.username} ({src_user.pk}, {src_user.first_name} '
+            f'{src_user.last_name})')
         dst_user = user_merge_runner.dst_user
-        self.stdout.write(
-            self.style.WARNING(
-                f'Source: {src_user.username} ({src_user.first_name} '
-                f'{src_user.last_name})'))
-        self.stdout.write(
-            self.style.WARNING(
-                f'Destination: {dst_user.username} ({dst_user.first_name} '
-                f'{dst_user.last_name})'))
+        dst_user_str = (
+            f'{dst_user.username} ({dst_user.pk}, {dst_user.first_name} '
+            f'{dst_user.last_name})')
+
+        self.stdout.write(self.style.WARNING(f'Source: {src_user_str}'))
+        self.stdout.write(self.style.WARNING(f'Destination: {dst_user_str}'))
 
         if dry_run:
             user_merge_runner.dry_run()
         else:
-            user_merge_runner.run()
-            enqueue_for_logging_strategy.log_queued_messages()
+            enqueue_for_logging_strategy.warning(
+                f'Initiating a merge of source User {src_user_str} into '
+                f'destination User {dst_user_str}.')
+            try:
+                user_merge_runner.run()
+            except Exception as e:
+                # TODO
+                pass
+            else:
+                enqueue_for_logging_strategy.success(
+                    f'Successfully merged source User {src_user_str} into '
+                    f'destination User {dst_user_str}.')
+                enqueue_for_logging_strategy.log_queued_messages()

--- a/coldfront/core/user/management/commands/merge_users.py
+++ b/coldfront/core/user/management/commands/merge_users.py
@@ -52,13 +52,14 @@ class Command(BaseCommand):
                 self.style.ERROR(f'User "{username_2}" does not exist.'))
             return
 
-        # TODO: Check that the first and last names of the two users match.
-
         user_merge_runner = UserMergeRunner(user_1, user_2)
 
-        print(f'Src: {user_merge_runner.src_user}')
-        print(f'Dst: {user_merge_runner.dst_user}')
+        self.stdout.write(
+            self.style.WARNING(f'Source: {user_merge_runner.src_user}'))
+        self.stdout.write(
+            self.style.WARNING(f'Destination: {user_merge_runner.dst_user}'))
 
-        # TODO: Call run or dry_run.
-
-        user_merge_runner.run()
+        if dry_run:
+            user_merge_runner.dry_run()
+        else:
+            user_merge_runner.run()

--- a/coldfront/core/user/management/commands/merge_users.py
+++ b/coldfront/core/user/management/commands/merge_users.py
@@ -4,7 +4,7 @@ import sys
 from django.contrib.auth.models import User
 from django.core.management.base import BaseCommand
 
-from coldfront.core.user.utils_.user_merge_utils import UserMergeRunner
+from coldfront.core.user.utils_.merge_users import UserMergeRunner
 from coldfront.core.utils.common import add_argparse_dry_run_argument
 
 
@@ -58,5 +58,7 @@ class Command(BaseCommand):
 
         print(f'Src: {user_merge_runner.src_user}')
         print(f'Dst: {user_merge_runner.dst_user}')
+
+        # TODO: Call run or dry_run.
 
         user_merge_runner.run()

--- a/coldfront/core/user/management/commands/merge_users.py
+++ b/coldfront/core/user/management/commands/merge_users.py
@@ -76,6 +76,7 @@ class Command(BaseCommand):
 
         if dry_run:
             user_merge_runner.dry_run()
+            self.stdout.write(self.style.WARNING('Dry run of merge complete.'))
         else:
             enqueue_for_logging_strategy.warning(
                 f'Initiating a merge of source User {src_user_str} into '
@@ -86,6 +87,7 @@ class Command(BaseCommand):
                 # TODO
                 pass
             else:
+                self.stdout.write(self.style.SUCCESS('Merge complete.'))
                 enqueue_for_logging_strategy.success(
                     f'Successfully merged source User {src_user_str} into '
                     f'destination User {dst_user_str}.')

--- a/coldfront/core/user/management/commands/merge_users.py
+++ b/coldfront/core/user/management/commands/merge_users.py
@@ -1,0 +1,62 @@
+import logging
+import sys
+
+from django.contrib.auth.models import User
+from django.core.management.base import BaseCommand
+
+from coldfront.core.user.utils_.user_merge_utils import UserMergeRunner
+from coldfront.core.utils.common import add_argparse_dry_run_argument
+
+
+"""An admin command that merges two Users into one."""
+
+
+class Command(BaseCommand):
+
+    help = (
+        'Merge two Users into one. The command chooses one instance, transfers '
+        'that instance\'s relationships, requests, etc. to the other, and then '
+        'deletes it.')
+
+    logger = logging.getLogger(__name__)
+
+    def add_arguments(self, parser):
+        add_argparse_dry_run_argument(parser)
+        parser.add_argument(
+            'username_1', help='The username of the first user.', type=str)
+        parser.add_argument(
+            'username_2', help='The username of the second user.', type=str)
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        if not dry_run:
+            user_confirmation = input(
+                'Are you sure you wish to proceed? [Y/y/N/n]: ')
+            if user_confirmation.strip().lower() != 'y':
+                self.stdout.write(self.style.WARNING('Merge aborted.'))
+                sys.exit(0)
+
+        username_1 = options['username_1']
+        try:
+            user_1 = User.objects.get(username=username_1)
+        except User.DoesNotExist:
+            self.stderr.write(
+                self.style.ERROR(f'User "{username_1}" does not exist.'))
+            return
+
+        username_2 = options['username_2']
+        try:
+            user_2 = User.objects.get(username=username_2)
+        except User.DoesNotExist:
+            self.stderr.write(
+                self.style.ERROR(f'User "{username_2}" does not exist.'))
+            return
+
+        # TODO: Check that the first and last names of the two users match.
+
+        user_merge_runner = UserMergeRunner(user_1, user_2)
+
+        print(f'Src: {user_merge_runner.src_user}')
+        print(f'Dst: {user_merge_runner.dst_user}')
+
+        user_merge_runner.run()

--- a/coldfront/core/user/utils_/merge_users/__init__.py
+++ b/coldfront/core/user/utils_/merge_users/__init__.py
@@ -1,0 +1,6 @@
+from coldfront.core.user.utils_.merge_users.runner import UserMergeRunner
+
+
+__all__ = [
+    'UserMergeRunner',
+]

--- a/coldfront/core/user/utils_/merge_users/class_handlers.py
+++ b/coldfront/core/user/utils_/merge_users/class_handlers.py
@@ -74,14 +74,12 @@ class ClassHandler(ABC):
         attribute in the source object."""
         return []
 
-    def _handle_associated_object(self):
+    def _handle_associated_object(self, transferred=False):
         """An object B may be associated with a User through a different
         object A. When A is deleted, B may be deleted with it. When A is
         transferred, B is transferred with it. Record that this has
         occurred."""
-        try:
-            self._src_obj.refresh_from_db()
-        except ObjectDoesNotExist:
+        if not transferred:
             # The object was deleted.
             message = (
                 f'{self._class_name}({self._src_obj.pk}): indirectly deleted')
@@ -233,7 +231,8 @@ class AllocationUserAttributeHandler(ClassHandler):
         super().__init__(*args, **kwargs)
 
     def _run_special_handling(self):
-        self._handle_associated_object()
+        transferred = self._src_obj.allocation_user.user == self._dst_user
+        self._handle_associated_object(transferred=transferred)
 
 
 class AllocationUserAttributeUsageHandler(ClassHandler):
@@ -242,7 +241,10 @@ class AllocationUserAttributeUsageHandler(ClassHandler):
         super().__init__(*args, **kwargs)
 
     def _run_special_handling(self):
-        self._handle_associated_object()
+        transferred = (
+            self._src_obj.allocation_user_attribute.allocation_user.user ==
+            self._dst_user)
+        self._handle_associated_object(transferred=transferred)
 
 
 class ClusterAccessRequestHandler(ClassHandler):
@@ -251,7 +253,8 @@ class ClusterAccessRequestHandler(ClassHandler):
         super().__init__(*args, **kwargs)
 
     def _run_special_handling(self):
-        self._handle_associated_object()
+        transferred = self._src_obj.allocation_user.user == self._dst_user
+        self._handle_associated_object(transferred=transferred)
 
 
 class ProjectUserHandler(ClassHandler):
@@ -310,7 +313,8 @@ class ProjectUserJoinRequestHandler(ClassHandler):
         super().__init__(*args, **kwargs)
 
     def _run_special_handling(self):
-        self._handle_associated_object()
+        transferred = self._src_obj.project_user.user == self._dst_user
+        self._handle_associated_object(transferred=transferred)
 
 
 class SavioProjectAllocationRequestHandler(ClassHandler):

--- a/coldfront/core/user/utils_/merge_users/class_handlers.py
+++ b/coldfront/core/user/utils_/merge_users/class_handlers.py
@@ -179,8 +179,6 @@ class AllocationUserHandler(ClassHandler):
         assert resource.name.endswith(' Compute')
 
         if self._dst_obj:
-            self._src_obj.delete()
-
             active_allocation_user_status = \
                 AllocationUserStatusChoice.objects.get(name='Active')
             if (self._dst_obj.status != active_allocation_user_status and
@@ -268,8 +266,6 @@ class ProjectUserHandler(ClassHandler):
                     self._src_obj.status == active_project_user_status):
                 self._dst_obj.status = self._src_obj.status
                 self._dst_obj.save()
-
-            self._src_obj.delete()
         else:
             self._src_obj.user = self._dst_user
             self._src_obj.save()

--- a/coldfront/core/user/utils_/merge_users/class_handlers.py
+++ b/coldfront/core/user/utils_/merge_users/class_handlers.py
@@ -67,6 +67,7 @@ class ClassHandler(ABC):
             self._run_special_handling()
             if self._dst_obj:
                 self._dst_obj.save()
+            self._src_obj.delete()
 
     def _get_settable_if_falsy_attrs(self):
         """Return a list of attributes that, if falsy in the

--- a/coldfront/core/user/utils_/merge_users/class_handlers.py
+++ b/coldfront/core/user/utils_/merge_users/class_handlers.py
@@ -67,7 +67,6 @@ class ClassHandler(ABC):
             self._run_special_handling()
             if self._dst_obj:
                 self._dst_obj.save()
-            self._src_obj.delete()
 
     def _get_settable_if_falsy_attrs(self):
         """Return a list of attributes that, if falsy in the

--- a/coldfront/core/user/utils_/merge_users/runner.py
+++ b/coldfront/core/user/utils_/merge_users/runner.py
@@ -27,7 +27,7 @@ class UserMergeRunner(object):
     has cluster access.
     """
 
-    def __init__(self, user_1, user_2):
+    def __init__(self, user_1, user_2, reporting_strategies=None):
         """Identify which of the two Users should be merged into."""
         self._dry = False
         # src_user's data will be merged into dst_user.
@@ -35,6 +35,12 @@ class UserMergeRunner(object):
         self._dst_user = None
         self._src_user_pk = None
         self._identify_src_and_dst_users(user_1, user_2)
+
+        # Report messages using each of the given strategies.
+        self._reporting_strategies = []
+        if isinstance(reporting_strategies, list):
+            for strategy in reporting_strategies:
+                self._reporting_strategies.append(strategy)
 
     @property
     def dst_user(self):
@@ -124,7 +130,8 @@ class UserMergeRunner(object):
 
             try:
                 handler = class_handler_factory.get_handler(
-                    obj.__class__, self._src_user, self._dst_user, obj)
+                    obj.__class__, self._src_user, self._dst_user, obj,
+                    reporting_strategies=self._reporting_strategies)
                 handler.run()
             except ValueError:
                 raise UserMergeError(

--- a/coldfront/core/user/utils_/merge_users/runner.py
+++ b/coldfront/core/user/utils_/merge_users/runner.py
@@ -1,0 +1,117 @@
+from django.contrib.auth.models import User
+from django.contrib.admin.utils import NestedObjects
+from django.db import DEFAULT_DB_ALIAS
+from django.db import transaction
+
+from coldfront.core.allocation.utils import has_cluster_access
+from coldfront.core.user.utils_.merge_users.class_handlers import ClassHandlerFactory
+
+
+class UserMergeRunner(object):
+    """A class that merges two User objects into one.
+
+    It identifies one User as a source and the other as a destination,
+    merges the source's relationships, requests, etc. into the
+    destination, and then deletes the source.
+
+    It currently only supports merging when only one of the given Users
+    has cluster access.
+    """
+
+    def __init__(self, user_1, user_2):
+        """Identify which of the two Users should be merged into."""
+        # src_user's data will be merged into dst_user.
+        self._src_user = None
+        self._dst_user = None
+        self._identify_src_and_dst_users(user_1, user_2)
+
+    @property
+    def dst_user(self):
+        return self._dst_user
+
+    @property
+    def src_user(self):
+        return self._src_user
+
+    @transaction.atomic
+    def run(self):
+        """Transfer dependencies from the source User to the destination
+        User, then delete the source User."""
+        try:
+            with transaction.atomic():
+                self._process_src_user_dependencies()
+                self._src_user.delete()
+
+                self._dst_user.refresh_from_db()
+                self._display_dst_user_dependencies()
+                raise Exception('Rolling back.')
+        except Exception as e:
+            # TODO
+            print(e)
+
+    def _identify_src_and_dst_users(self, user_1, user_2):
+        """Given two Users, determine which should be the source (the
+        one having its data merged and then deleted) and which should be
+        the destination (the one having data merged into it)."""
+        user_1_has_cluster_access = has_cluster_access(user_1)
+        user_2_has_cluster_access = has_cluster_access(user_2)
+        if not (user_1_has_cluster_access or user_2_has_cluster_access):
+            src, dst = user_2, user_1
+        elif user_1_has_cluster_access and not user_2_has_cluster_access:
+            src, dst = user_2, user_1
+        elif not user_1_has_cluster_access and user_2_has_cluster_access:
+            src, dst = user_1, user_2
+        else:
+            raise NotImplementedError(
+                'Both Users have cluster access. This case is not currently '
+                'handled.')
+        self._src_user = src
+        self._dst_user = dst
+
+    def _process_src_user_dependencies(self):
+        """Process each database object associated with the source User
+        on a case-by-case basis."""
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([self._src_user])
+        objects = collector.nested()
+
+        assert len(objects) == 2
+        assert isinstance(objects[0], User)
+        assert isinstance(objects[1], list)
+
+        for obj in self._yield_nested_objects(objects[1]):
+            class_handler_factory = ClassHandlerFactory()
+
+            # Block other threads from retrieving this object until the end of
+            # the transaction.
+            obj = obj.__class__.objects.select_for_update().get(pk=obj.pk)
+
+            try:
+                handler = class_handler_factory.get_handler(
+                    obj.__class__, self._src_user, self._dst_user, obj)
+                handler.run()
+            except ValueError:
+                print(
+                    f'Found no handler for object with class {obj.__class__}.')
+            except Exception as e:
+                # TODO
+                print(e)
+
+    def _display_dst_user_dependencies(self):
+        """TODO"""
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([self._dst_user])
+        objects = collector.nested()
+
+        for obj in self._yield_nested_objects(objects[1]):
+            print(obj.__class__, obj, obj.__dict__)
+
+    def _yield_nested_objects(self, objects):
+        """Given a list that contains objects and lists of potentially-
+        nested objects, return a generator that recursively yields
+        objects."""
+        for obj in objects:
+            if isinstance(obj, list):
+                yield from self._yield_nested_objects(obj)
+            else:
+                yield obj

--- a/coldfront/core/user/utils_/merge_users/runner.py
+++ b/coldfront/core/user/utils_/merge_users/runner.py
@@ -1,6 +1,5 @@
 from django.contrib.auth.models import User
 from django.contrib.admin.utils import NestedObjects
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import DEFAULT_DB_ALIAS
 from django.db import transaction
 
@@ -125,14 +124,9 @@ class UserMergeRunner(object):
 
             class_handler_factory = ClassHandlerFactory()
 
-            try:
-                # Block other threads from retrieving this object until the end
-                # of the transaction.
-                obj = obj.__class__.objects.select_for_update().get(pk=obj.pk)
-            except ObjectDoesNotExist:
-                # The object was deleted in a cascading fashion. Process it
-                # anyway for reporting purposes.
-                pass
+            # Block other threads from retrieving this object until the end of
+            # the transaction.
+            obj = obj.__class__.objects.select_for_update().get(pk=obj.pk)
 
             try:
                 handler = class_handler_factory.get_handler(

--- a/coldfront/core/user/utils_/merge_users/runner.py
+++ b/coldfront/core/user/utils_/merge_users/runner.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import User
 from django.contrib.admin.utils import NestedObjects
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import DEFAULT_DB_ALIAS
 from django.db import transaction
 
@@ -124,9 +125,14 @@ class UserMergeRunner(object):
 
             class_handler_factory = ClassHandlerFactory()
 
-            # Block other threads from retrieving this object until the end of
-            # the transaction.
-            obj = obj.__class__.objects.select_for_update().get(pk=obj.pk)
+            try:
+                # Block other threads from retrieving this object until the end
+                # of the transaction.
+                obj = obj.__class__.objects.select_for_update().get(pk=obj.pk)
+            except ObjectDoesNotExist:
+                # The object was deleted in a cascading fashion. Process it
+                # anyway for reporting purposes.
+                pass
 
             try:
                 handler = class_handler_factory.get_handler(

--- a/coldfront/core/user/utils_/user_merge_utils.py
+++ b/coldfront/core/user/utils_/user_merge_utils.py
@@ -1,0 +1,389 @@
+import inspect
+import logging
+
+from abc import ABC
+from abc import abstractmethod
+
+from django.contrib.auth.models import User
+from django.contrib.admin.utils import NestedObjects
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import DEFAULT_DB_ALIAS
+from django.db import transaction
+
+from flags.state import flag_enabled
+
+from coldfront.core.allocation.models import AllocationUser
+from coldfront.core.allocation.models import AllocationUserStatusChoice
+from coldfront.core.allocation.utils import has_cluster_access
+from coldfront.core.project.models import ProjectUser
+from coldfront.core.project.models import ProjectUserStatusChoice
+from coldfront.core.project.utils import higher_project_user_role
+
+
+class UserMergeRunner(object):
+    """TODO"""
+
+    def __init__(self, user_1, user_2):
+        """TODO"""
+        # Merge src_user's data into dst_user.
+        self._src_user = None
+        self._dst_user = None
+        self._identify_src_and_dst_users(user_1, user_2)
+        # TODO:
+        #  Error out if both users have cluster access.
+        #  Warn if the destination user is inactive.
+
+    @property
+    def dst_user(self):
+        return self._dst_user
+
+    @property
+    def src_user(self):
+        return self._src_user
+
+    def run(self):
+        """TODO"""
+        with transaction.atomic():
+            self._process_dependencies()
+            self._src_user.delete()
+            # TODO: Remove this.
+            raise Exception('Rolling back.')
+
+    def _identify_src_and_dst_users(self, user_1, user_2):
+        """Given two Users, determine which should be the source (the
+        one having its data merged and then deleted) and which should be
+        the destination (the one having data merged into it)."""
+        user_1_has_cluster_access = has_cluster_access(user_1)
+        user_2_has_cluster_access = has_cluster_access(user_2)
+        if not (user_1_has_cluster_access or user_2_has_cluster_access):
+            src, dst = user_2, user_1
+        elif user_1_has_cluster_access and not user_2_has_cluster_access:
+            src, dst = user_2, user_1
+        elif not user_1_has_cluster_access and user_2_has_cluster_access:
+            src, dst = user_1, user_2
+        else:
+            raise NotImplementedError(
+                'Both Users have cluster access. This case is not currently '
+                'handled.')
+        self._src_user = src
+        self._dst_user = dst
+
+    def _process_dependencies(self):
+        """TODO"""
+        collector = NestedObjects(using=DEFAULT_DB_ALIAS)
+        collector.collect([self._src_user])
+        objects = collector.nested()
+
+        assert len(objects) == 2
+        assert isinstance(objects[0], User)
+        assert isinstance(objects[1], list)
+
+        for obj in self._yield_nested_objects(objects[1]):
+            class_handler_factory = ClassHandlerFactory()
+            try:
+                handler = class_handler_factory.get_handler(
+                    obj.__class__, self._src_user, self._dst_user, obj)
+                handler.run()
+            except ValueError:
+                print(
+                    f'Found no handler for object with class {obj.__class__}.')
+            except Exception as e:
+                # TODO
+                print(e)
+
+    def _yield_nested_objects(self, objects):
+        """TODO"""
+        for obj in objects:
+            if isinstance(obj, list):
+                yield from self._yield_nested_objects(obj)
+            else:
+                yield obj
+
+
+class ClassHandlerFactory(object):
+    """A factory for returning a class that handles merging data from a
+    source object into a destination object of a given class when
+    merging User accounts."""
+
+    def get_handler(self, klass, *args, **kwargs):
+        """Return an instantiated handler for the given class with the
+        given arguments and keyword arguments."""
+        assert inspect.isclass(klass)
+        return self._get_handler_class(klass)(*args, **kwargs)
+
+    @staticmethod
+    def _get_handler_class(klass):
+        """Return the appropriate handler class for the given class. If
+        none are applicable, raise a ValueError."""
+        handler_class_name = f'{klass.__name__}Handler'
+        try:
+            return globals()[handler_class_name]
+        except KeyError:
+            raise ValueError(f'No handler for class {klass.__name__}.')
+
+
+class ClassHandler(ABC):
+    """TODO"""
+
+    @abstractmethod
+    def __init__(self, src_user, dst_user, src_obj):
+        """TODO"""
+        self._src_user = src_user
+        self._dst_user = dst_user
+        self._src_obj = src_obj
+        self._dst_obj = None
+
+        self._logger = logging.getLogger(__name__)
+
+    def dry_run(self):
+        """TODO"""
+        # TODO: Display what would(n't) happen.
+        #   # E.g., not overriding an existing billing_activity.
+        pass
+
+    def run(self):
+        """TODO"""
+        with transaction.atomic():
+            # TODO: Consider whether special handling may need to happen first.
+            if self._dst_obj:
+                self._set_falsy_attrs()
+            self._run_special_handling()
+
+    def _get_settable_if_falsy_attrs(self):
+        """TODO"""
+        return []
+
+    def _run_special_handling(self):
+        """TODO"""
+        raise NotImplementedError
+
+    def _set_attr_if_falsy(self, attr_name, dry=False):
+        """TODO"""
+        assert hasattr(self._src_obj, attr_name)
+        assert hasattr(self._dst_obj, attr_name)
+
+        src_attr = getattr(self._src_obj, attr_name)
+        dst_attr = getattr(self._dst_obj, attr_name)
+
+        if src_attr and not dst_attr:
+            if dry:
+                # TODO: Print.
+                pass
+            else:
+                setattr(self._dst_obj, attr_name, src_attr)
+                # TODO: Log.
+                #  Only flush to the log at the end of the transaction, or
+                #  Log that the transaction is being rolled back.
+                #  Include a UUID in each log message to identify the merge.
+
+    def _set_falsy_attrs(self):
+        """TODO"""
+        for attr_name in self._get_settable_if_falsy_attrs():
+            self._set_attr_if_falsy(attr_name)
+        self._dst_obj.save()
+
+    def _transfer_src_obj_to_dst_user(self):
+        """TODO"""
+        self._src_obj.user = self._dst_user
+        self._src_obj.save()
+
+
+class UserProfileHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._dst_obj = self._dst_user.userprofile
+
+    def _get_settable_if_falsy_attrs(self):
+        return [
+            'is_pi',
+            # Only the destination user should have a cluster UID.
+            # 'cluster_uid',
+            'phone_number',
+            'access_agreement_signed_date',
+            'billing_activity',
+        ]
+
+    def _run_special_handling(self):
+        """TODO"""
+        self._set_host_user()
+
+    def _set_host_user(self):
+        if flag_enabled('LRC_ONLY'):
+            # TODO
+            #  Deal with conflicts.
+            #  Handle LBL users.
+            self._set_attr_if_falsy('host_user')
+
+
+class SocialAccountHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _run_special_handling(self):
+        """TODO"""
+        self._transfer_src_obj_to_dst_user()
+
+
+class EmailAddressHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _run_special_handling(self):
+        """TODO"""
+        # TODO
+        #  Consider allowing a new primary to be set.
+        self._src_obj.primary = False
+        self._transfer_src_obj_to_dst_user()
+
+
+class AllocationUserHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            self._dst_obj = AllocationUser.objects.get(
+                allocation=self._src_obj.allocation, user=self._dst_user)
+        except ObjectDoesNotExist:
+            self._dst_obj = None
+
+    def _run_special_handling(self):
+        """TODO"""
+        allocation = self._src_obj.allocation
+
+        # TODO: Note that only compute Allocations are handled for now.
+
+        assert allocation.resources.count() == 1
+        resource = allocation.resources.first()
+        assert resource.name.endswith(' Compute')
+
+        if self._dst_obj:
+            self._src_obj.delete()
+
+            active_allocation_user_status = \
+                AllocationUserStatusChoice.objects.get(name='Active')
+            if (self._dst_obj.status != active_allocation_user_status and
+                    self._dst_obj.status == active_allocation_user_status):
+                self._dst_obj.status = self._src_obj.status
+                self._dst_obj.save()
+        else:
+            self._src_obj.user = self._dst_user
+            self._src_obj.save()
+
+
+class AllocationUserAttributeHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _run_special_handling(self):
+        # TODO: This block is duplicated. Factor it out.
+        try:
+            self._src_obj.refresh_from_db()
+        except ObjectDoesNotExist:
+            # The object was deleted.
+            # TODO: Log and write to output.
+            return
+        else:
+            # The object was transferred to the destination user.
+            # TODO: Log and write to output.
+            return
+
+
+class AllocationUserAttributeUsageHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _run_special_handling(self):
+        try:
+            self._src_obj.refresh_from_db()
+        except ObjectDoesNotExist:
+            # The object was deleted.
+            # TODO: Log and write to output.
+            return
+        else:
+            # The object was transferred to the destination user.
+            # TODO: Log and write to output.
+            return
+
+
+class ClusterAccessRequestHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _run_special_handling(self):
+        try:
+            self._src_obj.refresh_from_db()
+        except ObjectDoesNotExist:
+            # The object was deleted.
+            # TODO: Log and write to output.
+            return
+        else:
+            # The object was transferred to the destination user.
+            # TODO: Log and write to output.
+            return
+
+
+class ProjectUserHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            self._dst_obj = ProjectUser.objects.get(
+                project=self._src_obj.project, user=self._dst_user)
+        except ObjectDoesNotExist:
+            self._dst_obj = None
+
+    def _run_special_handling(self):
+        if self._dst_obj:
+            self._dst_obj.role = higher_project_user_role(
+                self._dst_obj.role, self._src_obj.role)
+
+            active_project_user_status = ProjectUserStatusChoice.objects.get(
+                name='Active')
+            if (self._dst_obj.status != active_project_user_status and
+                    self._src_obj.status == active_project_user_status):
+                self._dst_obj.status = self._src_obj.status
+                self._dst_obj.save()
+
+            self._src_obj.delete()
+        else:
+            self._src_obj.user = self._dst_user
+            self._src_obj.save()
+
+        # TODO: Run the runner?
+
+
+class ProjectUserJoinRequestHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _run_special_handling(self):
+        try:
+            self._src_obj.refresh_from_db()
+        except ObjectDoesNotExist:
+            # The object was deleted.
+            # TODO: Log and write to output.
+            return
+        else:
+            # The object was transferred to the destination user.
+            # TODO: Log and write to output.
+            return
+
+
+class SavioProjectAllocationRequestHandler(ClassHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _run_special_handling(self):
+        if self._src_obj.requester == self._src_user:
+            self._src_obj.requester = self._dst_user
+        if self._src_obj.pi == self._src_user:
+            self._src_obj.pi = self._dst_user
+        self._src_obj.save()

--- a/coldfront/core/utils/reporting/report_message_strategy.py
+++ b/coldfront/core/utils/reporting/report_message_strategy.py
@@ -1,0 +1,84 @@
+import logging
+
+from abc import ABC
+
+from django.core.management.base import BaseCommand
+from django.utils.termcolors import colorize
+
+
+class ReportMessageStrategy(ABC):
+    """An interface that uses the Strategy design pattern to vary how
+    messages are reported."""
+
+    def error(self, message):
+        raise NotImplementedError
+
+    def success(self, message):
+        raise NotImplementedError
+
+    def warning(self, message):
+        raise NotImplementedError
+
+
+class EnqueueForLoggingStrategy(ReportMessageStrategy):
+    """A strategy for enqueueing messages to be written to a logging instance
+    later."""
+
+    def __init__(self, logger):
+        assert isinstance(logger, logging.Logger)
+        self._logger = logger
+        # Tuples of the form (logging_func, message).
+        self._queue = []
+
+    def error(self, message):
+        logging_func = self._logger.error
+        self._queue.append((logging_func, message))
+
+    def success(self, message):
+        logging_func = self._logger.info
+        self._queue.append((logging_func, message))
+
+    def warning(self, message):
+        logging_func = self._logger.warning
+        self._queue.append((logging_func, message))
+
+    def log_queued_messages(self):
+        for logging_func, message in self._queue:
+            logging_func(message)
+
+
+class PrintStrategy(ReportMessageStrategy):
+    """A strategy for printing messages."""
+
+    def error(self, message):
+        print(colorize(text=message, fg="red"))
+
+    def success(self, message):
+        print(colorize(text=message, fg="green"))
+
+    def warning(self, message):
+        print(colorize(text=message, fg="yellow"))
+
+
+class WriteViaCommandStrategy(ReportMessageStrategy):
+    """A strategy for writing messages to stdout/stderr via a Django
+    management command."""
+
+    def __init__(self, command):
+        assert isinstance(command, BaseCommand)
+        self._command = command
+
+    def error(self, message):
+        stream = self._command.stderr
+        style = self._command.style.ERROR
+        stream.write(style(message))
+
+    def success(self, message):
+        stream = self._command.stdout
+        style = self._command.style.SUCCESS
+        stream.write(style(message))
+
+    def warning(self, message):
+        stream = self._command.stdout
+        style = self._command.style.WANRING
+        stream.write(style(message))


### PR DESCRIPTION
Refs #544

**Changes**
- Added a management command `merge_users` for merging a source `User` into a destination `User`, based on whichever has cluster access.
    - It currently only handles a subset of cases, but can be expanded as needed. Notably, it does not handle:
        - Two users who both have cluster access,
        - Source users who have non-compute `Allocations`,
        - LRC users.

**How to Test**
- This has been manually tested on staging.