### PR TITLE
Define SUs for ICAs periods for UCB Academic Year 24-25

### DIFF
--- a/coldfront/core/allocation/management/commands/data/brc_allocation_periods.json
+++ b/coldfront/core/allocation/management/commands/data/brc_allocation_periods.json
@@ -149,7 +149,7 @@
         "start_date": "2024-07-01",
         "end_date": "2024-07-19"
     },
-        {
+    {
         "name": "Fall Semester 2024",
         "start_date": "2024-08-21",
         "end_date": "2024-12-20"

--- a/coldfront/core/utils/management/commands/data/brc_service_units.json
+++ b/coldfront/core/utils/management/commands/data/brc_service_units.json
@@ -31,7 +31,15 @@
         {"allocation_period": "Summer Sessions 2024 - Session C", "value": "200000.00"},
         {"allocation_period": "Summer Sessions 2024 - Session D", "value": "200000.00"},
         {"allocation_period": "Summer Sessions 2024 - Session E", "value": "200000.00"},
-        {"allocation_period": "Summer Sessions 2024 - Session F", "value": "200000.00"}
+        {"allocation_period": "Summer Sessions 2024 - Session F", "value": "200000.00"},
+        {"allocation_period": "Fall Semester 2024", "value": "200000.00"},
+        {"allocation_period": "Spring Semester 2025", "value": "200000.00"},
+        {"allocation_period": "Summer Sessions 2025 - Session A", "value": "200000.00"},
+        {"allocation_period": "Summer Sessions 2025 - Session B", "value": "200000.00"},
+        {"allocation_period": "Summer Sessions 2025 - Session C", "value": "200000.00"},
+        {"allocation_period": "Summer Sessions 2025 - Session D", "value": "200000.00"},
+        {"allocation_period": "Summer Sessions 2025 - Session E", "value": "200000.00"},
+        {"allocation_period": "Summer Sessions 2025 - Session F", "value": "200000.00"}
     ],
     "Partner Computing Allowance": [
         {"allocation_period": "Allowance Year 2020 - 2021", "value": "300000.00"},


### PR DESCRIPTION
**Context**
- The form for requesting a new project with the computing allowance "Instructional Computing Allowance" is failing on MyBRC.
    - The form for selecting the allocation period is raising an error. Each period has a number of service units to be granted with it, and that number is pulled from the database for display, but the number was not defined for some of the options, leading to an error.

**Changes**
- Defined the number of SUs to be granted for missing allocation periods in the JSON file read by the `add_allowance_defaults` command, which will need to be run to fill in the missing values.

**Notes**
- Consider how this can be avoided in the future.