### PR TITLE
Configure logrotate for API + portal logs during Ansible provisioning

### DIFF
--- a/bootstrap/ansible/logrotate.tmpl
+++ b/bootstrap/ansible/logrotate.tmpl
@@ -1,0 +1,12 @@
+{{ log_path }}/{{ api_log_file }} {{ log_path }}/{{ portal_log_file }} {
+    weekly
+    rotate 8
+    dateext
+    dateformat -%Y%m%d-%H%s
+    copytruncate
+    missingok
+    notifempty
+    compress
+    delaycompress
+    su {{ djangooperator }} apache
+}

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -42,6 +42,7 @@ redis_host: localhost
 log_path: /var/log/user_portals/cf_mybrc
 portal_log_file: cf_mybrc_portal.log
 api_log_file: cf_mybrc_api.log
+logrotate_entry_name: cf_mybrc
 
 # Apache settings.
 # The name of the copy of the generated WSGI template in the Apache directory.

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -206,7 +206,7 @@
             state: started
             enabled: true
 
-        # Create Django application log files.
+        # Create Django application log files and set up log rotation.
 
         - name: Create a parent directory for storing Django application logs
           file:
@@ -234,6 +234,11 @@
             owner: "{{ djangooperator }}"
             group: apache
 
+        - name: Configure logrotate to rotate the Django API and portal logs
+          template:
+            src: "{{ git_prefix }}/{{ reponame }}/bootstrap/ansible/logrotate.tmpl"
+            dest: /etc/logrotate.d/{{ logrotate_entry_name }}
+
         # Prepare the Python virtual environment for the Django application.
 
         - name: Create Python virtual environment directory
@@ -252,7 +257,7 @@
           register: venv_register
           become_user: "{{ djangooperator }}"
           changed_when: venv_register.stdout == "created"
-        
+
         - name: Upgrade pip
           pip:
             name: pip


### PR DESCRIPTION
**Changes**
- Updated the Ansible playbook to configure `logrotate` to rotate the API and portal logs during provisioning.
    - Each log will be rotated weekly, with the last eight files kept. Rotated files, except the most recent one, are compressed.
    - Each rotated file has the date appended, along with the UNIX timestamp to avoid conflicts.

**Notes**
- A separate script is needed to archive the rotated, compressed files before `logrotate` deletes them.