### PR TITLE
Issue 598: Display pending request count for each request type

### DIFF
--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -151,6 +151,7 @@ TEMPLATES = [
                 'coldfront.core.utils.context_processors.display_time_zone',
                 'coldfront.core.utils.context_processors.portal_and_program_names',
                 'coldfront.core.utils.context_processors.primary_cluster_name',
+                'coldfront.core.utils.context_processors.request_alert_counts',
             ],
         },
     },

--- a/coldfront/core/utils/context_processors.py
+++ b/coldfront/core/utils/context_processors.py
@@ -87,30 +87,33 @@ def primary_cluster_name(request):
 
 def request_alert_counts(request):
 
-    context = {   
-        'cluster_account_req_count': ClusterAccessRequest.objects.filter(
-            status__name__in=['Pending - Add', 'Processing']).count(),
-        'project_removal_req_count': ProjectUserRemovalRequest.objects.filter(
-            status__name__in=['Pending', 'Processing']).count(),
-        'savio_project_req_count': SavioProjectAllocationRequest.objects.filter(
-            status__name__in=['Under Review', 'Approved - Processing']).count(),
-        'vector_project_req_count': VectorProjectAllocationRequest.objects.filter(
-            status__name__in=['Under Review', 'Approved - Processing']).count(),
-        'project_join_req_count': ProjectUserJoinRequest.objects.filter(
-            project_user__status__name='Pending - Add').count(),
-        'project_renewal_req_count': AllocationRenewalRequest.objects.filter(
-            status__name__in=['Under Review']).count(),
-        'su_purchase_req_count': AllocationAdditionRequest.objects.filter(
-            status__name__in=['Under Review']).count(),
-        'secure_dir_join_req_count': SecureDirAddUserRequest.objects.filter(
-            status__name__in=['Pending', 'Processing']).count(),
-        'secure_dir_remove_req_count': SecureDirRemoveUserRequest.objects.filter(
-            status__name__in=['Pending', 'Processing']).count(),
-        'secure_dir_req_count': SecureDirRequest.objects.filter(
-            status__name__in=['Under Review', 'Approved - Processing']).count(),
-        }
-    context = {k:v for k,v in context.items() if (v > 0)}
-    req_count_sum = sum(context.values())
-    context['request_counts'] = req_count_sum
+    if request.user.is_superuser or request.user.is_staff:
+        context = {   
+            'cluster_account_req_count': ClusterAccessRequest.objects.filter(
+                status__name__in=['Pending - Add', 'Processing']).count(),
+            'project_removal_req_count': ProjectUserRemovalRequest.objects.filter(
+                status__name__in=['Pending', 'Processing']).count(),
+            'savio_project_req_count': SavioProjectAllocationRequest.objects.filter(
+                status__name__in=['Under Review', 'Approved - Processing']).count(),
+            'vector_project_req_count': VectorProjectAllocationRequest.objects.filter(
+                status__name__in=['Under Review', 'Approved - Processing']).count(),
+            'project_join_req_count': ProjectUserJoinRequest.objects.filter(
+                project_user__status__name='Pending - Add').count(),
+            'project_renewal_req_count': AllocationRenewalRequest.objects.filter(
+                status__name__in=['Under Review']).count(),
+            'su_purchase_req_count': AllocationAdditionRequest.objects.filter(
+                status__name__in=['Under Review']).count(),
+            'secure_dir_join_req_count': SecureDirAddUserRequest.objects.filter(
+                status__name__in=['Pending', 'Processing']).count(),
+            'secure_dir_remove_req_count': SecureDirRemoveUserRequest.objects.filter(
+                status__name__in=['Pending', 'Processing']).count(),
+            'secure_dir_req_count': SecureDirRequest.objects.filter(
+                status__name__in=['Under Review', 'Approved - Processing']).count(),
+            }
+        context = {k:v for k,v in context.items() if (v > 0)}
+        req_count_sum = sum(context.values())
+        context['request_counts'] = req_count_sum
 
-    return context
+        return context
+    else:
+        return {}

--- a/coldfront/core/utils/context_processors.py
+++ b/coldfront/core/utils/context_processors.py
@@ -14,6 +14,7 @@ from coldfront.core.project.utils_.renewal_utils import get_current_allowance_ye
 from constance import config
 from django.conf import settings
 from django.db.models import Q
+from flags.state import flag_enabled
 
 import logging
 
@@ -95,13 +96,9 @@ def request_alert_counts(request):
                 status__name__in=['Pending', 'Processing']).count(),
             'savio_project_req_count': SavioProjectAllocationRequest.objects.filter(
                 status__name__in=['Under Review', 'Approved - Processing']).count(),
-            'vector_project_req_count': VectorProjectAllocationRequest.objects.filter(
-                status__name__in=['Under Review', 'Approved - Processing']).count(),
             'project_join_req_count': ProjectUserJoinRequest.objects.filter(
                 project_user__status__name='Pending - Add').count(),
             'project_renewal_req_count': AllocationRenewalRequest.objects.filter(
-                status__name__in=['Under Review']).count(),
-            'su_purchase_req_count': AllocationAdditionRequest.objects.filter(
                 status__name__in=['Under Review']).count(),
             'secure_dir_join_req_count': SecureDirAddUserRequest.objects.filter(
                 status__name__in=['Pending', 'Processing']).count(),
@@ -110,6 +107,17 @@ def request_alert_counts(request):
             'secure_dir_req_count': SecureDirRequest.objects.filter(
                 status__name__in=['Under Review', 'Approved - Processing']).count(),
             }
+        if flag_enabled('SERVICE_UNITS_PURCHASABLE'):
+            context.update(
+                su_purchase_req_count =
+                AllocationAdditionRequest.objects.filter(
+                    status__name__in=['Under Review']).count()
+            )
+        if flag_enabled('BRC_ONLY'):
+            context.update(
+                vector_project_req_count = 
+                VectorProjectAllocationRequest.objects.filter(status__name__in=
+                    ['Under Review', 'Approved - Processing']).count())
         context = {k:v for k,v in context.items() if (v > 0)}
         req_count_sum = sum(context.values())
         context['request_counts'] = req_count_sum

--- a/coldfront/core/utils/context_processors.py
+++ b/coldfront/core/utils/context_processors.py
@@ -93,17 +93,13 @@ def request_alert_counts(request):
         'project_removal_req_count': ProjectUserRemovalRequest.objects.filter(
             status__name__in=['Pending', 'Processing']).count(),
         'savio_project_req_count': SavioProjectAllocationRequest.objects.filter(
-            status__name__in=['Under Review', 'Approved - Processing'])
-            .count(),
+            status__name__in=['Under Review', 'Approved - Processing']).count(),
         'vector_project_req_count': VectorProjectAllocationRequest.objects.filter(
-            status__name__in=['Under Review', 'Approved - Processing']
-            ).count(),
+            status__name__in=['Under Review', 'Approved - Processing']).count(),
         'project_join_req_count': ProjectUserJoinRequest.objects.filter(
-            project_user__status__name='Pending - Add'
-            ).count(),
+            project_user__status__name='Pending - Add').count(),
         'project_renewal_req_count': AllocationRenewalRequest.objects.filter(
-            status__name__in=['Under Review']
-            ).count(),
+            status__name__in=['Under Review']).count(),
         'su_purchase_req_count': AllocationAdditionRequest.objects.filter(
             status__name__in=['Under Review']).count(),
         'secure_dir_join_req_count': SecureDirAddUserRequest.objects.filter(

--- a/coldfront/core/utils/context_processors.py
+++ b/coldfront/core/utils/context_processors.py
@@ -87,38 +87,45 @@ def primary_cluster_name(request):
 
 
 def request_alert_counts(request):
-
     if request.user.is_superuser or request.user.is_staff:
         context = {   
-            'cluster_account_req_count': ClusterAccessRequest.objects.filter(
-                status__name__in=['Pending - Add', 'Processing']).count(),
-            'project_removal_req_count': ProjectUserRemovalRequest.objects.filter(
-                status__name__in=['Pending', 'Processing']).count(),
-            'savio_project_req_count': SavioProjectAllocationRequest.objects.filter(
-                status__name__in=['Under Review', 'Approved - Processing']).count(),
+            'cluster_account_req_count':
+                ClusterAccessRequest.objects.filter(
+                    status__name__in=['Pending - Add', 'Processing']).count(),
+            'project_removal_req_count':
+                ProjectUserRemovalRequest.objects.filter(
+                    status__name__in=['Pending', 'Processing']).count(),
+            'savio_project_req_count':
+                SavioProjectAllocationRequest.objects.filter(
+                    status__name__in=[
+                        'Under Review', 'Approved - Processing']).count(),
             'project_join_req_count': ProjectUserJoinRequest.objects.filter(
                 project_user__status__name='Pending - Add').count(),
-            'project_renewal_req_count': AllocationRenewalRequest.objects.filter(
-                status__name__in=['Under Review']).count(),
+            'project_renewal_req_count':
+                AllocationRenewalRequest.objects.filter(
+                    status__name__in=['Under Review']).count(),
             'secure_dir_join_req_count': SecureDirAddUserRequest.objects.filter(
                 status__name__in=['Pending', 'Processing']).count(),
-            'secure_dir_remove_req_count': SecureDirRemoveUserRequest.objects.filter(
-                status__name__in=['Pending', 'Processing']).count(),
+            'secure_dir_remove_req_count':
+                SecureDirRemoveUserRequest.objects.filter(
+                    status__name__in=['Pending', 'Processing']).count(),
             'secure_dir_req_count': SecureDirRequest.objects.filter(
-                status__name__in=['Under Review', 'Approved - Processing']).count(),
+                status__name__in=[
+                    'Under Review', 'Approved - Processing']).count(),
             }
+
         if flag_enabled('SERVICE_UNITS_PURCHASABLE'):
-            context.update(
-                su_purchase_req_count =
+            context['su_purchase_req_count'] = \
                 AllocationAdditionRequest.objects.filter(
                     status__name__in=['Under Review']).count()
-            )
+
         if flag_enabled('BRC_ONLY'):
-            context.update(
-                vector_project_req_count = 
-                VectorProjectAllocationRequest.objects.filter(status__name__in=
-                    ['Under Review', 'Approved - Processing']).count())
-        context = {k:v for k,v in context.items() if (v > 0)}
+            context['vector_project_req_count'] = \
+                VectorProjectAllocationRequest.objects.filter(
+                    status__name__in=[
+                        'Under Review', 'Approved - Processing']).count()
+
+        context = {k: v for k,v in context.items() if v > 0}
         req_count_sum = sum(context.values())
         context['request_counts'] = req_count_sum
 

--- a/coldfront/core/utils/context_processors.py
+++ b/coldfront/core/utils/context_processors.py
@@ -1,4 +1,14 @@
-from coldfront.core.project.models import ProjectUser
+from coldfront.core.allocation.models import (AllocationRenewalRequest,
+                                              AllocationAdditionRequest,
+                                              SecureDirAddUserRequest,
+                                              SecureDirRemoveUserRequest,
+                                              SecureDirRequest,
+                                              ClusterAccessRequest)
+from coldfront.core.project.models import (ProjectUserRemovalRequest,
+                                           SavioProjectAllocationRequest,
+                                           VectorProjectAllocationRequest,
+                                           ProjectUserJoinRequest,
+                                           ProjectUser)
 from coldfront.core.project.utils_.renewal_utils import get_current_allowance_year_period
 
 from constance import config
@@ -73,3 +83,38 @@ def primary_cluster_name(request):
     return {
         'PRIMARY_CLUSTER_NAME': settings.PRIMARY_CLUSTER_NAME,
     }
+
+
+def request_alert_counts(request):
+
+    context = {   
+        'cluster_account_req_count': ClusterAccessRequest.objects.filter(
+            status__name__in=['Pending - Add', 'Processing']).count(),
+        'project_removal_req_count': ProjectUserRemovalRequest.objects.filter(
+            status__name__in=['Pending', 'Processing']).count(),
+        'savio_project_req_count': SavioProjectAllocationRequest.objects.filter(
+            status__name__in=['Under Review', 'Approved - Processing'])
+            .count(),
+        'vector_project_req_count': VectorProjectAllocationRequest.objects.filter(
+            status__name__in=['Under Review', 'Approved - Processing']
+            ).count(),
+        'project_join_req_count': ProjectUserJoinRequest.objects.filter(
+            project_user__status__name='Pending - Add'
+            ).count(),
+        'project_renewal_req_count': AllocationRenewalRequest.objects.filter(
+            status__name__in=['Under Review']
+            ).count(),
+        'su_purchase_req_count': AllocationAdditionRequest.objects.filter(
+            status__name__in=['Under Review']).count(),
+        'secure_dir_join_req_count': SecureDirAddUserRequest.objects.filter(
+            status__name__in=['Pending', 'Processing']).count(),
+        'secure_dir_remove_req_count': SecureDirRemoveUserRequest.objects.filter(
+            status__name__in=['Pending', 'Processing']).count(),
+        'secure_dir_req_count': SecureDirRequest.objects.filter(
+            status__name__in=['Under Review', 'Approved - Processing']).count(),
+        }
+    context = {k:v for k,v in context.items() if (v > 0)}
+    req_count_sum = sum(context.values())
+    context['request_counts'] = req_count_sum
+
+    return context

--- a/coldfront/static/common/css/common.css
+++ b/coldfront/static/common/css/common.css
@@ -143,6 +143,7 @@ body > main > div > div.card.border-primary > div.card-body > form > div.alert.a
   display: flex !important;
   justify-content: space-between !important;
   align-items: center !important;
+  margin-left: 5px;
 }
 
 

--- a/coldfront/static/common/css/common.css
+++ b/coldfront/static/common/css/common.css
@@ -139,6 +139,11 @@ body > main > div > div.card.border-primary > div.card-body > form > div.alert.a
 	position:relative;
 	top:1px;
 }
+.navbar-align-badges {
+  display: flex !important;
+  justify-content: space-between !important;
+  align-items: center !important;
+}
 
 
 /* Accessibility Modifications

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -4,7 +4,7 @@
 <li id="navbar-admin" class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin</a>
     <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-        <li><a class="dropdown-item" href="/admin">{{ PORTAL_NAME }} Administration</a></li>
+      <li><a class="dropdown-item" href="/admin">{{ PORTAL_NAME }} Administration</a></li>
         <li><a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a></li>
         <li><a id="navbar-jobs-list" class="dropdown-item" href="{% url 'slurm-job-list' %}?show_all_jobs=on">All Jobs</a></li>
         <li><a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a></li>
@@ -19,47 +19,49 @@
         {% endif %}
 
         <li><div class="dropdown-divider"></div></li>
-        <li class="dropdown-submenu"><a id="navbar-admin-requests" class="dropdown-item dropdown-toggle" href="#">Requests</a>
+        <li class="dropdown-submenu"><a id="navbar-admin-requests" class="dropdown-item dropdown-toggle" href="#">Requests 
+          <span class="badge badge-warning">{{ request_counts }}</span>
+        </a>
             <ul class="dropdown-menu">
                 <li><a id="navbar-view-all-requests-admin" class="dropdown-item" href="{% url 'request-hub-admin' %}">
-                  All Requests
+                  All Requests <span class="badge badge-warning">{{ request_counts }}</span>
                 </a></li>
                 <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
-                  Cluster Access Requests
+                  Cluster Access Requests <span class="badge badge-warning">{{ cluster_account_req_count }}</span>
                 </a></li>
                 <li><a id="navbar-project-new-project-requests" class="dropdown-item" href="{% url 'new-project-pending-request-list' %}">
-                  New Project Requests
+                  New Project Requests <span class="badge badge-warning">{{ savio_project_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'BRC_ONLY' as brc_only %}
                 {% if brc_only %}
                 <li><a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
-                  New Vector Project Requests
+                  New Vector Project Requests <span class="badge badge-warning">{{ vector_project_req_count }}</span>
                 </a></li>
                 {% endif %}
                 <li><a id="navbar-project-join-request-list" class="dropdown-item" href="{% url 'project-join-request-list' %}">
-                  Project Join Requests
+                  Project Join Requests <span class="badge badge-warning">{{ project_join_req_count }}</span>
                 </a></li>
                 <li><a id="navbar-project-removal-requests" class="dropdown-item" href="{% url 'project-removal-request-list' %}">
-                  Project Removal Requests
+                  Project Removal Requests <span class="badge badge-warning">{{ project_removal_req_count }}</span>
                 </a></li>
                 <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
-                  Project Renewal Requests
+                  Project Renewal Requests <span class="badge badge-warning">{{ project_renewal_req_count }}</span>
                 </a></li>
                 {% if secure_dirs_requestable %}
                   <li><a id="navbar-secure-directory-requests" class="dropdown-item" href="{% url 'secure-dir-pending-request-list' %}">
-                    Secure Directory Requests
+                    Secure Directory Requests <span class="badge badge-warning">{{ secure_dir_req_count }}</span>
                   </a></li>
                   <li><a id="navbar-secure-dir-add-user-requests" class="dropdown-item" href="{% url 'secure-dir-manage-users-request-list' 'add' 'pending' %}">
-                    Secure Directory Add User Requests
+                    Secure Directory Add User Requests <span class="badge badge-warning">{{ secure_dir_join_req_count }}</span>
                   </a></li>
                   <li><a id="navbar-secure-dir-remove-user-requests" class="dropdown-item" href="{% url 'secure-dir-manage-users-request-list' 'remove' 'pending' %}">
-                    Secure Directory Remove User Requests
+                    Secure Directory Remove User Requests <span class="badge badge-warning">{{ secure_dir_remove_req_count }}</span>
                   </a></li>
                 {% endif %}
                 {% flag_enabled 'SERVICE_UNITS_PURCHASABLE' as service_units_purchasable %}
                 {% if service_units_purchasable %}
                 <li><a id="navbar-service-units-purchase-requests" class="dropdown-item" href="{% url 'service-units-purchase-pending-request-list' %}">
-                  Service Units Purchase Requests
+                  Service Units Purchase Requests <span class="badge badge-warning">{{ su_purchase_req_count }}</span>
                 </a></li>
                 {% endif %}
             </ul>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -2,8 +2,8 @@
 
 
 <li id="navbar-admin" class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin 
-      <span class="badge badge-warning">{{ request_counts }}</span>
+    <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" data-toggle="dropdown">Admin 
+      <span class="badge badge-warning ml-2">{{ request_counts }}</span>
     </a>
     <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
       <li><a class="dropdown-item" href="/admin">{{ PORTAL_NAME }} Administration</a></li>
@@ -21,48 +21,48 @@
         {% endif %}
 
         <li><div class="dropdown-divider"></div></li>
-        <li class="dropdown-submenu"><a id="navbar-admin-requests" class="dropdown-item dropdown-toggle d-flex justify-content-between align-items-center" href="#">Requests 
+        <li class="dropdown-submenu"><a id="navbar-admin-requests" class="dropdown-item dropdown-toggle navbar-align-badges" href="#">Requests 
           <span class="badge badge-warning">{{ request_counts }}</span>
         </a>
             <ul class="dropdown-menu">
-                <li><a id="navbar-view-all-requests-admin" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'request-hub-admin' %}">
+                <li><a id="navbar-view-all-requests-admin" class="dropdown-item navbar-align-badges" href="{% url 'request-hub-admin' %}">
                   All Requests <span class="badge badge-warning">{{ request_counts }}</span>
                 </a></li>
-                <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
+                <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item navbar-align-badges" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
                   Cluster Access Requests <span class="badge badge-warning">{{ cluster_account_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-project-new-project-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'new-project-pending-request-list' %}">
+                <li><a id="navbar-project-new-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'new-project-pending-request-list' %}">
                   New Project Requests <span class="badge badge-warning">{{ savio_project_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'BRC_ONLY' as brc_only %}
                 {% if brc_only %}
-                <li><a id="navbar-project-vector-project-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'vector-project-pending-request-list' %}">
+                <li><a id="navbar-project-vector-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'vector-project-pending-request-list' %}">
                   New Vector Project Requests <span class="badge badge-warning">{{ vector_project_req_count }}</span>
                 </a></li>
                 {% endif %}
-                <li><a id="navbar-project-join-request-list" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'project-join-request-list' %}">
+                <li><a id="navbar-project-join-request-list" class="dropdown-item navbar-align-badges" href="{% url 'project-join-request-list' %}">
                   Project Join Requests <span class="badge badge-warning">{{ project_join_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-project-removal-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'project-removal-request-list' %}">
+                <li><a id="navbar-project-removal-requests" class="dropdown-item navbar-align-badges" href="{% url 'project-removal-request-list' %}">
                   Project Removal Requests <span class="badge badge-warning">{{ project_removal_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
+                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item navbar-align-badges" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
                   Project Renewal Requests <span class="badge badge-warning">{{ project_renewal_req_count }}</span>
                 </a></li>
                 {% if secure_dirs_requestable %}
-                  <li><a id="navbar-secure-directory-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'secure-dir-pending-request-list' %}">
+                  <li><a id="navbar-secure-directory-requests" class="dropdown-item navbar-align-badges" href="{% url 'secure-dir-pending-request-list' %}">
                     Secure Directory Requests <span class="badge badge-warning">{{ secure_dir_req_count }}</span>
                   </a></li>
-                  <li><a id="navbar-secure-dir-add-user-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'secure-dir-manage-users-request-list' 'add' 'pending' %}">
+                  <li><a id="navbar-secure-dir-add-user-requests" class="dropdown-item navbar-align-badges" href="{% url 'secure-dir-manage-users-request-list' 'add' 'pending' %}">
                     Secure Directory Add User Requests <span class="badge badge-warning">{{ secure_dir_join_req_count }}</span>
                   </a></li>
-                  <li><a id="navbar-secure-dir-remove-user-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'secure-dir-manage-users-request-list' 'remove' 'pending' %}">
+                  <li><a id="navbar-secure-dir-remove-user-requests" class="dropdown-item navbar-align-badges" href="{% url 'secure-dir-manage-users-request-list' 'remove' 'pending' %}">
                     Secure Directory Remove User Requests <span class="badge badge-warning">{{ secure_dir_remove_req_count }}</span>
                   </a></li>
                 {% endif %}
                 {% flag_enabled 'SERVICE_UNITS_PURCHASABLE' as service_units_purchasable %}
                 {% if service_units_purchasable %}
-                <li><a id="navbar-service-units-purchase-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'service-units-purchase-pending-request-list' %}">
+                <li><a id="navbar-service-units-purchase-requests" class="dropdown-item navbar-align-badges" href="{% url 'service-units-purchase-pending-request-list' %}">
                   Service Units Purchase Requests <span class="badge badge-warning">{{ su_purchase_req_count }}</span>
                 </a></li>
                 {% endif %}

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -6,7 +6,7 @@
       <span class="badge badge-warning ml-2">{{ request_counts }}</span>
     </a>
     <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-      <li><a class="dropdown-item" href="/admin">{{ PORTAL_NAME }} Administration</a></li>
+        <li><a class="dropdown-item" href="/admin">{{ PORTAL_NAME }} Administration</a></li>
         <li><a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a></li>
         <li><a id="navbar-jobs-list" class="dropdown-item" href="{% url 'slurm-job-list' %}?show_all_jobs=on">All Jobs</a></li>
         <li><a class="dropdown-item" href="{% url 'project-list' %}?show_all_projects=on">All Projects</a></li>
@@ -21,9 +21,10 @@
         {% endif %}
 
         <li><div class="dropdown-divider"></div></li>
-        <li class="dropdown-submenu"><a id="navbar-admin-requests" class="dropdown-item dropdown-toggle navbar-align-badges" href="#">Requests 
+        <li class="dropdown-submenu">
+          <a id="navbar-admin-requests" class="dropdown-item dropdown-toggle navbar-align-badges" href="#">Requests 
           <span class="badge badge-warning">{{ request_counts }}</span>
-        </a>
+          </a>
             <ul class="dropdown-menu">
                 <li><a id="navbar-view-all-requests-admin" class="dropdown-item navbar-align-badges" href="{% url 'request-hub-admin' %}">
                   All Requests <span class="badge badge-warning">{{ request_counts }}</span>
@@ -62,9 +63,9 @@
                 {% endif %}
                 {% flag_enabled 'SERVICE_UNITS_PURCHASABLE' as service_units_purchasable %}
                 {% if service_units_purchasable %}
-                <li><a id="navbar-service-units-purchase-requests" class="dropdown-item navbar-align-badges" href="{% url 'service-units-purchase-pending-request-list' %}">
-                  Service Units Purchase Requests <span class="badge badge-warning">{{ su_purchase_req_count }}</span>
-                </a></li>
+                  <li><a id="navbar-service-units-purchase-requests" class="dropdown-item navbar-align-badges" href="{% url 'service-units-purchase-pending-request-list' %}">
+                    Service Units Purchase Requests <span class="badge badge-warning">{{ su_purchase_req_count }}</span>
+                  </a></li>
                 {% endif %}
             </ul>
         </li>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -2,7 +2,9 @@
 
 
 <li id="navbar-admin" class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin</a>
+    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin
+      <span class="badge badge-warning">{{ request_counts }}</span>
+    </a>
     <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
       <li><a class="dropdown-item" href="/admin">{{ PORTAL_NAME }} Administration</a></li>
         <li><a class="dropdown-item" href="{% url 'allocation-list' %}?show_all_allocations=on">All Allocations</a></li>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -26,44 +26,44 @@
         </a>
             <ul class="dropdown-menu">
                 <li><a id="navbar-view-all-requests-admin" class="dropdown-item" href="{% url 'request-hub-admin' %}">
-                  All Requests <span class="badge badge-warning">{{ request_counts }}</span>
+                  All Requests <span class="badge badge-warning float-right">{{ request_counts }}</span>
                 </a></li>
                 <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
-                  Cluster Access Requests <span class="badge badge-warning">{{ cluster_account_req_count }}</span>
+                  Cluster Access Requests <span class="badge badge-warning float-right">{{ cluster_account_req_count }}</span>
                 </a></li>
                 <li><a id="navbar-project-new-project-requests" class="dropdown-item" href="{% url 'new-project-pending-request-list' %}">
-                  New Project Requests <span class="badge badge-warning">{{ savio_project_req_count }}</span>
+                  New Project Requests <span class="badge badge-warning float-right">{{ savio_project_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'BRC_ONLY' as brc_only %}
                 {% if brc_only %}
                 <li><a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
-                  New Vector Project Requests <span class="badge badge-warning">{{ vector_project_req_count }}</span>
+                  New Vector Project Requests <span class="badge badge-warning float-right">{{ vector_project_req_count }}</span>
                 </a></li>
                 {% endif %}
                 <li><a id="navbar-project-join-request-list" class="dropdown-item" href="{% url 'project-join-request-list' %}">
-                  Project Join Requests <span class="badge badge-warning">{{ project_join_req_count }}</span>
+                  Project Join Requests <span class="badge badge-warning float-right">{{ project_join_req_count }}</span>
                 </a></li>
                 <li><a id="navbar-project-removal-requests" class="dropdown-item" href="{% url 'project-removal-request-list' %}">
-                  Project Removal Requests <span class="badge badge-warning">{{ project_removal_req_count }}</span>
+                  Project Removal Requests <span class="badge badge-warning float-right">{{ project_removal_req_count }}</span>
                 </a></li>
                 <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
-                  Project Renewal Requests <span class="badge badge-warning">{{ project_renewal_req_count }}</span>
+                  Project Renewal Requests <span class="badge badge-warning float-right">{{ project_renewal_req_count }}</span>
                 </a></li>
                 {% if secure_dirs_requestable %}
                   <li><a id="navbar-secure-directory-requests" class="dropdown-item" href="{% url 'secure-dir-pending-request-list' %}">
-                    Secure Directory Requests <span class="badge badge-warning">{{ secure_dir_req_count }}</span>
+                    Secure Directory Requests <span class="badge badge-warning float-right">{{ secure_dir_req_count }}</span>
                   </a></li>
                   <li><a id="navbar-secure-dir-add-user-requests" class="dropdown-item" href="{% url 'secure-dir-manage-users-request-list' 'add' 'pending' %}">
-                    Secure Directory Add User Requests <span class="badge badge-warning">{{ secure_dir_join_req_count }}</span>
+                    Secure Directory Add User Requests <span class="badge badge-warning float-right">{{ secure_dir_join_req_count }}</span>
                   </a></li>
                   <li><a id="navbar-secure-dir-remove-user-requests" class="dropdown-item" href="{% url 'secure-dir-manage-users-request-list' 'remove' 'pending' %}">
-                    Secure Directory Remove User Requests <span class="badge badge-warning">{{ secure_dir_remove_req_count }}</span>
+                    Secure Directory Remove User Requests <span class="badge badge-warning float-right">{{ secure_dir_remove_req_count }}</span>
                   </a></li>
                 {% endif %}
                 {% flag_enabled 'SERVICE_UNITS_PURCHASABLE' as service_units_purchasable %}
                 {% if service_units_purchasable %}
                 <li><a id="navbar-service-units-purchase-requests" class="dropdown-item" href="{% url 'service-units-purchase-pending-request-list' %}">
-                  Service Units Purchase Requests <span class="badge badge-warning">{{ su_purchase_req_count }}</span>
+                  Service Units Purchase Requests <span class="badge badge-warning float-right">{{ su_purchase_req_count }}</span>
                 </a></li>
                 {% endif %}
             </ul>

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -2,7 +2,7 @@
 
 
 <li id="navbar-admin" class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin
+    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Admin 
       <span class="badge badge-warning">{{ request_counts }}</span>
     </a>
     <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
@@ -21,49 +21,49 @@
         {% endif %}
 
         <li><div class="dropdown-divider"></div></li>
-        <li class="dropdown-submenu"><a id="navbar-admin-requests" class="dropdown-item dropdown-toggle" href="#">Requests 
+        <li class="dropdown-submenu"><a id="navbar-admin-requests" class="dropdown-item dropdown-toggle d-flex justify-content-between align-items-center" href="#">Requests 
           <span class="badge badge-warning">{{ request_counts }}</span>
         </a>
             <ul class="dropdown-menu">
-                <li><a id="navbar-view-all-requests-admin" class="dropdown-item" href="{% url 'request-hub-admin' %}">
-                  All Requests <span class="badge badge-warning float-right">{{ request_counts }}</span>
+                <li><a id="navbar-view-all-requests-admin" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'request-hub-admin' %}">
+                  All Requests <span class="badge badge-warning">{{ request_counts }}</span>
                 </a></li>
-                <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
-                  Cluster Access Requests <span class="badge badge-warning float-right">{{ cluster_account_req_count }}</span>
+                <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
+                  Cluster Access Requests <span class="badge badge-warning">{{ cluster_account_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-project-new-project-requests" class="dropdown-item" href="{% url 'new-project-pending-request-list' %}">
-                  New Project Requests <span class="badge badge-warning float-right">{{ savio_project_req_count }}</span>
+                <li><a id="navbar-project-new-project-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'new-project-pending-request-list' %}">
+                  New Project Requests <span class="badge badge-warning">{{ savio_project_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'BRC_ONLY' as brc_only %}
                 {% if brc_only %}
-                <li><a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
-                  New Vector Project Requests <span class="badge badge-warning float-right">{{ vector_project_req_count }}</span>
+                <li><a id="navbar-project-vector-project-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'vector-project-pending-request-list' %}">
+                  New Vector Project Requests <span class="badge badge-warning">{{ vector_project_req_count }}</span>
                 </a></li>
                 {% endif %}
-                <li><a id="navbar-project-join-request-list" class="dropdown-item" href="{% url 'project-join-request-list' %}">
-                  Project Join Requests <span class="badge badge-warning float-right">{{ project_join_req_count }}</span>
+                <li><a id="navbar-project-join-request-list" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'project-join-request-list' %}">
+                  Project Join Requests <span class="badge badge-warning">{{ project_join_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-project-removal-requests" class="dropdown-item" href="{% url 'project-removal-request-list' %}">
-                  Project Removal Requests <span class="badge badge-warning float-right">{{ project_removal_req_count }}</span>
+                <li><a id="navbar-project-removal-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'project-removal-request-list' %}">
+                  Project Removal Requests <span class="badge badge-warning">{{ project_removal_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
-                  Project Renewal Requests <span class="badge badge-warning float-right">{{ project_renewal_req_count }}</span>
+                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
+                  Project Renewal Requests <span class="badge badge-warning">{{ project_renewal_req_count }}</span>
                 </a></li>
                 {% if secure_dirs_requestable %}
-                  <li><a id="navbar-secure-directory-requests" class="dropdown-item" href="{% url 'secure-dir-pending-request-list' %}">
-                    Secure Directory Requests <span class="badge badge-warning float-right">{{ secure_dir_req_count }}</span>
+                  <li><a id="navbar-secure-directory-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'secure-dir-pending-request-list' %}">
+                    Secure Directory Requests <span class="badge badge-warning">{{ secure_dir_req_count }}</span>
                   </a></li>
-                  <li><a id="navbar-secure-dir-add-user-requests" class="dropdown-item" href="{% url 'secure-dir-manage-users-request-list' 'add' 'pending' %}">
-                    Secure Directory Add User Requests <span class="badge badge-warning float-right">{{ secure_dir_join_req_count }}</span>
+                  <li><a id="navbar-secure-dir-add-user-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'secure-dir-manage-users-request-list' 'add' 'pending' %}">
+                    Secure Directory Add User Requests <span class="badge badge-warning">{{ secure_dir_join_req_count }}</span>
                   </a></li>
-                  <li><a id="navbar-secure-dir-remove-user-requests" class="dropdown-item" href="{% url 'secure-dir-manage-users-request-list' 'remove' 'pending' %}">
-                    Secure Directory Remove User Requests <span class="badge badge-warning float-right">{{ secure_dir_remove_req_count }}</span>
+                  <li><a id="navbar-secure-dir-remove-user-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'secure-dir-manage-users-request-list' 'remove' 'pending' %}">
+                    Secure Directory Remove User Requests <span class="badge badge-warning">{{ secure_dir_remove_req_count }}</span>
                   </a></li>
                 {% endif %}
                 {% flag_enabled 'SERVICE_UNITS_PURCHASABLE' as service_units_purchasable %}
                 {% if service_units_purchasable %}
-                <li><a id="navbar-service-units-purchase-requests" class="dropdown-item" href="{% url 'service-units-purchase-pending-request-list' %}">
-                  Service Units Purchase Requests <span class="badge badge-warning float-right">{{ su_purchase_req_count }}</span>
+                <li><a id="navbar-service-units-purchase-requests" class="dropdown-item d-flex justify-content-between align-items-center" href="{% url 'service-units-purchase-pending-request-list' %}">
+                  Service Units Purchase Requests <span class="badge badge-warning">{{ su_purchase_req_count }}</span>
                 </a></li>
                 {% endif %}
             </ul>

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -35,7 +35,7 @@
                     All Requests <span class="badge badge-warning">{{ request_counts }}</span>
                 </a></li>
                 <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item navbar-align-badges" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
-                    Cluster Account Requests <span class="badge badge-warning">{{ cluster_account_req_count }}</span>
+                    Cluster Access Requests <span class="badge badge-warning">{{ cluster_account_req_count }}</span>
                 </a></li>
                 <li><a id="navbar-project-new-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'new-project-pending-request-list' %}">
                     New Project Requests <span class="badge badge-warning">{{ savio_project_req_count }}</span>

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -6,7 +6,9 @@
     since existing templates use javascript to target it by ID
 {% endcomment %}
 <li id="navbar-admin" class="nav-item dropdown">
-    <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">Staff</a>
+    <a class="nav-link dropdown-toggle d-flex align-items-center" href="#" data-toggle="dropdown">Staff
+        <span class="badge badge-warning ml-2">{{ request_counts }}</span>
+    </a>
     <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
     {% comment %}
         all staff can perform a user search
@@ -25,33 +27,38 @@
         {% endif %}
 
         <li><div class="dropdown-divider"></div></li>
-        <li class="dropdown-submenu"><a class="dropdown-item dropdown-toggle" href="#">Requests</a>
+        <li class="dropdown-submenu"><a class="dropdown-item dropdown-toggle navbar-align-badges" href="#">Requests
+            <span class="badge badge-warning">{{ request_counts }}</span>
+        </a>
             <ul class="dropdown-menu">
-                <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
-                    Cluster Account Requests
+                <li><a id="navbar-view-all-requests-admin" class="dropdown-item navbar-align-badges" href="{% url 'request-hub-admin' %}">
+                    All Requests <span class="badge badge-warning">{{ request_counts }}</span>
                 </a></li>
-                <li><a id="navbar-project-new-project-requests" class="dropdown-item" href="{% url 'new-project-pending-request-list' %}">
-                    New Project Requests
+                <li><a id="navbar-allocation-cluster-account-requests" class="dropdown-item navbar-align-badges" href="{% url 'allocation-cluster-account-request-list' %}?show_all_requests=on">
+                    Cluster Account Requests <span class="badge badge-warning">{{ cluster_account_req_count }}</span>
+                </a></li>
+                <li><a id="navbar-project-new-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'new-project-pending-request-list' %}">
+                    New Project Requests <span class="badge badge-warning">{{ savio_project_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'BRC_ONLY' as brc_only %}
                 {% if brc_only %}
-                <li><a id="navbar-project-vector-project-requests" class="dropdown-item" href="{% url 'vector-project-pending-request-list' %}">
-                    New Vector Project Requests
+                <li><a id="navbar-project-vector-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'vector-project-pending-request-list' %}">
+                    New Vector Project Requests <span class="badge badge-warning">{{ vector_project_req_count }}</span>
                 </a></li>
                 {% endif %}
-                <li><a id="navbar-project-join-request-list" class="dropdown-item" href="{% url 'project-join-request-list' %}">
-                    Project Join Requests
+                <li><a id="navbar-project-join-request-list" class="dropdown-item navbar-align-badges" href="{% url 'project-join-request-list' %}">
+                    Project Join Requests <span class="badge badge-warning">{{ project_join_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-project-removal-requests" class="dropdown-item" href="{% url 'project-removal-request-list' %}">
-                    Project Removal Requests
+                <li><a id="navbar-project-removal-requests" class="dropdown-item navbar-align-badges" href="{% url 'project-removal-request-list' %}">
+                    Project Removal Requests <span class="badge badge-warning">{{ project_removal_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
-                    Project Renewal Requests
+                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item navbar-align-badges" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
+                    Project Renewal Requests <span class="badge badge-warning">{{ project_renewal_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'SERVICE_UNITS_PURCHASABLE' as service_units_purchasable %}
                 {% if service_units_purchasable %}
-                <li><a id="navbar-service-units-purchase-requests" class="dropdown-item" href="{% url 'service-units-purchase-pending-request-list' %}">
-                    Service Units Purchase Requests
+                <li><a id="navbar-service-units-purchase-requests" class="dropdown-item navbar-align-badges" href="{% url 'service-units-purchase-pending-request-list' %}">
+                    Service Units Purchase Requests <span class="badge badge-warning ml-2">{{ su_purchase_req_count }}</span>
                 </a></li>
                 {% endif %}
             </ul>


### PR DESCRIPTION
**Changes**
- Display bubble alerts containing the number of pending requests for the relevant request types on navbar and dropdowns for Admin (superuser) and Staff users.
  - Displays sum of counts next to "Requests" and "All Requests" items, as well as next to the "Admin" or "Staff" menu item.
- Calculates request counts in `context_processors.py`

**Testing**
- To manually/visually test, log in as a superuser or staff user, ensure that a yellow badge with a number appears on "Staff" or "Admin" navbar item.
- If you click down to "Requests," all request types with 1 or more pending request should also have badges. Go to "All Requests" and you can ensure the numbers displayed in the dropdown match those on the "All Requests" (`/user/request-hub-admin`) page.