### PR TITLE
Method for renewing Instructional Computing Allowances (ICAs)

### DIFF
--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,10 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv && \
-    apt install -y libfaketime && \
-    # Necessary for mod-wsgi requirement
-    apt install -y apache2-dev
+FROM coldfront-os
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,12 +1,19 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip && \
-    apt-get install -y libfaketime && \
+RUN apt update && \
+    apt install -y python3 python3-dev python3-pip python3-venv && \
+    apt install -y libfaketime && \
     # Necessary for mod-wsgi requirement
-    apt-get install -y apache2-dev
-
-COPY requirements.txt .
-RUN python3 -m pip install -r requirements.txt
+    apt install -y apache2-dev
 
 WORKDIR /var/www/coldfront_app/coldfront
+
+RUN python3 -m venv /var/www/coldfront_app/venv
+
+COPY requirements.txt .
+# Pin setuptools to avoid ImportError. Source: https://stackoverflow.com/a/78387663
+RUN /var/www/coldfront_app/venv/bin/pip install --upgrade pip wheel && \
+    /var/www/coldfront_app/venv/bin/pip install setuptools==68.2.2 && \
+    /var/www/coldfront_app/venv/bin/pip install -r requirements.txt
+
+ENV PATH="/var/www/coldfront_app/venv/bin:$PATH"

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -8,5 +8,3 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
-
-CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv
+FROM coldfront-os
 
 WORKDIR /app
 
@@ -11,3 +8,5 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
+
+CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip
-
-RUN pip3 install jinja2 pyyaml
+RUN apt update && \
+    apt install -y python3 python3-dev python3-pip python3-venv
 
 WORKDIR /app
+
+RUN python3 -m venv /app/venv
+
+RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
+    /app/venv/bin/pip install jinja2 pyyaml
+
+ENV PATH="/app/venv/bin:$PATH"

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,13 +1,8 @@
-FROM ubuntu:latest
+FROM coldfront-os
 
-RUN apt update && \
-    apt install -y gnupg lsb-release wget
+RUN dnf update -y && \
+    dnf install -y gnupg wget
 
-RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt update && \
-    apt -y install postgresql-client-15
-
-WORKDIR /var/www/coldfront_app/coldfront
+RUN dnf install -y postgresql
 
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y gnupg lsb-release wget
+RUN apt update && \
+    apt install -y gnupg lsb-release wget
 
 RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get -y install postgresql-client-15
+    apt update && \
+    apt -y install postgresql-client-15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -3,7 +3,7 @@ FROM coldfront-os
 RUN dnf update -y && \
     dnf install -y gnupg wget
 
-RUN dnf install -y postgresql
+RUN dnf module install -y postgresql:15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,4 +1,4 @@
-FROM coldfront-os
+FROM coldfront-app-base
 
 RUN dnf update -y && \
     dnf install -y gnupg wget

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -5,4 +5,6 @@ RUN dnf update -y && \
 
 RUN dnf install -y postgresql
 
+WORKDIR /var/www/coldfront_app/coldfront
+
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/os.Dockerfile
+++ b/bootstrap/development/docker/images/os.Dockerfile
@@ -1,0 +1,31 @@
+FROM rockylinux/rockylinux:8.8
+
+RUN dnf update -y && \
+    dnf install -y \
+    gcc \
+    make \
+    wget \
+    openssl-devel \
+    bzip2-devel \
+    httpd-devel \
+    libffi-devel \
+    zlib-devel \
+    readline-devel \
+    redhat-rpm-config \
+    sqlite-devel
+
+RUN mkdir -p /usr/src/python310 && \
+    cd /usr/src/python310 && \
+    wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz && \
+    tar -xzvf Python-3.10.14.tgz && \
+    cd Python-3.10.14 && \
+    ./configure --enable-optimizations --enable-shared && \
+    make && \
+    make install
+
+RUN rm -rf /usr/src/python310
+
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
+    ldconfig
+
+# TODO: libfaketime

--- a/bootstrap/development/docker/scripts/build_images.sh
+++ b/bootstrap/development/docker/scripts/build_images.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+docker build -f bootstrap/development/docker/images/os.Dockerfile -t coldfront-os .
 docker build -f bootstrap/development/docker/images/app-config.Dockerfile -t coldfront-app-config bootstrap/development/docker
 docker build -f bootstrap/development/docker/images/app-base.Dockerfile -t coldfront-app-base .
 docker build -f bootstrap/development/docker/images/app-shell.Dockerfile -t coldfront-app-shell .

--- a/bootstrap/development/docker/scripts/create_env_file.sh
+++ b/bootstrap/development/docker/scripts/create_env_file.sh
@@ -24,4 +24,3 @@ fi
 
 echo "DB_NAME=$DB_NAME" > $ENV_FILE_PATH
 echo "WEB_PORT=$PORT" >> $ENV_FILE_PATH
-

--- a/bootstrap/development/docker/scripts/docker_generate_secrets.sh
+++ b/bootstrap/development/docker/scripts/docker_generate_secrets.sh
@@ -8,8 +8,11 @@ else
     wd=$PWD
 fi
 
+# Do not mount directly onto /app, since the venv is located there and would be
+# wiped out.
 docker run -it \
-    -v $wd/bootstrap/development/docker:/app \
+    -v $wd/bootstrap/development/docker/config:/app/config \
+    -v $wd/bootstrap/development/docker/scripts:/app/scripts \
+    -v $wd/bootstrap/development/docker/secrets:/app/secrets \
     coldfront-app-config:latest \
     python3 scripts/generate_secrets.py
-

--- a/bootstrap/development/docker/scripts/docker_generate_settings.sh
+++ b/bootstrap/development/docker/scripts/docker_generate_settings.sh
@@ -22,8 +22,11 @@ cp coldfront/config/local_strings.py.sample coldfront/config/local_strings.py
 cp bootstrap/ansible/main.copyme bootstrap/development/docker/config/main.yml
 
 # Re-generate the Django development settings file.
+# Do not mount directly onto /app, since the venv is located there and would be
+# wiped out.
 (docker run -it \
     -v $wd/bootstrap/ansible/settings_template.tmpl:/tmp/settings_template.tmpl \
-    -v $wd/bootstrap/development/docker:/app \
+    -v $wd/bootstrap/development/docker/config:/app/config \
+    -v $wd/bootstrap/development/docker/scripts:/app/scripts \
     coldfront-app-config:latest \
     python3 scripts/generate_django_settings_file.py $DEPLOYMENT) 2>/dev/null > coldfront/config/dev_settings.py

--- a/coldfront/core/project/management/commands/projects.py
+++ b/coldfront/core/project/management/commands/projects.py
@@ -100,6 +100,7 @@ class Command(BaseCommand):
             'renew',
             help=(
                 'Renew ICA projects that have the Inactive status.'
+                'This command will approve and process the request.'
                 ))
         
         parser.add_argument(
@@ -108,7 +109,8 @@ class Command(BaseCommand):
         parser.add_argument(
             'username',
             help=(
-                'The username of the user making the request.'),
+                'The username of the user making the request.'
+                'The requester should be the project Principal Investigator.'),
             type=str)
         
         parser.add_argument(
@@ -227,7 +229,6 @@ class Command(BaseCommand):
         status = AllocationRenewalRequestStatusChoice.objects.get(name='Under Review')
         computing_allowance = Resource.objects.get(
             name='Instructional Computing Allowance')
-        # TODO:
         pi = requester
 
         request = AllocationRenewalRequest.objects.create(
@@ -378,6 +379,11 @@ class Command(BaseCommand):
         except Project.DoesNotExist:
             raise CommandError(
                 f'A Project with name "{project_name}" does not exist.')
+        else:
+            if not project_name.startswith("ic_"):
+                raise CommandError(
+                    f'The project with name "{project_name}" is not an ICA.'
+                )
         
         input_username = options['username']
         requester = None


### PR DESCRIPTION
Based off code from @matthew-li 
- This PR contains updated `projects` command-line tool (`coldfront.core.project.management.commands.projects`) to enable renewal of ICA projects that have the "Inactive" status.
    - Added a subcommand `renew` by which this can be done.
        - It takes arguments: the name of the `Project`, the username of the `User` making the request, and the name of the `AllocationPeriod` the allowance will be valid for.
        - It will approve and process the request. I will provide you with some example code I've run manually in the past that should be adapted into this command.
        - Disallow renewals of other project types at this point (so only ICAs).
        - There should be a `dry_run` flag (see the `create` subcommand).