### PR TITLE
Configure optional cron job to backup rotated log files

### DIFF
--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -43,6 +43,8 @@ log_path: /var/log/user_portals/cf_mybrc
 portal_log_file: cf_mybrc_portal.log
 api_log_file: cf_mybrc_api.log
 logrotate_entry_name: cf_mybrc
+# TODO: Logs are only backed up if a path to an existent directory is given.
+log_backup_dir_path:
 
 # Apache settings.
 # The name of the copy of the generated WSGI template in the Apache directory.

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -239,6 +239,21 @@
             src: "{{ git_prefix }}/{{ reponame }}/bootstrap/ansible/logrotate.tmpl"
             dest: /etc/logrotate.d/{{ logrotate_entry_name }}
 
+        - name: Check if an existent directory is given for backing up Django API and portal logs
+          stat:
+            path: "{{ log_backup_dir_path }}"
+          register: log_backup_dir_info
+
+        - name: Install a cron job to back up rotated Django API and portal logs if a directory is given
+          # This job is installed to /var/spool/cron/root.
+          ansible.builtin.cron:
+            name: "Back up rotated Django API and portal logs"
+            minute: "0"
+            hour: "0"
+            day: "15"
+            job: "mv {{ log_path }}/*.gz {{ log_backup_dir_path }}"
+          when: log_backup_dir_info.stat.exists and log_backup_dir_info.stat.isdir
+
         # Prepare the Python virtual environment for the Django application.
 
         - name: Create Python virtual environment directory


### PR DESCRIPTION
**Changes**
- Added an Ansible task to install a cron job to back up rotated log files to a designated directory.
    - The job is only installed if an existent directory is given via the variable `log_backup_dir_path`.
    - The job is configured to run at the first minute on the 15th day of each month.
        - Given that rotated files are kept in the log directory for 8 weeks, no log should be deleted before it is successfully backed up.