### PR TITLE
Add admin-only view for listing usages of billing IDs

### DIFF
--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -22,6 +22,7 @@ urlpatterns = [
     path('project/', include('coldfront.core.project.urls')),
     path('allocation/', include('coldfront.core.allocation.urls')),
     path('jobs/', include('coldfront.core.statistics.urls')),
+    path('billing/', include('coldfront.core.billing.urls')),
     # path('grant/', include('coldfront.core.grant.urls')),
     # path('publication/', include('coldfront.core.publication.urls')),
     # path('research-output/', include('coldfront.core.research_output.urls')),

--- a/coldfront/core/billing/forms.py
+++ b/coldfront/core/billing/forms.py
@@ -1,9 +1,12 @@
 from django import forms
 from django.conf import settings
+from django.contrib.auth.models import User
 from django.core.validators import MinLengthValidator
 from django.core.validators import RegexValidator
 
+from coldfront.core.billing.models import BillingActivity
 from coldfront.core.billing.utils.validation import is_billing_id_valid
+from coldfront.core.project.models import Project
 
 
 # TODO: Replace this module with a directory as needed.
@@ -43,3 +46,35 @@ class BillingIDValidationForm(forms.Form):
             raise forms.ValidationError(
                 f'Project ID {billing_id} is not currently valid.')
         return billing_id
+
+
+class BillingActivityChoiceField(forms.ModelChoiceField):
+
+    @staticmethod
+    def label_from_instance(obj):
+        return obj.full_id()
+
+
+class BillingIDUsagesSearchForm(forms.Form):
+
+    billing_id = BillingActivityChoiceField(
+        help_text=(
+            'Filter results to only include usages of the selected ID. If an '
+            'ID does not appear in the list, then there are no usages.'),
+        label='LBL Project ID',
+        queryset=BillingActivity.objects.all(),
+        required=False)
+    project = forms.ModelChoiceField(
+        help_text=(
+            'Filter results to include usages of IDs associated with the '
+            'selected project.'),
+        label='Project',
+        queryset=Project.objects.all(),
+        required=False)
+    user = forms.ModelChoiceField(
+        help_text=(
+            'Filter results to include usages of IDs associated with the '
+            'selected user.'),
+        label='User',
+        queryset=User.objects.all(),
+        required=False)

--- a/coldfront/core/billing/templates/billing/billing_id_usages_search.html
+++ b/coldfront/core/billing/templates/billing/billing_id_usages_search.html
@@ -1,0 +1,137 @@
+{% extends "common/base.html" %}
+{% load common_tags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+{% block title %}
+  LBL Project ID Usages
+{% endblock %}
+
+{% block content %}
+<script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
+<link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
+
+<h1>LBL Project ID Usages</h1>
+<hr>
+
+<div class="mb-3" id="accordion">
+  <div class="card">
+    <div class="card-header">
+      <a id="expand_button" role="button" class="card-link " data-toggle="collapse" href="#collapseOne">
+        <i class="fas fa-filter" aria-hidden="true"></i> Search
+        <i id="plus_minus" class="fas {{expand_accordion|get_icon}} float-right"></i>
+      </a>
+    </div>
+    <div id="collapseOne" class="{{expand_accordion}}" data-parent="#accordion">
+      <div class="card-body">
+        <form id="search_form" method="GET" action="{% url 'billing-id-usages' %}" autocomplete="off">
+          {{ search_form|crispy }}
+          <input type="submit" class="btn btn-primary" value="Search">
+          <button id="form_reset_button" type="button" class="btn btn-secondary">Reset</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<hr>
+
+<h3>Project Default</h3>
+<p>The following project IDs are used as the default IDs for the respective projects.</p>
+<strong>Results Found: {{ project_default_usages|length }}</strong>
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th scope="col" class="text-nowrap">
+          Project
+        </th>
+        <th scope="col" class="text-nowrap">
+          LBL Project ID
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for usage in project_default_usages %}
+      <tr>
+        <td>{{ usage.project_name }}</td>
+        <td>{{ usage.full_id }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<br>
+
+<h3>Recharge</h3>
+<p>The following project IDs are used for the recharge fee for the respective project users.</p>
+<strong>Results Found: {{ recharge_usages|length }}</strong>
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th scope="col" class="text-nowrap">
+          Project
+        </th>
+        <th scope="col" class="text-nowrap">
+          User
+        </th>
+        <th scope="col" class="text-nowrap">
+          LBL Project ID
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for usage in recharge_usages %}
+      <tr>
+        <td>{{ usage.project_name }}</td>
+        <td>{{ usage.username }}</td>
+        <td>{{ usage.full_id }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<br>
+
+<h3>User Account</h3>
+<p>The following project IDs are used for the user account fee for the respective users.</p>
+<strong>Results Found: {{ user_account_usages|length }}</strong>
+<div class="table-responsive">
+  <table class="table table-sm">
+    <thead>
+      <tr>
+        <th scope="col" class="text-nowrap">
+          User
+        </th>
+        <th scope="col" class="text-nowrap">
+          LBL Project ID
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for usage in user_account_usages %}
+      <tr>
+        <td>{{ usage.username }}</td>
+        <td>{{ usage.full_id }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+<br>
+
+<script>
+  $('select').selectize({
+    create: false,
+    sortField: 'text'
+  });
+</script>
+
+<script>
+  $("#navbar-main > ul > li.active").removeClass("active");
+  $("#navbar-admin").addClass("active");
+  $("#navbar-billing-id-usages").addClass("active");
+</script>
+
+{% endblock %}

--- a/coldfront/core/billing/urls.py
+++ b/coldfront/core/billing/urls.py
@@ -1,0 +1,17 @@
+from flags.urls import flagged_paths
+
+from coldfront.core.billing.views import admin_views
+
+
+urlpatterns = []
+
+
+with flagged_paths('LRC_ONLY') as path:
+    flagged_url_patterns = [
+        path('usages/',
+             admin_views.BillingIDUsagesSearchView.as_view(),
+             name='billing-id-usages'),
+    ]
+
+
+urlpatterns += flagged_url_patterns

--- a/coldfront/core/billing/views/admin_views.py
+++ b/coldfront/core/billing/views/admin_views.py
@@ -1,0 +1,81 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.views.generic.base import TemplateView
+
+from coldfront.core.billing.forms import BillingIDUsagesSearchForm
+from coldfront.core.billing.models import BillingActivity
+from coldfront.core.billing.utils.queries import get_billing_id_usages
+
+
+class BillingIDUsagesSearchView(LoginRequiredMixin, UserPassesTestMixin,
+                                TemplateView):
+    """Search for usages of billing IDs."""
+
+    template_name = 'billing/billing_id_usages_search.html'
+
+    def test_func(self):
+        user = self.request.user
+        return user.is_superuser or user.is_staff
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        context['project_default_usages'] = []
+        context['recharge_usages'] = []
+        context['user_account_usages'] = []
+
+        search_form = BillingIDUsagesSearchForm(self.request.GET)
+        context['search_form'] = search_form
+        if not search_form.is_valid():
+            return context
+        data = search_form.cleaned_data
+        usage_kwargs = {'full_id': None, 'project_obj': None, 'user_obj': None}
+        billing_activity = data.get('billing_id', None)
+        if billing_activity:
+            billing_id = billing_activity.full_id()
+            usage_kwargs['full_id'] = billing_id
+        else:
+            billing_id = ''
+        usage_kwargs['project_obj'] = data.get('project', None)
+        usage_kwargs['user_obj'] = data.get('user', None)
+        usages = get_billing_id_usages(**usage_kwargs)
+
+        # TODO: Much of this is duplicated from the billing_ids command.
+        #  Refactor.
+        full_id_by_billing_activity_pk = {}
+
+        for allocation_attribute in usages.project_default:
+            pk = int(allocation_attribute.value)
+            if billing_id:
+                full_id = billing_id
+            elif pk in full_id_by_billing_activity_pk:
+                full_id = full_id_by_billing_activity_pk[pk]
+            else:
+                full_id = BillingActivity.objects.get(pk=pk).full_id()
+                full_id_by_billing_activity_pk[pk] = full_id
+            project_name = allocation_attribute.allocation.project.name
+            context['project_default_usages'].append(
+                {'project_name': project_name, 'full_id': full_id})
+
+        for allocation_user_attribute in usages.recharge:
+            pk = int(allocation_user_attribute.value)
+            if billing_id:
+                full_id = billing_id
+            elif pk in full_id_by_billing_activity_pk:
+                full_id = full_id_by_billing_activity_pk[pk]
+            else:
+                full_id = BillingActivity.objects.get(pk=pk).full_id()
+                full_id_by_billing_activity_pk[pk] = full_id
+            project_name = allocation_user_attribute.allocation.project.name
+            username = allocation_user_attribute.allocation_user.user.username
+            context['recharge_usages'].append(
+                {'project_name': project_name, 'username': username,
+                 'full_id': full_id})
+
+        for user_profile in usages.user_account:
+            full_id = user_profile.billing_activity.full_id()
+            username = user_profile.user.username
+            context['user_account_usages'].append(
+                {'username': username, 'full_id': full_id})
+
+        return context

--- a/coldfront/core/project/urls.py
+++ b/coldfront/core/project/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path
 from django.views.generic import TemplateView
-from flags.urls import flagged_paths
 
 from flags.urls import flagged_paths
 

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -9,9 +9,14 @@
         <li><a id="navbar-jobs-list" class="dropdown-item" href="{% url 'slurm-job-list' %}?show_all_jobs=on">All Jobs</a></li>
         <li><a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a></li>
         <li><a class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a></li>
+        {% comment %}
         <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
+        {% endcomment %}
         <li><a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a></li>
-
+        {% flag_enabled 'LRC_ONLY' as lrc_only %}
+        {% if lrc_only %}
+        <li><a class="dropdown-item" id="navbar-billing-id-usages" href="{% url 'billing-id-usages' %}">LBL Project IDs</a></li>
+        {% endif %}
 
         <li><div class="dropdown-divider"></div></li>
         <li class="dropdown-submenu"><a id="navbar-admin-requests" class="dropdown-item dropdown-toggle" href="#">Requests</a>

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -15,8 +15,14 @@
         <li><a id="navbar-jobs-list" class="dropdown-item" href="{% url 'slurm-job-list' %}?show_all_jobs=on">All Jobs</a></li>
         <li><a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a></li>
         <li><a id="navbar-user-list" class="dropdown-item" href="{% url 'user-search-all' %}">All Users</a></li>
+        {% comment %}
         <li><a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a></li>
+        {% endcomment %}
         <li><a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a></li>
+        {% flag_enabled 'LRC_ONLY' as lrc_only %}
+        {% if lrc_only %}
+        <li><a class="dropdown-item" href="{% url 'billing-id-usages' %}">LBL Project IDs</a></li>
+        {% endif %}
 
         <li><div class="dropdown-divider"></div></li>
         <li class="dropdown-submenu"><a class="dropdown-item dropdown-toggle" href="#">Requests</a>


### PR DESCRIPTION
**Changes**
- Added an admin view (Admin > LBL Project IDs) for listing usages of billing IDs, with logic identical to the `list` subcommand of `billing_ids` described in #559.
    - The view is also accessible to staff (Staff > LBL Project IDs), but not regular users.