### PR TITLE
Registered Django admin pages for models that don't have them

### DIFF
--- a/coldfront/core/allocation/admin.py
+++ b/coldfront/core/allocation/admin.py
@@ -18,8 +18,24 @@ from coldfront.core.allocation.models import (Allocation, AllocationAccount,
                                               AllocationUserStatusChoice,
                                               AttributeType, SecureDirRequest,
                                               SecureDirAddUserRequest,
-                                              SecureDirRemoveUserRequest)
+                                              SecureDirRemoveUserRequest,
+                                            AllocationRenewalRequest, 
+                                            AllocationAdditionRequestStatusChoice, 
+                                            AllocationAdditionRequest, 
+                                            SecureDirAddUserRequestStatusChoice, 
+                                            SecureDirRemoveUserRequestStatusChoice, 
+                                            SecureDirRequestStatusChoice, 
+                                            ClusterAccessRequestStatusChoice, 
+                                            ClusterAccessRequest, )
 
+admin.site.register(AllocationRenewalRequest)
+admin.site.register(AllocationAdditionRequestStatusChoice)
+admin.site.register(AllocationAdditionRequest)
+admin.site.register(SecureDirAddUserRequestStatusChoice)
+admin.site.register(SecureDirRemoveUserRequestStatusChoice)
+admin.site.register(SecureDirRequestStatusChoice)
+admin.site.register(ClusterAccessRequestStatusChoice)
+admin.site.register(ClusterAccessRequest)
 
 @admin.register(AllocationStatusChoice)
 class AllocationStatusChoiceAdmin(admin.ModelAdmin):

--- a/coldfront/core/project/admin.py
+++ b/coldfront/core/project/admin.py
@@ -3,15 +3,26 @@ import textwrap
 from django.contrib import admin
 from simple_history.admin import SimpleHistoryAdmin
 
+from coldfront.core.statistics.models import (ProjectTransaction,
+                                              ProjectUserTransaction)
+
 from coldfront.core.project.models import (Project, ProjectAdminComment,
                                             ProjectReview, ProjectStatusChoice,
                                             ProjectUser, ProjectUserMessage,
                                             ProjectUserRoleChoice,
                                             ProjectUserStatusChoice,
-                                            SavioProjectAllocationRequest)
-from coldfront.core.statistics.models import (ProjectTransaction,
-                                              ProjectUserTransaction)
+                                            SavioProjectAllocationRequest,
+                                            ProjectUserJoinRequest, 
+                                            ProjectAllocationRequestStatusChoice, 
+                                            VectorProjectAllocationRequest, 
+                                            ProjectUserRemovalRequestStatusChoice, 
+                                            ProjectUserRemovalRequest, )
 
+admin.site.register(ProjectUserJoinRequest)
+admin.site.register(ProjectAllocationRequestStatusChoice)
+admin.site.register(VectorProjectAllocationRequest)
+admin.site.register(ProjectUserRemovalRequestStatusChoice)
+admin.site.register(ProjectUserRemovalRequest)
 
 @admin.register(ProjectStatusChoice)
 class ProjectStatusChoiceAdmin(admin.ModelAdmin):

--- a/coldfront/core/statistics/admin.py
+++ b/coldfront/core/statistics/admin.py
@@ -6,6 +6,8 @@ from coldfront.core.statistics.models import Node
 from coldfront.core.statistics.models import ProjectTransaction
 from coldfront.core.statistics.models import ProjectUserTransaction
 
+admin.site.register(CPU)
+admin.site.register(Node)
 
 @admin.register(ProjectTransaction)
 class ProjectTransactionAdmin(admin.ModelAdmin):

--- a/coldfront/core/user/admin.py
+++ b/coldfront/core/user/admin.py
@@ -2,7 +2,10 @@ from django.contrib import admin
 
 from allauth.account.models import EmailAddress
 
-from coldfront.core.user.models import UserProfile
+from coldfront.core.user.models import UserProfile, IdentityLinkingRequestStatusChoice, IdentityLinkingRequest
+
+admin.site.register(IdentityLinkingRequest)
+admin.site.register(IdentityLinkingRequestStatusChoice)
 
 
 @admin.register(UserProfile)


### PR DESCRIPTION
Added admin.site.register(<model_name>) for any missing models on the admin site. 