### PR TITLE
Add SU amounts for the next allowance year; fix test bugs relating to transition to new allowance year

### DIFF
--- a/coldfront/core/allocation/tests/test_commands/test_start_allocation_period.py
+++ b/coldfront/core/allocation/tests/test_commands/test_start_allocation_period.py
@@ -9,6 +9,7 @@ import random
 from django.contrib.auth.models import User
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.db.models import Q
 
 from coldfront.api.statistics.utils import get_accounting_allocation_objects
 from coldfront.core.allocation.management.commands.start_allocation_period import Command as StartAllocationPeriodCommand
@@ -73,7 +74,11 @@ class TestStartAllocationPeriod(TestBase):
         self.next_allowance_year = get_next_allowance_year_period()
 
         self.previous_instructional_period = AllocationPeriod.objects.filter(
-            end_date__lt=self.current_date).latest('end_date')
+            Q(end_date__lt=self.current_date) &
+            (Q(name__startswith='Fall') |
+             Q(name__startswith='Spring') |
+             Q(name__startswith='Summer'))
+        ).latest('end_date')
         # There are some dates not covered by instructional AllocationPeriods
         # on which these tests would fail, so create one.
         self.current_instructional_period = AllocationPeriod.objects.create(

--- a/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_under_project_view.py
+++ b/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_under_project_view.py
@@ -165,6 +165,9 @@ class TestAllocationRenewalRequestUnderProjectView(TestBase):
         self.assertTrue(pre_time <= request.request_time <= post_time)
         self.assertTrue(request.renewal_survey_answers)
 
+    # TODO: As of the time of this writing, only one period is selectable.
+    #  Moreover, any future period will have the survey, so this test may be
+    #  obsolete.
     def test_renewal_survey_step_conditionally_required(self):
         """Test that the renewal survey step is only required when the
         selected AllocationPeriod is 'Allowance Year 2024 - 2025'.
@@ -177,7 +180,6 @@ class TestAllocationRenewalRequestUnderProjectView(TestBase):
 
         # The survey only needs to be provided for a particular period.
         success_by_period_name = {
-            'Allowance Year 2023 - 2024': True,
             'Allowance Year 2024 - 2025': False,
         }
 

--- a/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_view.py
+++ b/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_view.py
@@ -162,6 +162,9 @@ class TestAllocationRenewalRequestView(TestBase):
         self.assertTrue(pre_time <= request.request_time <= post_time)
         self.assertTrue(request.renewal_survey_answers)
 
+    # TODO: As of the time of this writing, only one period is selectable.
+    #  Moreover, any future period will have the survey, so this test may be
+    #  obsolete.
     def test_renewal_survey_step_conditionally_required(self):
         """Test that the renewal survey step is only required when the
         selected AllocationPeriod is 'Allowance Year 2024 - 2025'.
@@ -174,7 +177,6 @@ class TestAllocationRenewalRequestView(TestBase):
 
         # The survey only needs to be provided for a particular period.
         success_by_period_name = {
-            'Allowance Year 2023 - 2024': True,
             'Allowance Year 2024 - 2025': False,
         }
 

--- a/coldfront/core/utils/management/commands/data/brc_service_units.json
+++ b/coldfront/core/utils/management/commands/data/brc_service_units.json
@@ -4,7 +4,8 @@
         {"allocation_period": "Allowance Year 2021 - 2022", "value": "300000.00"},
         {"allocation_period": "Allowance Year 2022 - 2023", "value": "300000.00"},
         {"allocation_period": "Allowance Year 2023 - 2024", "value": "300000.00"},
-        {"allocation_period": "Allowance Year 2024 - 2025", "value": "300000.00"}
+        {"allocation_period": "Allowance Year 2024 - 2025", "value": "300000.00"},
+        {"allocation_period": "Allowance Year 2025 - 2026", "value": "300000.00"}
     ],
     "Instructional Computing Allowance": [
         {"allocation_period": "Fall Semester 2021", "value": "200000.00"},
@@ -37,6 +38,7 @@
         {"allocation_period": "Allowance Year 2021 - 2022", "value": "300000.00"},
         {"allocation_period": "Allowance Year 2022 - 2023", "value": "300000.00"},
         {"allocation_period": "Allowance Year 2023 - 2024", "value": "300000.00"},
-        {"allocation_period": "Allowance Year 2024 - 2025", "value": "300000.00"}
+        {"allocation_period": "Allowance Year 2024 - 2025", "value": "300000.00"},
+        {"allocation_period": "Allowance Year 2025 - 2026", "value": "300000.00"}
     ]
 }

--- a/coldfront/core/utils/management/commands/data/lrc_service_units.json
+++ b/coldfront/core/utils/management/commands/data/lrc_service_units.json
@@ -3,6 +3,7 @@
         {"allocation_period": "Allowance Year 2021 - 2022", "value": "300000.00"},
         {"allocation_period": "Allowance Year 2022 - 2023", "value": "300000.00"},
         {"allocation_period": "Allowance Year 2023 - 2024", "value": "500000.00"},
-        {"allocation_period": "Allowance Year 2024 - 2025", "value": "500000.00"}
+        {"allocation_period": "Allowance Year 2024 - 2025", "value": "500000.00"},
+        {"allocation_period": "Allowance Year 2025 - 2026", "value": "500000.00"}
     ]
 }


### PR DESCRIPTION
**Changes**
- Updated the JSONs used to created `TimedResourceAttributes` for service units amounts for "Allowance Year 2025 - 2026".
- Corrected a bug in `test_start_allocation_period` causing an Allowance Year period to be detected as an instructional period.
- Removed testing of "Allowance Year 2023 - 2024" from the tests for whether the renewal survey appears, since that period may no longer be selected.
    - Note: These tests, and the functionality they test, must still be updated to remove the hard-coded period.