### PR TITLE
Make it more clear to users that these are not handled by cluster administrators.

### DIFF
--- a/coldfront/core/project/templates/project/project_join_request_list.html
+++ b/coldfront/core/project/templates/project/project_join_request_list.html
@@ -22,6 +22,10 @@ Project Join Requests
             cluster access under the project will automatically be created, to be processed
             by cluster administrators.
         </td>
+         <b>
+            Please contact a project manager or PI if your request has not been
+            reviewed in a reasonable time frame.
+          </b>
       </tr>
     </tbody>
   </table>

--- a/coldfront/core/project/templates/project/project_join_request_list_table.html
+++ b/coldfront/core/project/templates/project/project_join_request_list_table.html
@@ -23,6 +23,10 @@
     <th scope="col">
       Reason
     </th>
+    <th scope="col">
+      Status
+      {% include 'common/table_sorter.html' with table_sorter_field='project_user__status__name' %}
+    </th>
   </tr>
   </thead>
   <tbody>
@@ -41,6 +45,9 @@
       <td>{{ join_request.created|date:"M. d, Y" }}</td>
       <td>
         {{ join_request.reason }}
+      </td>
+      <td>
+        {{ join_request.project_user.status.name }}
       </td>
     </tr>
   {% endfor %}

--- a/coldfront/core/project/views_/join_views/approval_views.py
+++ b/coldfront/core/project/views_/join_views/approval_views.py
@@ -255,6 +255,8 @@ class ProjectJoinRequestListView(LoginRequiredMixin, UserPassesTestMixin,
                     'Pending - Add').order_by(
                     'project_user', '-created').distinct(
                     'project_user'))
+            
+        project_join_requests = project_join_requests.select_related('project_user__status')
 
         join_request_search_form = JoinRequestSearchForm(self.request.GET)
 
@@ -328,6 +330,8 @@ class ProjectJoinRequestListView(LoginRequiredMixin, UserPassesTestMixin,
             filter_parameters_with_order_by
 
         join_request_queryset = self.get_queryset()
+        
+        join_request_queryset = join_request_queryset.select_related('project_user__status')
 
         paginator = Paginator(join_request_queryset, self.paginate_by)
 


### PR DESCRIPTION
In the table of requests on [Requests > Project Join Requests > Go To Project Join Requests Main Page] , display a status column indicating that it's pending on project PIs/managers.

Add the bolded "Please contact..." text in Project > Join a Project to above page.