### PR TITLE
Clean user-provided secure directory name

### DIFF
--- a/coldfront/core/allocation/templates/secure_dir/secure_dir_request/directory_name.html
+++ b/coldfront/core/allocation/templates/secure_dir/secure_dir_request/directory_name.html
@@ -31,8 +31,8 @@
   <p>Please provide the name of the secure directory you are requesting.</p>
 
   <p>
-    For example, to request the secure directories <em>{{ scratch_path }}/pl1_example</em> and
-    <em>{{ groups_path }}/pl1_example</em>, you would provide <strong>example</strong>.
+    For example, to request the secure directories <em>{{ scratch_path }}/{{ directory_name_prefix }}example</em> and
+    <em>{{ groups_path }}/{{ directory_name_prefix }}example</em>, you would provide <strong>example</strong>.
   </p>
   <p>
     Note that you will receive both a groups and a scratch secure directory upon approval of this request.

--- a/coldfront/core/allocation/templates/secure_dir/secure_dir_request/secure_dir_request_card.html
+++ b/coldfront/core/allocation/templates/secure_dir/secure_dir_request/secure_dir_request_card.html
@@ -52,17 +52,17 @@
 
     <p class="card-text text-justify">
       <strong>Proposed Directory Name: </strong>
-      {{ secure_dir_request.directory_name }}
+      {{ proposed_directory_name }}
     </p>
 
     <p class="card-text text-justify">
       <strong>Proposed Groups Path: </strong>
-      {{ groups_path }}
+      {{ proposed_groups_path }}
     </p>
 
     <p class="card-text text-justify">
       <strong>Proposed Scratch Path: </strong>
-      {{ scratch_path }}
+      {{ proposed_scratch_path }}
     </p>
   </div>
 </div>

--- a/coldfront/core/allocation/tests/test_utils/test_secure_dir_utils.py
+++ b/coldfront/core/allocation/tests/test_utils/test_secure_dir_utils.py
@@ -30,7 +30,7 @@ class TestCreateSecureDir(TestBase):
 
         self.project1 = self.create_active_project_with_pi('project1', self.pi)
 
-        self.subdirectory_name = 'test_dir'
+        self.subdirectory_name = 'pl1_test_dir'
         call_command('add_directory_defaults')
         create_secure_dirs(self.project1, self.subdirectory_name, 'groups')
         create_secure_dirs(self.project1, self.subdirectory_name, 'scratch')

--- a/coldfront/core/allocation/tests/test_views/test_secure_dir_request_views.py
+++ b/coldfront/core/allocation/tests/test_views/test_secure_dir_request_views.py
@@ -168,7 +168,7 @@ class TestSecureDirRequestWizard(TestSecureDirRequestBase):
             form_data[1]['1-rdm_consultants'])
         self.assertEqual(
             request.directory_name,
-            form_data[2]['2-directory_name'])
+            f'pl1_{form_data[2]["2-directory_name"]}')
         self.assertEqual(request.project, self.project1)
         self.assertTrue(
             pre_time < request.request_time < utc_now_offset_aware())
@@ -444,9 +444,9 @@ class TestSecureDirRequestDetailView(TestSecureDirRequestBase):
                       f'on the cluster is complete.',
                       f'The paths to your secure group and scratch directories '
                       f'are \'/global/home/groups/pl1data/'
-                      f'pl1_{self.request0.directory_name}\' and '
+                      f'{self.request0.directory_name}\' and '
                       f'\'/global/scratch/p2p3/'
-                      f'pl1_{self.request0.directory_name}\', '
+                      f'{self.request0.directory_name}\', '
                       f'respectively.']
 
         self.assertEqual(len(pi_emails), len(mail.outbox))
@@ -780,7 +780,8 @@ class TestSecureDirRequestReviewSetupView(TestSecureDirRequestBase):
 
         self.request0.refresh_from_db()
         self.assertRedirects(response, self.success_url)
-        self.assertEqual(self.request0.directory_name, data['directory_name'])
+        self.assertEqual(
+            self.request0.directory_name, f'pl1_{data["directory_name"]}')
         self.assertEqual(self.request0.status.name, 'Approved - Processing')
         self.assertEqual(self.request0.state['setup']['status'], 'Completed')
 
@@ -792,6 +793,7 @@ class TestSecureDirRequestReviewSetupView(TestSecureDirRequestBase):
         """Tests that a Denied status denies the request."""
         self.client.login(username=self.admin.username, password=self.password)
         data = {'status': 'Denied',
+                'directory_name': self.request0.directory_name,
                 'justification': 'This is a test denial justification.'}
         response = self.client.post(self.url, data)
 

--- a/coldfront/core/allocation/views_/secure_dir_views.py
+++ b/coldfront/core/allocation/views_/secure_dir_views.py
@@ -36,13 +36,15 @@ from coldfront.core.allocation.utils_.secure_dir_utils import \
     get_secure_dir_manage_user_request_objects, secure_dir_request_state_status, \
     SecureDirRequestDenialRunner, SecureDirRequestApprovalRunner, \
     get_secure_dir_allocations, get_default_secure_dir_paths, \
-    pi_eligible_to_request_secure_dir, set_sec_dir_context
+    pi_eligible_to_request_secure_dir, SECURE_DIRECTORY_NAME_PREFIX, \
+    set_sec_dir_context
 from coldfront.core.project.forms import ReviewStatusForm, ReviewDenyForm
 from coldfront.core.project.models import ProjectUser, Project
 from coldfront.core.user.utils import access_agreement_signed
 from coldfront.core.utils.common import utc_now_offset_aware, \
     session_wizard_all_form_data
 from coldfront.core.utils.mail import send_email_template
+
 
 logger = logging.getLogger(__name__)
 
@@ -875,6 +877,7 @@ class SecureDirRequestWizard(LoginRequiredMixin,
         groups_path, scratch_path = get_default_secure_dir_paths()
         context['groups_path'] = groups_path
         context['scratch_path'] = scratch_path
+        context['directory_name_prefix'] = SECURE_DIRECTORY_NAME_PREFIX
 
         return context
 


### PR DESCRIPTION
**Changes**
- Updated the forms for requesting a new secure directory and for updating a secure directory's name during review to allow the user to provide a name that either has or does not have the expected prefix (`pl1_`). This prevents a name from being displayed erroneously (e.g., `pl1_pl1_name`).
- Updated the corresponding views to store the directory name in `SecureDirRequest` with the prefix included.
- Updated views and templates to avoid prepending the prefix given that it is now stored.
- Updated tests.