### PR TITLE
Simplify labels for computing allowances in new project request form step

### DIFF
--- a/coldfront/core/project/forms_/new_project_forms/request_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/request_forms.py
@@ -130,9 +130,15 @@ class SavioProjectAllocationPeriodForm(forms.Form):
         return AllocationPeriod.objects.filter(f).order_by(*order_by)
 
 
+class ComputingAllowanceField(forms.ModelChoiceField):
+
+    def label_from_instance(self, obj):
+        return obj.name
+
+
 class ComputingAllowanceForm(forms.Form):
 
-    computing_allowance = forms.ModelChoiceField(
+    computing_allowance = ComputingAllowanceField(
         label='Computing Allowance',
         queryset=Resource.objects.filter(
             resource_type__name='Computing Allowance').order_by('pk'))


### PR DESCRIPTION
**Changes**
- Updated the label for a computing allowance in the first step of the new project request form from e.g.,
    - "Faculty Computing Allowance (Computing Allowance)" to "Faculty Computing Allowance"
    - "Recharge Allocation (Computing Allowance)" to "Recharge Allocation"

**How to Test**
- Ensure that the redundant suffix no longer appears.