### PR TITLE
Issue 602: Add diagram to display SU usage by user on Allocation Detail page

### DIFF
--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -370,10 +370,8 @@ Allocation Detail
       },
       data: pie_data,
       legend: {
-        item: {
-          onclick: function (id) { }
-        }
-      }
+          position: 'right',
+      },
     });
   }
 

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -183,6 +183,9 @@ Allocation Detail
       <div class="card-body">
         <h3 class="card-title">{{attribute}} by User</h3>
         <div id="user-pie"></div>
+        <div id="no-data-message">
+          <center>No usage data available.</center>
+        </div>
       </div>
     </div>
     {% endfor %}
@@ -358,23 +361,28 @@ Allocation Detail
           }
         }
       });
-
     }
   }
 
   function drawPies(pie_data) {
-    var chart = c3.generate({
-      bindto: '#user-pie',
-      pie: {
-        title: "Service Usage by User"
-      },
-      data: pie_data,
-      legend: {
-          position: 'right',
-      },
-    });
+    if (pie_data.columns[0].length > 1) {
+      var chart = c3.generate({
+        bindto: '#user-pie',
+        pie: {
+          title: "Service Usage by User"
+        },
+        data: pie_data,
+        legend: {
+            position: 'right',
+        },
+      });
+      $('#user-pie').show();
+      $('#no-data-message').hide();
+    } else {
+      $('#user-pie').hide();
+      $('#no-data-message').show();
+    }
   }
-
   $(".datepicker").datepicker({ dateFormat: 'yy-mm-dd' });
 </script>
 

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -346,7 +346,7 @@ Allocation Detail
     var guage_data = {{ guage_data | safe }};
     var pie_data = {{ pie_data | safe }};
   drawGauges(guage_data);
-  drawPies(pie_data)
+  drawPies(pie_data);
   });
 
   function drawGauges(guage_data) {
@@ -373,7 +373,7 @@ Allocation Detail
         },
         data: pie_data,
         legend: {
-            position: 'right',
+          position: 'right',
         },
       });
       $('#user-pie').show();

--- a/coldfront/core/allocation/templates/allocation/allocation_detail.html
+++ b/coldfront/core/allocation/templates/allocation/allocation_detail.html
@@ -178,6 +178,14 @@ Allocation Detail
       </div>
     </div>
     {% endfor %}
+    {% for attribute in attributes_with_usage %}
+    <div class="card mb-3 mr-1">
+      <div class="card-body">
+        <h3 class="card-title">{{attribute}} by User</h3>
+        <div id="user-pie"></div>
+      </div>
+    </div>
+    {% endfor %}
     {% endif %}
   </div>
 </div>
@@ -333,7 +341,9 @@ Allocation Detail
 
   $(document).ready(function () {
     var guage_data = {{ guage_data | safe }};
+    var pie_data = {{ pie_data | safe }};
   drawGauges(guage_data);
+  drawPies(pie_data)
   });
 
   function drawGauges(guage_data) {
@@ -351,6 +361,22 @@ Allocation Detail
 
     }
   }
+
+  function drawPies(pie_data) {
+    var chart = c3.generate({
+      bindto: '#user-pie',
+      pie: {
+        title: "Service Usage by User"
+      },
+      data: pie_data,
+      legend: {
+        item: {
+          onclick: function (id) { }
+        }
+      }
+    });
+  }
+
   $(".datepicker").datepicker({ dateFormat: 'yy-mm-dd' });
 </script>
 

--- a/coldfront/core/allocation/utils.py
+++ b/coldfront/core/allocation/utils.py
@@ -79,7 +79,6 @@ def generate_user_su_pie_data(usage_data):
     pie_data = {
         "columns": [],
         "type": 'pie',
-        "order": 'asc',
     }
     for username, data in usage_data:
         label = "%s: %.2f" % (username, float(data)) 

--- a/coldfront/core/allocation/utils.py
+++ b/coldfront/core/allocation/utils.py
@@ -74,6 +74,18 @@ def generate_guauge_data_from_usage(name, value, usage):
 
     return usage_data
 
+def generate_user_su_pie_data(usage_data):
+
+    pie_data = {
+        "columns": [],
+        "type": 'pie',
+        "order": 'asc',
+    }
+    for username, data in usage_data:
+        label = "%s: %.2f" % (username, float(data)) 
+        if data != '0.00':
+            pie_data['columns'].append([label, data])
+    return pie_data
 
 def get_user_resources(user_obj):
 

--- a/coldfront/core/allocation/views.py
+++ b/coldfront/core/allocation/views.py
@@ -40,7 +40,8 @@ from coldfront.core.allocation.models import (Allocation, AllocationAccount,
 from coldfront.core.allocation.signals import (allocation_activate_user,
                                                allocation_remove_user)
 from coldfront.core.allocation.utils import (generate_guauge_data_from_usage,
-                                             get_user_resources)
+                                             get_user_resources,
+                                             generate_user_su_pie_data)
 from coldfront.core.billing.models import BillingActivity
 from coldfront.core.project.models import (Project, ProjectUser,
                                            ProjectUserStatusChoice)
@@ -276,6 +277,9 @@ class AllocationDetailView(LoginRequiredMixin, UserPassesTestMixin, TemplateView
             can_edit_users = True
 
         context['can_edit_users'] = can_edit_users
+
+        pie_data = generate_user_su_pie_data(allocation_user_su_usages.items())
+        context['pie_data'] = pie_data
 
         return context
 


### PR DESCRIPTION
**Changes**
- Adds a pie chart that displays the SU usage broken down by user. Hovering over a slice brings up the username, used SUs, and percentage of total used for users with positive SU usage.
- Added function in `allocation/utils.py` to generate the pie chart data.
- New `context_data` attribute for `pie_data` in `allocation/views.py`.
- New `drawPies` function in `allocation_detail.html` draws the pie chart, which is inserted right under the existing "Service Units" gauge graph.
- Legend appears to the right of the pie chart in columns.
- When there are no users with non-zero usage, displays a message indicating there is no data available.

**Testing**
- Manual testing can be done by navigating to any project's Allocation Detail page and ensuring things look okay. Good examples (BRC) are:
  - Project with many active users: `allocation/450/`
  - Project with average amount of users: `allocation/369/`
  - Project with one active user: `allocation/11/`
  - Project with no active users: `allocation/2/`