### PR TITLE
Install Python dependencies in virtual environment in Docker images to satisfy PEP 668; replace apt-get with apt

### DIFF
--- a/bootstrap/development/docker/README.md
+++ b/bootstrap/development/docker/README.md
@@ -68,12 +68,19 @@ Note that these steps must be run from the root directory of the repo.
    Notes:
      - This step may be run multiple times.
 
-8. Retrieve a PostgreSQL database dump file that will be provided for you. Place it in the root directory of the repo. Load it into your instance. You must provide the name of your Docker project. Note that this may take several minutes.
+8. Retrieve a PostgreSQL database dump file that will be provided for you. Place it in the root directory of the repo. Load it into your instance. You must provide the name of your Docker project.
 
    ```bash
    export RELATIVE_CONTAINER_DUMP_FILE_PATH=YYYY_MM_DD-HH-MM.dump
    sh bootstrap/development/docker/scripts/docker_load_database_backup.sh $DOCKER_PROJECT_NAME $RELATIVE_CONTAINER_DUMP_FILE_PATH
    ```
+
+   Notes:
+     - This may take several minutes.
+     - The following error may appear in the output, but is not an issue:
+       ```
+       ERROR:  role "postgres" already exists
+       ```
 
 9. At this point, the web service should be functioning. Navigate to it from the browser at "http://localhost:WEB_PORT", where `WEB_PORT` is the one defined above.
 

--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,10 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv && \
-    apt install -y libfaketime && \
-    # Necessary for mod-wsgi requirement
-    apt install -y apache2-dev
+FROM coldfront-os
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,12 +1,19 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip && \
-    apt-get install -y libfaketime && \
+RUN apt update && \
+    apt install -y python3 python3-dev python3-pip python3-venv && \
+    apt install -y libfaketime && \
     # Necessary for mod-wsgi requirement
-    apt-get install -y apache2-dev
-
-COPY requirements.txt .
-RUN python3 -m pip install -r requirements.txt
+    apt install -y apache2-dev
 
 WORKDIR /var/www/coldfront_app/coldfront
+
+RUN python3 -m venv /var/www/coldfront_app/venv
+
+COPY requirements.txt .
+# Pin setuptools to avoid ImportError. Source: https://stackoverflow.com/a/78387663
+RUN /var/www/coldfront_app/venv/bin/pip install --upgrade pip wheel && \
+    /var/www/coldfront_app/venv/bin/pip install setuptools==68.2.2 && \
+    /var/www/coldfront_app/venv/bin/pip install -r requirements.txt
+
+ENV PATH="/var/www/coldfront_app/venv/bin:$PATH"

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -8,5 +8,3 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
-
-CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv
+FROM coldfront-os
 
 WORKDIR /app
 
@@ -11,3 +8,5 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
+
+CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip
-
-RUN pip3 install jinja2 pyyaml
+RUN apt update && \
+    apt install -y python3 python3-dev python3-pip python3-venv
 
 WORKDIR /app
+
+RUN python3 -m venv /app/venv
+
+RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
+    /app/venv/bin/pip install jinja2 pyyaml
+
+ENV PATH="/app/venv/bin:$PATH"

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,13 +1,8 @@
-FROM ubuntu:latest
+FROM coldfront-os
 
-RUN apt update && \
-    apt install -y gnupg lsb-release wget
+RUN dnf update -y && \
+    dnf install -y gnupg wget
 
-RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt update && \
-    apt -y install postgresql-client-15
-
-WORKDIR /var/www/coldfront_app/coldfront
+RUN dnf install -y postgresql
 
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y gnupg lsb-release wget
+RUN apt update && \
+    apt install -y gnupg lsb-release wget
 
 RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get -y install postgresql-client-15
+    apt update && \
+    apt -y install postgresql-client-15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -3,7 +3,7 @@ FROM coldfront-os
 RUN dnf update -y && \
     dnf install -y gnupg wget
 
-RUN dnf install -y postgresql
+RUN dnf module install -y postgresql:15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,4 +1,4 @@
-FROM coldfront-os
+FROM coldfront-app-base
 
 RUN dnf update -y && \
     dnf install -y gnupg wget

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -5,4 +5,6 @@ RUN dnf update -y && \
 
 RUN dnf install -y postgresql
 
+WORKDIR /var/www/coldfront_app/coldfront
+
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/os.Dockerfile
+++ b/bootstrap/development/docker/images/os.Dockerfile
@@ -1,0 +1,31 @@
+FROM rockylinux/rockylinux:8.8
+
+RUN dnf update -y && \
+    dnf install -y \
+    gcc \
+    make \
+    wget \
+    openssl-devel \
+    bzip2-devel \
+    httpd-devel \
+    libffi-devel \
+    zlib-devel \
+    readline-devel \
+    redhat-rpm-config \
+    sqlite-devel
+
+RUN mkdir -p /usr/src/python310 && \
+    cd /usr/src/python310 && \
+    wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz && \
+    tar -xzvf Python-3.10.14.tgz && \
+    cd Python-3.10.14 && \
+    ./configure --enable-optimizations --enable-shared && \
+    make && \
+    make install
+
+RUN rm -rf /usr/src/python310
+
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
+    ldconfig
+
+# TODO: libfaketime

--- a/bootstrap/development/docker/scripts/build_images.sh
+++ b/bootstrap/development/docker/scripts/build_images.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+docker build -f bootstrap/development/docker/images/os.Dockerfile -t coldfront-os .
 docker build -f bootstrap/development/docker/images/app-config.Dockerfile -t coldfront-app-config bootstrap/development/docker
 docker build -f bootstrap/development/docker/images/app-base.Dockerfile -t coldfront-app-base .
 docker build -f bootstrap/development/docker/images/app-shell.Dockerfile -t coldfront-app-shell .

--- a/bootstrap/development/docker/scripts/create_env_file.sh
+++ b/bootstrap/development/docker/scripts/create_env_file.sh
@@ -24,4 +24,3 @@ fi
 
 echo "DB_NAME=$DB_NAME" > $ENV_FILE_PATH
 echo "WEB_PORT=$PORT" >> $ENV_FILE_PATH
-

--- a/bootstrap/development/docker/scripts/docker_generate_secrets.sh
+++ b/bootstrap/development/docker/scripts/docker_generate_secrets.sh
@@ -8,8 +8,11 @@ else
     wd=$PWD
 fi
 
+# Do not mount directly onto /app, since the venv is located there and would be
+# wiped out.
 docker run -it \
-    -v $wd/bootstrap/development/docker:/app \
+    -v $wd/bootstrap/development/docker/config:/app/config \
+    -v $wd/bootstrap/development/docker/scripts:/app/scripts \
+    -v $wd/bootstrap/development/docker/secrets:/app/secrets \
     coldfront-app-config:latest \
     python3 scripts/generate_secrets.py
-

--- a/bootstrap/development/docker/scripts/docker_generate_settings.sh
+++ b/bootstrap/development/docker/scripts/docker_generate_settings.sh
@@ -22,8 +22,11 @@ cp coldfront/config/local_strings.py.sample coldfront/config/local_strings.py
 cp bootstrap/ansible/main.copyme bootstrap/development/docker/config/main.yml
 
 # Re-generate the Django development settings file.
+# Do not mount directly onto /app, since the venv is located there and would be
+# wiped out.
 (docker run -it \
     -v $wd/bootstrap/ansible/settings_template.tmpl:/tmp/settings_template.tmpl \
-    -v $wd/bootstrap/development/docker:/app \
+    -v $wd/bootstrap/development/docker/config:/app/config \
+    -v $wd/bootstrap/development/docker/scripts:/app/scripts \
     coldfront-app-config:latest \
     python3 scripts/generate_django_settings_file.py $DEPLOYMENT) 2>/dev/null > coldfront/config/dev_settings.py


### PR DESCRIPTION
**Context**
- The Ubuntu Docker image pulled for Apple Silicon appears to have adopted [PEP 668](https://peps.python.org/pep-0668/), producing the below error when attempting to install Pip requirements in the absence of a virtual environment.
    ```
    error: externally-managed-environment
    
    × This environment is externally managed
    ╰─> To install Python packages system-wide, try apt install
        python3-xyz, where xyz is the package you are trying to
        install.
    
        If you wish to install a non-Debian-packaged Python package,
        create a virtual environment using python3 -m venv path/to/venv.
        Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
        sure you have python3-full installed.
    
        If you wish to install a non-Debian packaged Python application,
        it may be easiest to use pipx install xyz, which will manage a
        virtual environment for you. Make sure you have pipx installed.
    
        See /usr/share/doc/python3.11/README.venv for more information.
    
    note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
    hint: See PEP 668 for the detailed specification.
    ```

**Changes**
- Added a virtual environment to the `app-config` and `app-base` images.
- Prepended the binary directory of the virtual environment to `PATH` in these images so that the environment does not need to be explicitly sourced.
- Replaced `apt-get` calls with `apt` (newer, more user-friendly).

**How to Test**
- Ensure that the Docker build succeeds on both Intel (tested by me) and Apple Silicon.
- Ensure that Django commands (e.g., `python manage.py shell`) can be run in child containers without sourcing the virtual environment.

**Notes**
- It appears that, on Intel, Python 3.10 is installed, but on Apple Silicon, Python 3.11 is.