### PR TITLE
Add AY25-26 periods for BRC/LRC; add UCB 2024-25 calendar periods

### DIFF
--- a/coldfront/core/allocation/management/commands/data/brc_allocation_periods.json
+++ b/coldfront/core/allocation/management/commands/data/brc_allocation_periods.json
@@ -25,6 +25,11 @@
         "end_date": "2025-05-31"
     },
     {
+        "name": "Allowance Year 2025 - 2026",
+        "start_date": "2025-06-01",
+        "end_date": "2026-05-31"
+    },
+    {
         "name": "Fall Semester 2021",
         "start_date": "2021-08-18",
         "end_date": "2021-12-17"
@@ -143,5 +148,45 @@
         "name": "Summer Sessions 2024 - Session F",
         "start_date": "2024-07-01",
         "end_date": "2024-07-19"
+    },
+        {
+        "name": "Fall Semester 2024",
+        "start_date": "2024-08-21",
+        "end_date": "2024-12-20"
+    },
+    {
+        "name": "Spring Semester 2025",
+        "start_date": "2025-01-14",
+        "end_date": "2025-05-16"
+    },
+    {
+        "name": "Summer Sessions 2025 - Session A",
+        "start_date": "2025-05-27",
+        "end_date": "2025-07-03"
+    },
+    {
+        "name": "Summer Sessions 2025 - Session B",
+        "start_date": "2025-06-09",
+        "end_date": "2025-08-15"
+    },
+    {
+        "name": "Summer Sessions 2025 - Session C",
+        "start_date": "2025-06-23",
+        "end_date": "2025-08-15"
+    },
+    {
+        "name": "Summer Sessions 2025 - Session D",
+        "start_date": "2025-07-07",
+        "end_date": "2025-08-15"
+    },
+    {
+        "name": "Summer Sessions 2025 - Session E",
+        "start_date": "2025-07-28",
+        "end_date": "2025-08-15"
+    },
+    {
+        "name": "Summer Sessions 2025 - Session F",
+        "start_date": "2025-07-07",
+        "end_date": "2025-07-25"
     }
 ]

--- a/coldfront/core/allocation/management/commands/data/lrc_allocation_periods.json
+++ b/coldfront/core/allocation/management/commands/data/lrc_allocation_periods.json
@@ -18,5 +18,10 @@
         "name": "Allowance Year 2024 - 2025",
         "start_date": "2024-10-01",
         "end_date": "2025-09-30"
+    },
+    {
+        "name": "Allowance Year 2025 - 2026",
+        "start_date": "2025-10-01",
+        "end_date": "2026-09-30"
     }
 ]


### PR DESCRIPTION
**Changes**
- Added `AllocationPeriod` entries:
    - For "Allowance Year 2025 - 2026" for BRC and LRC.
    - For UC Berkeley [Academic Calendar](https://registrar.berkeley.edu/wp-content/uploads/UCB_AcademicCalendar_2024-25.pdf) semesters and summer sessions for BRC.

**How to Test**
- Ensure that the test suite passes.
- Review the code changes and add comments as needed.
    - In particular, double-check the dates against the calendar linked above.
- Manual Testing
    - For both BRC and LRC:
        - Run `python manage.py create_allocation_periods --dry_run` and ensure that the new periods are listed.
        - Re-run it without the dry run flag and ensure that the new periods are created.
            - Note: They should not appear in the new project request or renewal request flows.