### PR TITLE
Exclude project-specific billing IDs if user has irrelevant status on project

### DIFF
--- a/coldfront/core/billing/management/commands/billing_ids.py
+++ b/coldfront/core/billing/management/commands/billing_ids.py
@@ -206,6 +206,10 @@ class Command(BaseCommand):
             line = f'project_default,{project_name},{full_id}'
             self.stdout.write(line)
 
+        # Only display a Recharge entry if the user has one of the following
+        # statuses on the project.
+        relevant_project_user_status_names = [
+            'Active', 'Pending - Add', 'Pending - Remove']
         for allocation_user_attribute in usages.recharge:
             pk = int(allocation_user_attribute.value)
             if billing_id:
@@ -217,6 +221,14 @@ class Command(BaseCommand):
                 full_id_by_billing_activity_pk[pk] = full_id
             project_name = allocation_user_attribute.allocation.project.name
             username = allocation_user_attribute.allocation_user.user.username
+
+            user_has_relevant_status_on_project = ProjectUser.objects.filter(
+                project=allocation_user_attribute.allocation.project,
+                user=allocation_user_attribute.allocation_user.user,
+                status__name__in=relevant_project_user_status_names).exists()
+            if not user_has_relevant_status_on_project:
+                continue
+
             line = f'recharge,{project_name},{username},{full_id}'
             self.stdout.write(line)
 

--- a/coldfront/core/billing/views/admin_views.py
+++ b/coldfront/core/billing/views/admin_views.py
@@ -256,6 +256,10 @@ class BillingIDUsagesSearchView(LoginRequiredMixin, UserPassesTestMixin,
                 'full_id': full_id,
             })
 
+        # Only display a Recharge entry if the user has one of the following
+        # statuses on the project.
+        relevant_project_user_status_names = [
+            'Active', 'Pending - Add', 'Pending - Remove']
         for allocation_user_attribute in usages.recharge:
             pk = int(allocation_user_attribute.value)
             if billing_id:
@@ -267,6 +271,14 @@ class BillingIDUsagesSearchView(LoginRequiredMixin, UserPassesTestMixin,
                 full_id_by_billing_activity_pk[pk] = full_id
             project = allocation_user_attribute.allocation.project
             user = allocation_user_attribute.allocation_user.user
+
+            user_has_relevant_status_on_project = ProjectUser.objects.filter(
+                project=project,
+                user=user,
+                status__name__in=relevant_project_user_status_names).exists()
+            if not user_has_relevant_status_on_project:
+                continue
+
             context['recharge_usages'].append(
                 {
                     'project_pk': project.pk,


### PR DESCRIPTION
**Changes**
- Updated the admin view for listing billing IDs and the `billing_ids` command to avoid listing recharge billing IDs if the corresponding user does not have one of the following statuses on the corresponding project: "Active", "Pending - Add", "Pending - Remove".
    - Currently, that means that users with the following statuses are excluded: "Denied", "Removed".