### PR TITLE
Docker dev. env: Switch to Rocky 8.8; lock Python 3.10

### DIFF
--- a/bootstrap/development/docker/README.md
+++ b/bootstrap/development/docker/README.md
@@ -68,12 +68,19 @@ Note that these steps must be run from the root directory of the repo.
    Notes:
      - This step may be run multiple times.
 
-8. Retrieve a PostgreSQL database dump file that will be provided for you. Place it in the root directory of the repo. Load it into your instance. You must provide the name of your Docker project. Note that this may take several minutes.
+8. Retrieve a PostgreSQL database dump file that will be provided for you. Place it in the root directory of the repo. Load it into your instance. You must provide the name of your Docker project.
 
    ```bash
    export RELATIVE_CONTAINER_DUMP_FILE_PATH=YYYY_MM_DD-HH-MM.dump
    sh bootstrap/development/docker/scripts/docker_load_database_backup.sh $DOCKER_PROJECT_NAME $RELATIVE_CONTAINER_DUMP_FILE_PATH
    ```
+
+   Notes:
+     - This may take several minutes.
+     - The following error may appear in the output, but is not an issue:
+       ```
+       ERROR:  role "postgres" already exists
+       ```
 
 9. At this point, the web service should be functioning. Navigate to it from the browser at "http://localhost:WEB_PORT", where `WEB_PORT` is the one defined above.
 

--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,10 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv && \
-    apt install -y libfaketime && \
-    # Necessary for mod-wsgi requirement
-    apt install -y apache2-dev
+FROM coldfront-os
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -8,5 +8,3 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
-
-CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv
+FROM coldfront-os
 
 WORKDIR /app
 
@@ -11,3 +8,5 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
+
+CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,13 +1,8 @@
-FROM ubuntu:latest
+FROM coldfront-os
 
-RUN apt update && \
-    apt install -y gnupg lsb-release wget
+RUN dnf update -y && \
+    dnf install -y gnupg wget
 
-RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt update && \
-    apt -y install postgresql-client-15
-
-WORKDIR /var/www/coldfront_app/coldfront
+RUN dnf install -y postgresql
 
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -3,7 +3,7 @@ FROM coldfront-os
 RUN dnf update -y && \
     dnf install -y gnupg wget
 
-RUN dnf install -y postgresql
+RUN dnf module install -y postgresql:15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,4 +1,4 @@
-FROM coldfront-os
+FROM coldfront-app-base
 
 RUN dnf update -y && \
     dnf install -y gnupg wget

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -5,4 +5,6 @@ RUN dnf update -y && \
 
 RUN dnf install -y postgresql
 
+WORKDIR /var/www/coldfront_app/coldfront
+
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/os.Dockerfile
+++ b/bootstrap/development/docker/images/os.Dockerfile
@@ -1,0 +1,31 @@
+FROM rockylinux/rockylinux:8.8
+
+RUN dnf update -y && \
+    dnf install -y \
+    gcc \
+    make \
+    wget \
+    openssl-devel \
+    bzip2-devel \
+    httpd-devel \
+    libffi-devel \
+    zlib-devel \
+    readline-devel \
+    redhat-rpm-config \
+    sqlite-devel
+
+RUN mkdir -p /usr/src/python310 && \
+    cd /usr/src/python310 && \
+    wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz && \
+    tar -xzvf Python-3.10.14.tgz && \
+    cd Python-3.10.14 && \
+    ./configure --enable-optimizations --enable-shared && \
+    make && \
+    make install
+
+RUN rm -rf /usr/src/python310
+
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
+    ldconfig
+
+# TODO: libfaketime

--- a/bootstrap/development/docker/scripts/build_images.sh
+++ b/bootstrap/development/docker/scripts/build_images.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+docker build -f bootstrap/development/docker/images/os.Dockerfile -t coldfront-os .
 docker build -f bootstrap/development/docker/images/app-config.Dockerfile -t coldfront-app-config bootstrap/development/docker
 docker build -f bootstrap/development/docker/images/app-base.Dockerfile -t coldfront-app-base .
 docker build -f bootstrap/development/docker/images/app-shell.Dockerfile -t coldfront-app-shell .


### PR DESCRIPTION
**Changes**
- Changed the underlying base Docker image from `ubuntu:latest` to `rockylinux:8.8`.
- Installed Python 3.10 from source to avoid differences between e.g., Intel and Apple Silicon, as well as incompatibilities caused by later versions of Python (e.g., 3.12).
- Moved dependency installation (including Python) into a new base image `os`, inherited by `app-base` and `app-config`.
- Updated the Docker `README.md` to note that an error may arise during the database load, but is not an issue.

**How to Test**
- Ensure that the Docker build succeeds on both Intel (tested by me) and Apple Silicon.
- Ensure that the development environment instructions work from beginning to end.