### PR TITLE
Issue 610: Superusers can create standalone clusters from UI

### DIFF
--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,10 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv && \
-    apt install -y libfaketime && \
-    # Necessary for mod-wsgi requirement
-    apt install -y apache2-dev
+FROM coldfront-os
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,12 +1,19 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip && \
-    apt-get install -y libfaketime && \
+RUN apt update && \
+    apt install -y python3 python3-dev python3-pip python3-venv && \
+    apt install -y libfaketime && \
     # Necessary for mod-wsgi requirement
-    apt-get install -y apache2-dev
-
-COPY requirements.txt .
-RUN python3 -m pip install -r requirements.txt
+    apt install -y apache2-dev
 
 WORKDIR /var/www/coldfront_app/coldfront
+
+RUN python3 -m venv /var/www/coldfront_app/venv
+
+COPY requirements.txt .
+# Pin setuptools to avoid ImportError. Source: https://stackoverflow.com/a/78387663
+RUN /var/www/coldfront_app/venv/bin/pip install --upgrade pip wheel && \
+    /var/www/coldfront_app/venv/bin/pip install setuptools==68.2.2 && \
+    /var/www/coldfront_app/venv/bin/pip install -r requirements.txt
+
+ENV PATH="/var/www/coldfront_app/venv/bin:$PATH"

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -8,5 +8,3 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
-
-CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv
+FROM coldfront-os
 
 WORKDIR /app
 
@@ -11,3 +8,5 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
+
+CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip
-
-RUN pip3 install jinja2 pyyaml
+RUN apt update && \
+    apt install -y python3 python3-dev python3-pip python3-venv
 
 WORKDIR /app
+
+RUN python3 -m venv /app/venv
+
+RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
+    /app/venv/bin/pip install jinja2 pyyaml
+
+ENV PATH="/app/venv/bin:$PATH"

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,13 +1,8 @@
-FROM ubuntu:latest
+FROM coldfront-os
 
-RUN apt update && \
-    apt install -y gnupg lsb-release wget
+RUN dnf update -y && \
+    dnf install -y gnupg wget
 
-RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt update && \
-    apt -y install postgresql-client-15
-
-WORKDIR /var/www/coldfront_app/coldfront
+RUN dnf install -y postgresql
 
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y gnupg lsb-release wget
+RUN apt update && \
+    apt install -y gnupg lsb-release wget
 
 RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get -y install postgresql-client-15
+    apt update && \
+    apt -y install postgresql-client-15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -3,7 +3,7 @@ FROM coldfront-os
 RUN dnf update -y && \
     dnf install -y gnupg wget
 
-RUN dnf install -y postgresql
+RUN dnf module install -y postgresql:15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,4 +1,4 @@
-FROM coldfront-os
+FROM coldfront-app-base
 
 RUN dnf update -y && \
     dnf install -y gnupg wget

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -5,4 +5,6 @@ RUN dnf update -y && \
 
 RUN dnf install -y postgresql
 
+WORKDIR /var/www/coldfront_app/coldfront
+
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/os.Dockerfile
+++ b/bootstrap/development/docker/images/os.Dockerfile
@@ -1,0 +1,31 @@
+FROM rockylinux/rockylinux:8.8
+
+RUN dnf update -y && \
+    dnf install -y \
+    gcc \
+    make \
+    wget \
+    openssl-devel \
+    bzip2-devel \
+    httpd-devel \
+    libffi-devel \
+    zlib-devel \
+    readline-devel \
+    redhat-rpm-config \
+    sqlite-devel
+
+RUN mkdir -p /usr/src/python310 && \
+    cd /usr/src/python310 && \
+    wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz && \
+    tar -xzvf Python-3.10.14.tgz && \
+    cd Python-3.10.14 && \
+    ./configure --enable-optimizations --enable-shared && \
+    make && \
+    make install
+
+RUN rm -rf /usr/src/python310
+
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
+    ldconfig
+
+# TODO: libfaketime

--- a/bootstrap/development/docker/scripts/build_images.sh
+++ b/bootstrap/development/docker/scripts/build_images.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+docker build -f bootstrap/development/docker/images/os.Dockerfile -t coldfront-os .
 docker build -f bootstrap/development/docker/images/app-config.Dockerfile -t coldfront-app-config bootstrap/development/docker
 docker build -f bootstrap/development/docker/images/app-base.Dockerfile -t coldfront-app-base .
 docker build -f bootstrap/development/docker/images/app-shell.Dockerfile -t coldfront-app-shell .

--- a/bootstrap/development/docker/scripts/create_env_file.sh
+++ b/bootstrap/development/docker/scripts/create_env_file.sh
@@ -24,4 +24,3 @@ fi
 
 echo "DB_NAME=$DB_NAME" > $ENV_FILE_PATH
 echo "WEB_PORT=$PORT" >> $ENV_FILE_PATH
-

--- a/bootstrap/development/docker/scripts/docker_generate_secrets.sh
+++ b/bootstrap/development/docker/scripts/docker_generate_secrets.sh
@@ -8,8 +8,11 @@ else
     wd=$PWD
 fi
 
+# Do not mount directly onto /app, since the venv is located there and would be
+# wiped out.
 docker run -it \
-    -v $wd/bootstrap/development/docker:/app \
+    -v $wd/bootstrap/development/docker/config:/app/config \
+    -v $wd/bootstrap/development/docker/scripts:/app/scripts \
+    -v $wd/bootstrap/development/docker/secrets:/app/secrets \
     coldfront-app-config:latest \
     python3 scripts/generate_secrets.py
-

--- a/bootstrap/development/docker/scripts/docker_generate_settings.sh
+++ b/bootstrap/development/docker/scripts/docker_generate_settings.sh
@@ -22,8 +22,11 @@ cp coldfront/config/local_strings.py.sample coldfront/config/local_strings.py
 cp bootstrap/ansible/main.copyme bootstrap/development/docker/config/main.yml
 
 # Re-generate the Django development settings file.
+# Do not mount directly onto /app, since the venv is located there and would be
+# wiped out.
 (docker run -it \
     -v $wd/bootstrap/ansible/settings_template.tmpl:/tmp/settings_template.tmpl \
-    -v $wd/bootstrap/development/docker:/app \
+    -v $wd/bootstrap/development/docker/config:/app/config \
+    -v $wd/bootstrap/development/docker/scripts:/app/scripts \
     coldfront-app-config:latest \
     python3 scripts/generate_django_settings_file.py $DEPLOYMENT) 2>/dev/null > coldfront/config/dev_settings.py

--- a/coldfront/core/project/forms_/new_project_forms/request_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/request_forms.py
@@ -858,7 +858,7 @@ class VectorProjectDetailsForm(forms.Form):
 class StandaloneClusterDetailsForm(forms.Form):
     name = forms.CharField(
         help_text=(
-            'The unique name of the project, which must contain only '
+            'The unique name of the standalone cluster, which must contain only '
             'lowercase letters and numbers.'),
         label='Name',
         max_length=12,
@@ -870,16 +870,8 @@ class StandaloneClusterDetailsForm(forms.Form):
                 message=(
                     'Name must contain only lowercase letters and numbers.'))
         ])
-    title = forms.CharField(
-        help_text='A unique, human-readable title for the project.',
-        label='Title',
-        max_length=255,
-        required=True,
-        validators=[
-            MinLengthValidator(4),
-        ])
     description = forms.CharField(
-        help_text='A few sentences describing your project.',
+        help_text='A few sentences describing your standalone cluster.',
         label='Description',
         validators=[MinLengthValidator(10)],
         widget=forms.Textarea(attrs={'rows': 3}))
@@ -991,3 +983,12 @@ class StandaloneClusterNewManagerForm(forms.Form):
                 'A user with that email address already exists.')
 
         return email
+
+class StandaloneClusterReviewAndSubmitForm(forms.Form):
+
+    confirmation = forms.BooleanField(
+        label=(
+            'I have reviewed my selections and understand the changes '
+            'described above. Submit my request.'),
+        required=True)
+    

--- a/coldfront/core/project/forms_/new_project_forms/request_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/request_forms.py
@@ -870,6 +870,27 @@ class StandaloneClusterDetailsForm(forms.Form):
                 message=(
                     'Name must contain only lowercase letters and numbers.'))
         ])
+    title = forms.CharField(
+        help_text='A unique, human-readable title for the project.',
+        label='Title',
+        max_length=255,
+        required=True,
+        validators=[
+            MinLengthValidator(4),
+        ])
+    description = forms.CharField(
+        help_text='A few sentences describing your project.',
+        label='Description',
+        validators=[MinLengthValidator(10)],
+        widget=forms.Textarea(attrs={'rows': 3}))
+
+    def clean_name(self):
+        cleaned_data = super().clean()
+        name = cleaned_data['name'].lower()
+        if Project.objects.filter(name=name):
+            raise forms.ValidationError(
+                f'A project with name {name} already exists.')
+        return name
 
 class StandaloneClusterExistingPIForm(forms.Form):
     PI = PIChoiceField(

--- a/coldfront/core/project/management/commands/projects.py
+++ b/coldfront/core/project/management/commands/projects.py
@@ -6,12 +6,7 @@ from django.db import transaction
 
 from flags.state import flag_enabled
 
-from coldfront.core.allocation.models import Allocation
-from coldfront.core.allocation.models import AllocationAttribute
-from coldfront.core.allocation.models import AllocationAttributeType
-from coldfront.core.allocation.models import AllocationStatusChoice
 from coldfront.core.project.models import Project
-from coldfront.core.project.models import ProjectStatusChoice
 from coldfront.core.project.models import ProjectUser
 from coldfront.core.project.models import ProjectUserRoleChoice
 from coldfront.core.project.models import ProjectUserStatusChoice
@@ -21,10 +16,7 @@ from coldfront.core.project.utils_.new_project_user_utils import NewProjectUserR
 from coldfront.core.project.utils_.new_project_user_utils import NewProjectUserSource
 from coldfront.core.resource.models import Resource
 from coldfront.core.resource.utils import get_primary_compute_resource_name
-from coldfront.core.statistics.models import ProjectTransaction
 from coldfront.core.utils.common import add_argparse_dry_run_argument
-from coldfront.core.utils.common import display_time_zone_current_date
-from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.utils.email.email_strategy import DropEmailStrategy
 
 import logging

--- a/coldfront/core/project/templates/project/project_list.html
+++ b/coldfront/core/project/templates/project/project_list.html
@@ -16,12 +16,6 @@
         <i class="fas fa-plus" aria-hidden="true"></i>
         Create a project
       </a>
-      {% if user.is_superuser %}
-        <a class="btn btn-primary" href="{% url 'new-standalone-cluster-request' %}" role="button">
-          <i class="fas fa-plus" aria-hidden="true"></i>
-          Create a standalone cluster
-        </a>
-      {% endif %}
       <a class="btn btn-primary" href="{% url 'project-join-list' %}" role="button">
         <i class="fas fa-user-plus" aria-hidden="true"></i>
         Join a project

--- a/coldfront/core/project/templates/project/project_list.html
+++ b/coldfront/core/project/templates/project/project_list.html
@@ -16,6 +16,12 @@
         <i class="fas fa-plus" aria-hidden="true"></i>
         Create a project
       </a>
+      {% if user.is_superuser %}
+        <a class="btn btn-primary" href="{% url 'new-standalone-cluster-request' %}" role="button">
+          <i class="fas fa-plus" aria-hidden="true"></i>
+          Create a standalone cluster
+        </a>
+      {% endif %}
       <a class="btn btn-primary" href="{% url 'project-join-list' %}" role="button">
         <i class="fas fa-user-plus" aria-hidden="true"></i>
         Join a project

--- a/coldfront/core/project/templates/project/project_request/standalone_cluster/project_details.html
+++ b/coldfront/core/project/templates/project/project_request/standalone_cluster/project_details.html
@@ -1,0 +1,60 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+New Standalone Cluster - Project Details
+{% endblock %}
+
+
+{% block head %}
+{{ wizard.form.media }}
+{% endblock %}
+
+
+{% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
+
+<h1>New Standalone Cluster Details</h1><hr>
+
+<p>You are creating a new standalone cluster. Please provide the following details:</p>
+
+<form action="" method="post">
+  {% csrf_token %}
+  <table>
+    {{ wizard.management_form }}
+    {% if wizard.form.forms %}
+      {{ wizard.form.management_form }}
+      {% for form in wizard.form.forms %}
+        {{ form|crispy }}
+      {% endfor %}
+    {% else %}
+      {{ wizard.form|crispy }}
+    {% endif %}
+  </table>
+  {% if wizard.steps.prev %}
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.first }}">
+      First Step
+    </button>
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.prev }}">
+      Previous Step
+    </button>
+  {% endif %}
+  <input class="btn btn-primary" type="submit" value="Next Step"/>
+</form>
+<br>
+
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+
+{% endblock %}

--- a/coldfront/core/project/templates/project/project_request/standalone_cluster/project_existing_manager.html
+++ b/coldfront/core/project/templates/project/project_request/standalone_cluster/project_existing_manager.html
@@ -1,0 +1,70 @@
+{% extends "common/base.html" %}
+{% load feature_flags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+New Standalone Cluster - Existing Manager
+{% endblock %}
+
+
+{% block head %}
+{{ wizard.form.media }}
+{% endblock %}
+
+
+{% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
+<script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
+<link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
+
+<h1>New Standalone Cluster: Manager</h1><hr>
+
+<p>Select an existing user to be a Manager of the project. You may search for the user in the selection field. If the desired user is not listed, you may skip this step and specify information for a new Manager in the next step.</p>
+
+<form action="" method="post">
+  {% csrf_token %}
+  <table>
+    {{ wizard.management_form }}
+    {% if wizard.form.forms %}
+      {{ wizard.form.management_form }}
+      {% for form in wizard.form.forms %}
+        {{ form|crispy }}
+      {% endfor %}
+    {% else %}
+      {{ wizard.form|crispy }}
+    {% endif %}
+  </table>
+  {% if wizard.steps.prev %}
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.first }}">
+      First Step
+    </button>
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.prev }}">
+      Previous Step
+    </button>
+  {% endif %}
+  <input class="btn btn-primary" type="submit" value="Next Step"/>
+</form>
+<br>
+
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+
+<script>
+  $('select').selectize({
+    create: false,
+    sortField: 'text'
+  })
+</script>
+
+{% endblock %}

--- a/coldfront/core/project/templates/project/project_request/standalone_cluster/project_existing_pi.html
+++ b/coldfront/core/project/templates/project/project_request/standalone_cluster/project_existing_pi.html
@@ -1,0 +1,78 @@
+{% extends "common/base.html" %}
+{% load feature_flags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+New Standalone Cluster - Existing PI
+{% endblock %}
+
+
+{% block head %}
+{{ wizard.form.media }}
+{% endblock %}
+
+
+{% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
+<script type='text/javascript' src="{% static 'selectize/selectize.min.js' %}"></script>
+<link rel='stylesheet' type='text/css' href="{% static 'selectize/selectize.bootstrap3.css' %}"/>
+
+<h1>New Standalone Cluster: Principal Investigator</h1><hr>
+
+<p>Select an existing user to be a Principal Investigator of the project. You may search for the user in the selection field. If the desired user is not listed, you may skip this step and specify information for a new PI in the next step.</p>
+{% flag_enabled 'LRC_ONLY' as lrc_only %}
+{% if lrc_only %}
+  <p>Note: Only LBL employees, users with an "@lbl.gov" email, can be selected as a PI.</p>
+{% endif %}
+
+{% if allowance_is_one_per_pi %}
+  <p>Note: Each PI may only have one {{ computing_allowance.name }} at a time, so any that have pending requests or active allocations are not selectable.</p>
+{% endif %}
+
+<form action="" method="post">
+  {% csrf_token %}
+  <table>
+    {{ wizard.management_form }}
+    {% if wizard.form.forms %}
+      {{ wizard.form.management_form }}
+      {% for form in wizard.form.forms %}
+        {{ form|crispy }}
+      {% endfor %}
+    {% else %}
+      {{ wizard.form|crispy }}
+    {% endif %}
+  </table>
+  {% if wizard.steps.prev %}
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.first }}">
+      First Step
+    </button>
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.prev }}">
+      Previous Step
+    </button>
+  {% endif %}
+  <input class="btn btn-primary" type="submit" value="Next Step"/>
+</form>
+<br>
+
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+
+<script>
+  $('select').selectize({
+    create: false,
+    sortField: 'text'
+  })
+</script>
+
+{% endblock %}

--- a/coldfront/core/project/templates/project/project_request/standalone_cluster/project_new_manager.html
+++ b/coldfront/core/project/templates/project/project_request/standalone_cluster/project_new_manager.html
@@ -1,0 +1,60 @@
+{% extends "common/base.html" %}
+{% load feature_flags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+New Standalone Cluster - New Manager
+{% endblock %}
+
+
+{% block head %}
+{{ wizard.form.media }}
+{% endblock %}
+
+{% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
+<h1>New Standalone Cluster: Manager</h1><hr>
+
+<p>Provide details about a new user, who will be a Manager for the project. An existing user should have been selected in the previous step.</p>
+
+<form action="" method="post">
+  {% csrf_token %}
+  <table>
+    {{ wizard.management_form }}
+    {% if wizard.form.forms %}
+      {{ wizard.form.management_form }}
+      {% for form in wizard.form.forms %}
+        {{ form|crispy }}
+        <hr>
+      {% endfor %}
+    {% else %}
+      {{ wizard.form|crispy }}
+    {% endif %}
+  </table>
+  {% if wizard.steps.prev %}
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.first }}">
+      First Step
+    </button>
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.prev }}">
+      Previous Step
+    </button>
+  {% endif %}
+  <input class="btn btn-primary" type="submit" value="Next Step"/>
+</form>
+<br>
+
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+
+{% endblock %}

--- a/coldfront/core/project/templates/project/project_request/standalone_cluster/project_new_pi.html
+++ b/coldfront/core/project/templates/project/project_request/standalone_cluster/project_new_pi.html
@@ -1,0 +1,65 @@
+{% extends "common/base.html" %}
+{% load feature_flags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+New Standalone Cluster - New PI
+{% endblock %}
+
+
+{% block head %}
+{{ wizard.form.media }}
+{% endblock %}
+
+{% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
+<h1>New Standalone Cluster: Principal Investigator</h1><hr>
+
+<p>Provide details about a new user, who will be a Principal Investigator for the project. An existing user should have been selected in the previous step.</p>
+
+{% flag_enabled 'LRC_ONLY' as lrc_only %}
+{% if lrc_only %}
+  <p>Note: Only LBL employees, users with an "@lbl.gov" email, can be a PI.</p>
+{% endif %}
+
+<form action="" method="post">
+  {% csrf_token %}
+  <table>
+    {{ wizard.management_form }}
+    {% if wizard.form.forms %}
+      {{ wizard.form.management_form }}
+      {% for form in wizard.form.forms %}
+        {{ form|crispy }}
+        <hr>
+      {% endfor %}
+    {% else %}
+      {{ wizard.form|crispy }}
+    {% endif %}
+  </table>
+  {% if wizard.steps.prev %}
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.first }}">
+      First Step
+    </button>
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.prev }}">
+      Previous Step
+    </button>
+  {% endif %}
+  <input class="btn btn-primary" type="submit" value="Next Step"/>
+</form>
+<br>
+
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+
+{% endblock %}

--- a/coldfront/core/project/templates/project/project_request/standalone_cluster/review_and_submit.html
+++ b/coldfront/core/project/templates/project/project_request/standalone_cluster/review_and_submit.html
@@ -1,0 +1,93 @@
+{% extends "common/base.html" %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+
+{% block title %}
+Project Renewal - Review and Submit
+{% endblock %}
+
+
+{% block head %}
+{{ wizard.form.media }}
+{% endblock %}
+
+
+{% block content %}
+<script type="text/javascript" src="{% static 'common/js/leave_form_alert.js' %}"></script>
+<h1>Review and Submit</h1><hr>
+
+<ol class="breadcrumb">
+  <li>Standalone Cluster Name: {{ breadcrumb_project }}</li>
+  <li>&nbsp;<i class="fas fa-angle-double-right"></i>&nbsp;</li>
+  <li>{{ breadcrumb_pi }}</li>
+  <li>&nbsp;<i class="fas fa-angle-double-right"></i>&nbsp;</li>
+  <li>{{ breadcrumb_manager }}</li>
+</ol>
+
+<p>
+  Review your selections and submit.
+</p>
+
+<div class="table-responsive">
+  <table class="table table-sm">
+    <tbody>
+      <tr>
+        <th>Standalone Cluster Name</th>
+        <td>
+          {{ breadcrumb_project }}
+        </td>
+      </tr>
+      <tr>
+        <th>Principal Investigator (PI)</th>
+        <td>
+          {{ pi }}
+        </td>
+      </tr>
+      <tr>
+        <th>Manager</th>
+        <td>{{ manager }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+
+<form action="" method="post">
+  {% csrf_token %}
+  <table>
+    {{ wizard.management_form }}
+    {% if wizard.form.forms %}
+      {{ wizard.form.management_form }}
+      {% for form in wizard.form.forms %}
+        {{ form|crispy }}
+      {% endfor %}
+    {% else %}
+      {{ wizard.form|crispy }}
+    {% endif %}
+  </table>
+  {% if wizard.steps.prev %}
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.first }}">
+      First Step
+    </button>
+    <button
+        class="btn btn-secondary"
+        formnovalidate="formnovalidate"
+        name="wizard_goto_step"
+        type="submit"
+        value="{{ wizard.steps.prev }}">
+      Previous Step
+    </button>
+  {% endif %}
+  <input class="btn btn-primary" type="submit" value="Submit"/>
+</form>
+<br>
+
+<p>Step {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</p>
+
+{% endblock %}

--- a/coldfront/core/project/urls.py
+++ b/coldfront/core/project/urls.py
@@ -66,6 +66,11 @@ urlpatterns += [
              condition_dict=new_project_request_views.SavioProjectRequestWizard.condition_dict(),
          ),
          name='new-project-request'),
+    path('new-standalone-cluster-request/',
+         new_project_request_views.StandaloneClusterRequestWizard.as_view(
+             condition_dict=new_project_request_views.StandaloneClusterRequestWizard.condition_dict(),
+         ),
+         name='new-standalone-cluster-request'),
     path('new-project-pending-request-list/',
          new_project_approval_views.SavioProjectRequestListView.as_view(
              completed=False),

--- a/coldfront/core/project/views_/new_project_views/request_views.py
+++ b/coldfront/core/project/views_/new_project_views/request_views.py
@@ -824,11 +824,13 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
                 pi = self.__handle_pi_data(form_data)
                 manager = self.__handle_manager_data(form_data)
                 project, resource = self.__handle_create_new_standalone_cluster(form_data, pi, manager)
+                redirect_url = '/project/' + str(project.pk) + '/'
         except Exception as e:
             self.logger.exception(e)
             message = 'Unexpected failure. Please contact an administrator.'
             messages.error(self.request, message)
         else:
+            # TODO: More informative message?
             message = (
                 'Thank you for your submission. It will be reviewed and '
                 'processed by administrators.')

--- a/coldfront/core/project/views_/new_project_views/request_views.py
+++ b/coldfront/core/project/views_/new_project_views/request_views.py
@@ -737,3 +737,535 @@ class VectorProjectRequestView(LoginRequiredMixin, UserPassesTestMixin,
         allocation.save()
 
         return project
+
+class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
+                                SessionWizardView):
+    FORMS = [
+        ('computing_allowance', ComputingAllowanceForm),
+        ('allocation_period', SavioProjectAllocationPeriodForm),
+        ('existing_pi', SavioProjectExistingPIForm),
+        ('new_pi', SavioProjectNewPIForm),
+        ('ica_extra_fields', SavioProjectICAExtraFieldsForm),
+        ('recharge_extra_fields', SavioProjectRechargeExtraFieldsForm),
+        ('pool_allocations', SavioProjectPoolAllocationsForm),
+        ('pooled_project_selection', SavioProjectPooledProjectSelectionForm),
+        ('details', SavioProjectDetailsForm),
+        ('billing_id', BillingIDValidationForm),
+        ('survey', SavioProjectSurveyForm),
+    ]
+
+    TEMPLATES = {
+        'computing_allowance':
+            'project/project_request/savio/project_computing_allowance.html',
+        'allocation_period':
+            'project/project_request/savio/project_allocation_period.html',
+        'existing_pi':
+            'project/project_request/savio/project_existing_pi.html',
+        'new_pi':
+            'project/project_request/savio/project_new_pi.html',
+        'ica_extra_fields':
+            'project/project_request/savio/project_ica_extra_fields.html',
+        'recharge_extra_fields':
+            'project/project_request/savio/project_recharge_extra_fields.html',
+        'pool_allocations':
+            'project/project_request/savio/project_pool_allocations.html',
+        'pooled_project_selection':
+            ('project/project_request/savio/'
+             'project_pooled_project_selection.html'),
+        'details': 'project/project_request/savio/project_details.html',
+        'billing_id': 'project/project_request/savio/project_billing_id.html',
+        'survey': 'project/project_request/savio/project_survey.html',
+    }
+
+    form_list = [
+        ComputingAllowanceForm,
+        SavioProjectAllocationPeriodForm,
+        SavioProjectExistingPIForm,
+        SavioProjectNewPIForm,
+        SavioProjectICAExtraFieldsForm,
+        SavioProjectRechargeExtraFieldsForm,
+        SavioProjectPoolAllocationsForm,
+        SavioProjectPooledProjectSelectionForm,
+        SavioProjectDetailsForm,
+        BillingIDValidationForm,
+        SavioProjectSurveyForm,
+    ]
+
+    logger = logging.getLogger(__name__)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Define a lookup table from form name to step number.
+        self.step_numbers_by_form_name = {
+            name: i for i, (name, _) in enumerate(self.FORMS)}
+        
+    def test_func(self):
+        if self.request.user.is_superuser:
+            return True
+        signed_date = (
+            self.request.user.userprofile.access_agreement_signed_date)
+        if signed_date is not None:
+            return True
+        message = (
+            'You must sign the User Access Agreement before you can create a '
+            'new project.')
+        messages.error(self.request, message)
+
+    def get_context_data(self, form, **kwargs):
+        context = super().get_context_data(form=form, **kwargs)
+        current_step = int(self.steps.current)
+        self.__set_data_from_previous_steps(current_step, context)
+        return context
+
+    def get_form_kwargs(self, step=None):
+        # For each step, a list of kwargs required by the corresponding form.
+        required_keys_by_step_name = {
+            'allocation_period': ['computing_allowance'],
+            'existing_pi': ['computing_allowance', 'allocation_period'],
+            'pooled_project_selection': ['computing_allowance'],
+            'details': ['computing_allowance'],
+            'survey': ['computing_allowance'],
+        }
+        # For each step number, the corresponding step name.
+        step_names_by_step_number = {
+            self.step_numbers_by_form_name[name]: name
+            for name in required_keys_by_step_name
+        }
+
+        step_number = int(step)
+        if step_number not in step_names_by_step_number:
+            return {}
+
+        data = {}
+        self.__set_data_from_previous_steps(step_number, data)
+
+        kwargs = {}
+        step_name = step_names_by_step_number[step_number]
+        for key in required_keys_by_step_name[step_name]:
+            kwargs[key] = data.get(key, None)
+        return kwargs
+
+    def get_template_names(self):
+        return [self.TEMPLATES[self.FORMS[int(self.steps.current)][0]]]
+
+    def done(self, form_list, **kwargs):
+        """Perform processing and store information in a request
+        object."""
+        redirect_url = '/'
+        try:
+            form_data = session_wizard_all_form_data(
+                form_list, kwargs['form_dict'], len(self.form_list))
+
+            request_kwargs = {
+                'requester': self.request.user,
+            }
+            computing_allowance = self.__get_computing_allowance(form_data)
+            computing_allowance_wrapper = ComputingAllowance(
+                computing_allowance)
+
+            with transaction.atomic():
+                allocation_period = self.__get_allocation_period(form_data)
+                pi = self.__handle_pi_data(form_data)
+
+                if computing_allowance_wrapper.is_instructional():
+                    self.__handle_ica_allowance(
+                        form_data, computing_allowance_wrapper, request_kwargs)
+                elif computing_allowance_wrapper.is_recharge():
+                    self.__handle_recharge_allowance(
+                        form_data, computing_allowance_wrapper, request_kwargs)
+
+                pooling_requested = self.__get_pooling_requested(form_data)
+                if pooling_requested:
+                    project = self.__handle_pool_with_existing_project(
+                        form_data)
+                else:
+                    project = self.__handle_create_new_project(form_data)
+                    if self.__billing_id_required():
+                        self.__handle_billing_id(form_data, request_kwargs)
+
+                survey_data = self.__get_survey_data(form_data)
+
+                # Store transformed form data in a request.
+                # TODO: allocation_type will eventually be removed from the
+                # TODO: model.
+                computing_allowance_interface = ComputingAllowanceInterface()
+                request_kwargs['allocation_type'] = \
+                    computing_allowance_interface.name_short_from_name(
+                        computing_allowance_wrapper.get_name())
+                request_kwargs['computing_allowance'] = computing_allowance
+                request_kwargs['allocation_period'] = allocation_period
+                request_kwargs['pi'] = pi
+                request_kwargs['project'] = project
+                request_kwargs['pool'] = pooling_requested
+                request_kwargs['survey_answers'] = survey_data
+                request_kwargs['status'] = \
+                    ProjectAllocationRequestStatusChoice.objects.get(
+                        name='Under Review')
+                request_kwargs['request_time'] = utc_now_offset_aware()
+                request = SavioProjectAllocationRequest.objects.create(
+                    **request_kwargs)
+
+            # Send a notification email to admins.
+            try:
+                send_new_project_request_admin_notification_email(request)
+            except Exception as e:
+                self.logger.error(
+                    'Failed to send notification email. Details:\n')
+                self.logger.exception(e)
+            # Send a notification email to the PI if the requester differs.
+            if request.requester != request.pi:
+                try:
+                    send_new_project_request_pi_notification_email(request)
+                except Exception as e:
+                    self.logger.error(
+                        'Failed to send notification email. Details:\n')
+                    self.logger.exception(e)
+        except Exception as e:
+            self.logger.exception(e)
+            message = 'Unexpected failure. Please contact an administrator.'
+            messages.error(self.request, message)
+        else:
+            message = (
+                'Thank you for your submission. It will be reviewed and '
+                'processed by administrators.')
+            messages.success(self.request, message)
+
+        return HttpResponseRedirect(redirect_url)
+
+    @staticmethod
+    def condition_dict():
+        view = StandaloneClusterRequestWizard
+        return {
+            '1': view.show_allocation_period_form_condition,
+            '3': view.show_new_pi_form_condition,
+            '4': view.show_ica_extra_fields_form_condition,
+            '5': view.show_recharge_extra_fields_form_condition,
+            '6': view.show_pool_allocations_form_condition,
+            '7': view.show_pooled_project_selection_form_condition,
+            '8': view.show_details_form_condition,
+            '9': view.show_billing_id_form_condition,
+        }
+
+    def show_allocation_period_form_condition(self):
+        """Only show the form for selecting an AllocationPeriod for
+        periodic allowances."""
+        step_name = 'computing_allowance'
+        step = str(self.step_numbers_by_form_name[step_name])
+        cleaned_data = self.get_cleaned_data_for_step(step) or {}
+        computing_allowance = cleaned_data.get('computing_allowance', None)
+        if not computing_allowance:
+            return False
+        return ComputingAllowance(computing_allowance).is_periodic()
+
+    def show_billing_id_form_condition(self):
+        """Only show the form for providing a billing ID when it is
+        required, and when pooling is not requested."""
+        if not self.__billing_id_required():
+            return False
+        step_name = 'pool_allocations'
+        step = str(self.step_numbers_by_form_name[step_name])
+        cleaned_data = self.get_cleaned_data_for_step(step) or {}
+        return not cleaned_data.get('pool', False)
+
+    def show_details_form_condition(self):
+        step_name = 'pool_allocations'
+        step = str(self.step_numbers_by_form_name[step_name])
+        cleaned_data = self.get_cleaned_data_for_step(step) or {}
+        return not cleaned_data.get('pool', False)
+
+    def show_ica_extra_fields_form_condition(self):
+        step_name = 'computing_allowance'
+        step = str(self.step_numbers_by_form_name[step_name])
+        cleaned_data = self.get_cleaned_data_for_step(step) or {}
+        computing_allowance = cleaned_data.get('computing_allowance', None)
+        if not computing_allowance:
+            return False
+        computing_allowance = ComputingAllowance(computing_allowance)
+        return (
+            computing_allowance.is_instructional() and
+            computing_allowance.requires_extra_information())
+
+    def show_new_pi_form_condition(self):
+        step_name = 'existing_pi'
+        step = str(self.step_numbers_by_form_name[step_name])
+        cleaned_data = self.get_cleaned_data_for_step(step) or {}
+        return cleaned_data.get('PI', None) is None
+
+    def show_pool_allocations_form_condition(self):
+        step_name = 'computing_allowance'
+        step = str(self.step_numbers_by_form_name[step_name])
+        cleaned_data = self.get_cleaned_data_for_step(step) or {}
+        computing_allowance = cleaned_data.get('computing_allowance', None)
+        if not computing_allowance:
+            return False
+        return ComputingAllowance(computing_allowance).is_poolable()
+
+    def show_pooled_project_selection_form_condition(self):
+        step_name = 'pool_allocations'
+        step = str(self.step_numbers_by_form_name[step_name])
+        cleaned_data = self.get_cleaned_data_for_step(step) or {}
+        return cleaned_data.get('pool', False)
+
+    def show_recharge_extra_fields_form_condition(self):
+        step_name = 'computing_allowance'
+        step = str(self.step_numbers_by_form_name[step_name])
+        cleaned_data = self.get_cleaned_data_for_step(step) or {}
+        computing_allowance = cleaned_data.get('computing_allowance', None)
+        if not computing_allowance:
+            return False
+        computing_allowance = ComputingAllowance(computing_allowance)
+        return (
+            computing_allowance.is_recharge() and
+            computing_allowance.requires_extra_information())
+
+    @staticmethod
+    def __billing_id_required():
+        """Return whether a billing ID should be requested from the
+        user. Ultimately, the form will only be included if pooling is
+        not requested."""
+        return flag_enabled('LRC_ONLY')
+
+    def __get_allocation_period(self, form_data):
+        """Return the AllocationPeriod the user selected."""
+        step_number = self.step_numbers_by_form_name['allocation_period']
+        data = form_data[step_number]
+        return data.get('allocation_period', None)
+
+    def __get_computing_allowance(self, form_data):
+        """Return the computing allowance (Resource) the user
+        selected."""
+        step_number = self.step_numbers_by_form_name['computing_allowance']
+        data = form_data[step_number]
+        return data['computing_allowance']
+
+    def __get_pooling_requested(self, form_data):
+        """Return whether pooling was requested."""
+        step_number = self.step_numbers_by_form_name['pool_allocations']
+        data = form_data[step_number]
+        return data.get('pool', False)
+
+    def __get_survey_data(self, form_data):
+        """Return provided survey data."""
+        step_number = self.step_numbers_by_form_name['survey']
+        return form_data[step_number]
+
+    def __handle_billing_id(self, form_data, request_kwargs):
+        """Store the User-provided billing ID in the given dictionary to
+        be used during request creation."""
+        step_number = self.step_numbers_by_form_name['billing_id']
+        data = form_data[step_number]
+        billing_id = data['billing_id']
+        request_kwargs['billing_activity'] = \
+            get_or_create_billing_activity_from_full_id(billing_id)
+
+    def __handle_ica_allowance(self, form_data, computing_allowance_wrapper,
+                               request_kwargs):
+        """Perform ICA-specific handling.
+
+        In particular, set fields in the given dictionary to be used
+        during request creation. Set the extra_fields field from the
+        given form data and set the state field to include an additional
+        step."""
+        if computing_allowance_wrapper.requires_extra_information():
+            step_number = self.step_numbers_by_form_name['ica_extra_fields']
+            data = form_data[step_number]
+            extra_fields = savio_project_request_ica_extra_fields_schema()
+            for field in extra_fields:
+                extra_fields[field] = data[field]
+            request_kwargs['extra_fields'] = extra_fields
+        request_kwargs['state'] = savio_project_request_ica_state_schema()
+
+    def __handle_pi_data(self, form_data):
+        """Return the requested PI. If the PI did not exist, create a
+        new User and UserProfile."""
+        # If an existing PI was selected, return the existing User object.
+        step_number = self.step_numbers_by_form_name['existing_pi']
+        data = form_data[step_number]
+        if data['PI']:
+            return data['PI']
+
+        # Create a new User object intended to be a new PI.
+        step_number = self.step_numbers_by_form_name['new_pi']
+        data = form_data[step_number]
+        email = data['email']
+        try:
+            pi = User.objects.create(
+                username=email,
+                first_name=data['first_name'],
+                last_name=data['last_name'],
+                email=email,
+                is_active=True)
+        except IntegrityError as e:
+            self.logger.error(f'User {email} unexpectedly exists.')
+            raise e
+
+        # Set the user's middle name in the UserProfile; generate a PI request.
+        try:
+            pi_profile = pi.userprofile
+        except UserProfile.DoesNotExist as e:
+            self.logger.error(
+                f'User {email} unexpectedly has no UserProfile.')
+            raise e
+        pi_profile.middle_name = data['middle_name']
+        pi_profile.upgrade_request = utc_now_offset_aware()
+        pi_profile.save()
+
+        # Create an unverified, primary EmailAddress for the new User object.
+        try:
+            EmailAddress.objects.create(
+                user=pi,
+                email=email,
+                verified=False,
+                primary=True)
+        except IntegrityError as e:
+            self.logger.error(
+                f'EmailAddress {email} unexpectedly already exists.')
+            raise e
+
+        return pi
+
+    def __handle_recharge_allowance(self, form_data,
+                                    computing_allowance_wrapper,
+                                    request_kwargs):
+        """Perform Recharge-specific handling.
+
+        In particular, set fields in the given dictionary to be used
+        during request creation. If required, set the extra_fields field
+        from the given form data. In general, set the state field to
+        include an additional step."""
+        if computing_allowance_wrapper.requires_extra_information():
+            step_number = self.step_numbers_by_form_name[
+                'recharge_extra_fields']
+            data = form_data[step_number]
+            extra_fields = savio_project_request_recharge_extra_fields_schema()
+            for field in extra_fields:
+                extra_fields[field] = data[field]
+            request_kwargs['extra_fields'] = extra_fields
+        request_kwargs['state'] = savio_project_request_recharge_state_schema()
+
+    def __handle_create_new_project(self, form_data):
+        """Create a new project and an allocation to the primary Compute
+        resource."""
+        step_number = self.step_numbers_by_form_name['details']
+        data = form_data[step_number]
+
+        # Create the new Project.
+        status = ProjectStatusChoice.objects.get(name='New')
+        try:
+            project = Project.objects.create(
+                name=data['name'],
+                status=status,
+                title=data['title'],
+                description=data['description'])
+                #field_of_science=data['field_of_science'])
+        except IntegrityError as e:
+            self.logger.error(
+                f'Project {data["name"]} unexpectedly already exists.')
+            raise e
+
+        # Create an allocation to the primary compute resource.
+        status = AllocationStatusChoice.objects.get(name='New')
+        allocation = Allocation.objects.create(project=project, status=status)
+        resource = get_primary_compute_resource()
+        allocation.resources.add(resource)
+        allocation.save()
+
+        return project
+
+    def __handle_pool_with_existing_project(self, form_data):
+        """Return the requested project to pool with."""
+        step_number = \
+            self.step_numbers_by_form_name['pooled_project_selection']
+        data = form_data[step_number]
+        project = data['project']
+
+        # Validate that the project has exactly one allocation to the "Savio
+        # Compute" resource.
+        resource = get_primary_compute_resource()
+        allocations = Allocation.objects.filter(
+            project=project, resources__pk__exact=resource.pk)
+        try:
+            assert allocations.count() == 1
+        except AssertionError as e:
+            number = 'no' if allocations.count() == 0 else 'more than one'
+            self.logger.error(
+                f'Project {project.name} unexpectedly has {number} Allocation '
+                f'to Resource {resource.name}')
+            raise e
+
+        return project
+
+    def __set_data_from_previous_steps(self, step, dictionary):
+        """Update the given dictionary with data from previous steps."""
+        computing_allowance_form_step = \
+            self.step_numbers_by_form_name['computing_allowance']
+        if step > computing_allowance_form_step:
+            computing_allowance_form_data = self.get_cleaned_data_for_step(
+                str(computing_allowance_form_step))
+            if computing_allowance_form_data:
+                dictionary.update(computing_allowance_form_data)
+                computing_allowance_wrapper = ComputingAllowance(
+                    computing_allowance_form_data['computing_allowance'])
+                dictionary['allowance_is_one_per_pi'] = \
+                    computing_allowance_wrapper.is_one_per_pi()
+
+        allocation_period_form_step = \
+            self.step_numbers_by_form_name['allocation_period']
+        if step > allocation_period_form_step:
+            allocation_period_form_data = self.get_cleaned_data_for_step(
+                str(allocation_period_form_step))
+            if allocation_period_form_data:
+                dictionary.update(allocation_period_form_data)
+
+        existing_pi_step = self.step_numbers_by_form_name['existing_pi']
+        new_pi_step = self.step_numbers_by_form_name['new_pi']
+        if step > new_pi_step:
+            existing_pi_form_data = self.get_cleaned_data_for_step(
+                str(existing_pi_step))
+            new_pi_form_data = self.get_cleaned_data_for_step(str(new_pi_step))
+            if existing_pi_form_data['PI'] is not None:
+                pi = existing_pi_form_data['PI']
+                dictionary.update({
+                    'breadcrumb_pi': (
+                        f'Existing PI: {pi.first_name} {pi.last_name} '
+                        f'({pi.email})')
+                })
+            else:
+                first_name = new_pi_form_data['first_name']
+                last_name = new_pi_form_data['last_name']
+                email = new_pi_form_data['email']
+                dictionary.update({
+                    'breadcrumb_pi': (
+                        f'New PI: {first_name} {last_name} ({email})')
+                })
+
+        pool_allocations_step = \
+            self.step_numbers_by_form_name['pool_allocations']
+        if step > pool_allocations_step:
+            computing_allowance = ComputingAllowance(
+                dictionary['computing_allowance'])
+            if computing_allowance.is_poolable():
+                pool_allocations_form_data = self.get_cleaned_data_for_step(
+                    str(pool_allocations_step))
+                pooling_requested = pool_allocations_form_data['pool']
+            else:
+                pooling_requested = False
+            dictionary.update({'breadcrumb_pooling': pooling_requested})
+
+        pooled_project_selection_step = \
+            self.step_numbers_by_form_name['pooled_project_selection']
+        details_step = self.step_numbers_by_form_name['details']
+        if step > details_step:
+            if pooling_requested:
+                pooled_project_selection_form_data = \
+                    self.get_cleaned_data_for_step(
+                        str(pooled_project_selection_step))
+                project = pooled_project_selection_form_data['project']
+                dictionary.update({
+                    'breadcrumb_project': f'Project: {project.name}'
+                })
+            else:
+                details_form_data = self.get_cleaned_data_for_step(
+                    str(details_step))
+                name = details_form_data['name']
+                dictionary.update({'breadcrumb_project': f'Project: {name}'})

--- a/coldfront/core/project/views_/new_project_views/request_views.py
+++ b/coldfront/core/project/views_/new_project_views/request_views.py
@@ -15,6 +15,11 @@ from coldfront.core.project.forms_.new_project_forms.request_forms import SavioP
 from coldfront.core.project.forms_.new_project_forms.request_forms import SavioProjectRechargeExtraFieldsForm
 from coldfront.core.project.forms_.new_project_forms.request_forms import SavioProjectSurveyForm
 from coldfront.core.project.forms_.new_project_forms.request_forms import VectorProjectDetailsForm
+from coldfront.core.project.forms_.new_project_forms.request_forms import StandaloneClusterDetailsForm
+from coldfront.core.project.forms_.new_project_forms.request_forms import StandaloneClusterExistingPIForm
+from coldfront.core.project.forms_.new_project_forms.request_forms import StandaloneClusterNewPIForm
+from coldfront.core.project.forms_.new_project_forms.request_forms import StandaloneClusterExistingManagerForm
+from coldfront.core.project.forms_.new_project_forms.request_forms import StandaloneClusterNewManagerForm
 from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
 from coldfront.core.project.models import ProjectStatusChoice
@@ -741,54 +746,32 @@ class VectorProjectRequestView(LoginRequiredMixin, UserPassesTestMixin,
 class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
                                 SessionWizardView):
     FORMS = [
-        ('computing_allowance', ComputingAllowanceForm),
-        ('allocation_period', SavioProjectAllocationPeriodForm),
-        ('existing_pi', SavioProjectExistingPIForm),
-        ('new_pi', SavioProjectNewPIForm),
-        ('ica_extra_fields', SavioProjectICAExtraFieldsForm),
-        ('recharge_extra_fields', SavioProjectRechargeExtraFieldsForm),
-        ('pool_allocations', SavioProjectPoolAllocationsForm),
-        ('pooled_project_selection', SavioProjectPooledProjectSelectionForm),
-        ('details', SavioProjectDetailsForm),
-        ('billing_id', BillingIDValidationForm),
-        ('survey', SavioProjectSurveyForm),
+                
+        ('details', StandaloneClusterDetailsForm),
+        ('existing_pi', StandaloneClusterExistingPIForm),
+        ('new_pi', StandaloneClusterNewPIForm),
+        ('existing_manager', StandaloneClusterExistingManagerForm),
+        ('new_manager', StandaloneClusterNewManagerForm),
     ]
 
     TEMPLATES = {
-        'computing_allowance':
-            'project/project_request/savio/project_computing_allowance.html',
-        'allocation_period':
-            'project/project_request/savio/project_allocation_period.html',
+        'details': 'project/project_request/standalone_cluster/project_details.html',
         'existing_pi':
-            'project/project_request/savio/project_existing_pi.html',
+            'project/project_request/standalone_cluster/project_existing_pi.html',
         'new_pi':
-            'project/project_request/savio/project_new_pi.html',
-        'ica_extra_fields':
-            'project/project_request/savio/project_ica_extra_fields.html',
-        'recharge_extra_fields':
-            'project/project_request/savio/project_recharge_extra_fields.html',
-        'pool_allocations':
-            'project/project_request/savio/project_pool_allocations.html',
-        'pooled_project_selection':
-            ('project/project_request/savio/'
-             'project_pooled_project_selection.html'),
-        'details': 'project/project_request/savio/project_details.html',
-        'billing_id': 'project/project_request/savio/project_billing_id.html',
-        'survey': 'project/project_request/savio/project_survey.html',
+            'project/project_request/standalone_cluster/project_new_pi.html',
+        'existing_manager':
+            'project/project_request/standalone_cluster/project_existing_manager.html',
+        'new_manager':
+            'project/project_request/standalone_cluster/project_new_manager.html',
     }
 
     form_list = [
-        ComputingAllowanceForm,
-        SavioProjectAllocationPeriodForm,
-        SavioProjectExistingPIForm,
-        SavioProjectNewPIForm,
-        SavioProjectICAExtraFieldsForm,
-        SavioProjectRechargeExtraFieldsForm,
-        SavioProjectPoolAllocationsForm,
-        SavioProjectPooledProjectSelectionForm,
-        SavioProjectDetailsForm,
-        BillingIDValidationForm,
-        SavioProjectSurveyForm,
+        StandaloneClusterDetailsForm,
+        StandaloneClusterExistingPIForm,
+        StandaloneClusterNewPIForm,
+        StandaloneClusterExistingManagerForm,
+        StandaloneClusterNewManagerForm,
     ]
 
     logger = logging.getLogger(__name__)
@@ -802,13 +785,8 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
     def test_func(self):
         if self.request.user.is_superuser:
             return True
-        signed_date = (
-            self.request.user.userprofile.access_agreement_signed_date)
-        if signed_date is not None:
-            return True
         message = (
-            'You must sign the User Access Agreement before you can create a '
-            'new project.')
+            'You do not have permission to create a standalone cluster.')
         messages.error(self.request, message)
 
     def get_context_data(self, form, **kwargs):
@@ -816,34 +794,6 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
         current_step = int(self.steps.current)
         self.__set_data_from_previous_steps(current_step, context)
         return context
-
-    def get_form_kwargs(self, step=None):
-        # For each step, a list of kwargs required by the corresponding form.
-        required_keys_by_step_name = {
-            'allocation_period': ['computing_allowance'],
-            'existing_pi': ['computing_allowance', 'allocation_period'],
-            'pooled_project_selection': ['computing_allowance'],
-            'details': ['computing_allowance'],
-            'survey': ['computing_allowance'],
-        }
-        # For each step number, the corresponding step name.
-        step_names_by_step_number = {
-            self.step_numbers_by_form_name[name]: name
-            for name in required_keys_by_step_name
-        }
-
-        step_number = int(step)
-        if step_number not in step_names_by_step_number:
-            return {}
-
-        data = {}
-        self.__set_data_from_previous_steps(step_number, data)
-
-        kwargs = {}
-        step_name = step_names_by_step_number[step_number]
-        for key in required_keys_by_step_name[step_name]:
-            kwargs[key] = data.get(key, None)
-        return kwargs
 
     def get_template_names(self):
         return [self.TEMPLATES[self.FORMS[int(self.steps.current)][0]]]
@@ -855,71 +805,14 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
         try:
             form_data = session_wizard_all_form_data(
                 form_list, kwargs['form_dict'], len(self.form_list))
-
             request_kwargs = {
                 'requester': self.request.user,
             }
-            computing_allowance = self.__get_computing_allowance(form_data)
-            computing_allowance_wrapper = ComputingAllowance(
-                computing_allowance)
-
             with transaction.atomic():
-                allocation_period = self.__get_allocation_period(form_data)
                 pi = self.__handle_pi_data(form_data)
-
-                if computing_allowance_wrapper.is_instructional():
-                    self.__handle_ica_allowance(
-                        form_data, computing_allowance_wrapper, request_kwargs)
-                elif computing_allowance_wrapper.is_recharge():
-                    self.__handle_recharge_allowance(
-                        form_data, computing_allowance_wrapper, request_kwargs)
-
-                pooling_requested = self.__get_pooling_requested(form_data)
-                if pooling_requested:
-                    project = self.__handle_pool_with_existing_project(
-                        form_data)
-                else:
-                    project = self.__handle_create_new_project(form_data)
-                    if self.__billing_id_required():
-                        self.__handle_billing_id(form_data, request_kwargs)
-
-                survey_data = self.__get_survey_data(form_data)
-
-                # Store transformed form data in a request.
-                # TODO: allocation_type will eventually be removed from the
-                # TODO: model.
-                computing_allowance_interface = ComputingAllowanceInterface()
-                request_kwargs['allocation_type'] = \
-                    computing_allowance_interface.name_short_from_name(
-                        computing_allowance_wrapper.get_name())
-                request_kwargs['computing_allowance'] = computing_allowance
-                request_kwargs['allocation_period'] = allocation_period
-                request_kwargs['pi'] = pi
-                request_kwargs['project'] = project
-                request_kwargs['pool'] = pooling_requested
-                request_kwargs['survey_answers'] = survey_data
-                request_kwargs['status'] = \
-                    ProjectAllocationRequestStatusChoice.objects.get(
-                        name='Under Review')
-                request_kwargs['request_time'] = utc_now_offset_aware()
-                request = SavioProjectAllocationRequest.objects.create(
-                    **request_kwargs)
-
-            # Send a notification email to admins.
-            try:
-                send_new_project_request_admin_notification_email(request)
-            except Exception as e:
-                self.logger.error(
-                    'Failed to send notification email. Details:\n')
-                self.logger.exception(e)
-            # Send a notification email to the PI if the requester differs.
-            if request.requester != request.pi:
-                try:
-                    send_new_project_request_pi_notification_email(request)
-                except Exception as e:
-                    self.logger.error(
-                        'Failed to send notification email. Details:\n')
-                    self.logger.exception(e)
+                manager = self.__handle_manager_data(form_data)
+                project = self.__handle_create_new_standalone_cluster(form_data)
+                # TODO: create Resource object to represent the cluster.
         except Exception as e:
             self.logger.exception(e)
             message = 'Unexpected failure. Please contact an administrator.'
@@ -936,145 +829,29 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
     def condition_dict():
         view = StandaloneClusterRequestWizard
         return {
-            '1': view.show_allocation_period_form_condition,
-            '3': view.show_new_pi_form_condition,
-            '4': view.show_ica_extra_fields_form_condition,
-            '5': view.show_recharge_extra_fields_form_condition,
-            '6': view.show_pool_allocations_form_condition,
-            '7': view.show_pooled_project_selection_form_condition,
-            '8': view.show_details_form_condition,
-            '9': view.show_billing_id_form_condition,
+            '2': view.show_new_pi_form_condition,
+            '4': view.show_new_manager_form_condition,
         }
 
-    def show_allocation_period_form_condition(self):
-        """Only show the form for selecting an AllocationPeriod for
-        periodic allowances."""
-        step_name = 'computing_allowance'
-        step = str(self.step_numbers_by_form_name[step_name])
-        cleaned_data = self.get_cleaned_data_for_step(step) or {}
-        computing_allowance = cleaned_data.get('computing_allowance', None)
-        if not computing_allowance:
-            return False
-        return ComputingAllowance(computing_allowance).is_periodic()
-
-    def show_billing_id_form_condition(self):
-        """Only show the form for providing a billing ID when it is
-        required, and when pooling is not requested."""
-        if not self.__billing_id_required():
-            return False
-        step_name = 'pool_allocations'
-        step = str(self.step_numbers_by_form_name[step_name])
-        cleaned_data = self.get_cleaned_data_for_step(step) or {}
-        return not cleaned_data.get('pool', False)
-
     def show_details_form_condition(self):
-        step_name = 'pool_allocations'
+        step_name = 'details'
         step = str(self.step_numbers_by_form_name[step_name])
         cleaned_data = self.get_cleaned_data_for_step(step) or {}
         return not cleaned_data.get('pool', False)
-
-    def show_ica_extra_fields_form_condition(self):
-        step_name = 'computing_allowance'
-        step = str(self.step_numbers_by_form_name[step_name])
-        cleaned_data = self.get_cleaned_data_for_step(step) or {}
-        computing_allowance = cleaned_data.get('computing_allowance', None)
-        if not computing_allowance:
-            return False
-        computing_allowance = ComputingAllowance(computing_allowance)
-        return (
-            computing_allowance.is_instructional() and
-            computing_allowance.requires_extra_information())
 
     def show_new_pi_form_condition(self):
         step_name = 'existing_pi'
         step = str(self.step_numbers_by_form_name[step_name])
         cleaned_data = self.get_cleaned_data_for_step(step) or {}
         return cleaned_data.get('PI', None) is None
-
-    def show_pool_allocations_form_condition(self):
-        step_name = 'computing_allowance'
+    
+    def show_new_manager_form_condition(self):
+        step_name = 'existing_manager'
         step = str(self.step_numbers_by_form_name[step_name])
         cleaned_data = self.get_cleaned_data_for_step(step) or {}
-        computing_allowance = cleaned_data.get('computing_allowance', None)
-        if not computing_allowance:
-            return False
-        return ComputingAllowance(computing_allowance).is_poolable()
-
-    def show_pooled_project_selection_form_condition(self):
-        step_name = 'pool_allocations'
-        step = str(self.step_numbers_by_form_name[step_name])
-        cleaned_data = self.get_cleaned_data_for_step(step) or {}
-        return cleaned_data.get('pool', False)
-
-    def show_recharge_extra_fields_form_condition(self):
-        step_name = 'computing_allowance'
-        step = str(self.step_numbers_by_form_name[step_name])
-        cleaned_data = self.get_cleaned_data_for_step(step) or {}
-        computing_allowance = cleaned_data.get('computing_allowance', None)
-        if not computing_allowance:
-            return False
-        computing_allowance = ComputingAllowance(computing_allowance)
-        return (
-            computing_allowance.is_recharge() and
-            computing_allowance.requires_extra_information())
+        return not cleaned_data.get('manager', False)        
 
     @staticmethod
-    def __billing_id_required():
-        """Return whether a billing ID should be requested from the
-        user. Ultimately, the form will only be included if pooling is
-        not requested."""
-        return flag_enabled('LRC_ONLY')
-
-    def __get_allocation_period(self, form_data):
-        """Return the AllocationPeriod the user selected."""
-        step_number = self.step_numbers_by_form_name['allocation_period']
-        data = form_data[step_number]
-        return data.get('allocation_period', None)
-
-    def __get_computing_allowance(self, form_data):
-        """Return the computing allowance (Resource) the user
-        selected."""
-        step_number = self.step_numbers_by_form_name['computing_allowance']
-        data = form_data[step_number]
-        return data['computing_allowance']
-
-    def __get_pooling_requested(self, form_data):
-        """Return whether pooling was requested."""
-        step_number = self.step_numbers_by_form_name['pool_allocations']
-        data = form_data[step_number]
-        return data.get('pool', False)
-
-    def __get_survey_data(self, form_data):
-        """Return provided survey data."""
-        step_number = self.step_numbers_by_form_name['survey']
-        return form_data[step_number]
-
-    def __handle_billing_id(self, form_data, request_kwargs):
-        """Store the User-provided billing ID in the given dictionary to
-        be used during request creation."""
-        step_number = self.step_numbers_by_form_name['billing_id']
-        data = form_data[step_number]
-        billing_id = data['billing_id']
-        request_kwargs['billing_activity'] = \
-            get_or_create_billing_activity_from_full_id(billing_id)
-
-    def __handle_ica_allowance(self, form_data, computing_allowance_wrapper,
-                               request_kwargs):
-        """Perform ICA-specific handling.
-
-        In particular, set fields in the given dictionary to be used
-        during request creation. Set the extra_fields field from the
-        given form data and set the state field to include an additional
-        step."""
-        if computing_allowance_wrapper.requires_extra_information():
-            step_number = self.step_numbers_by_form_name['ica_extra_fields']
-            data = form_data[step_number]
-            extra_fields = savio_project_request_ica_extra_fields_schema()
-            for field in extra_fields:
-                extra_fields[field] = data[field]
-            request_kwargs['extra_fields'] = extra_fields
-        request_kwargs['state'] = savio_project_request_ica_state_schema()
-
     def __handle_pi_data(self, form_data):
         """Return the requested PI. If the PI did not exist, create a
         new User and UserProfile."""
@@ -1123,27 +900,57 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
             raise e
 
         return pi
+    
+    def __handle_manager_data(self, form_data):
+        """Return the requested manager. If the manager did not exist, create a
+        new User and UserProfile."""
+        # If an existing manager was selected, return the existing User object.
+        step_number = self.step_numbers_by_form_name['existing_manager']
+        data = form_data[step_number]
+        if data['manager']:
+            return data['manager']
 
-    def __handle_recharge_allowance(self, form_data,
-                                    computing_allowance_wrapper,
-                                    request_kwargs):
-        """Perform Recharge-specific handling.
+        # Create a new User object intended to be a new manager.
+        step_number = self.step_numbers_by_form_name['new_manager']
+        data = form_data[step_number]
+        email = data['email']
+        try:
+            manager = User.objects.create(
+                username=email,
+                first_name=data['first_name'],
+                last_name=data['last_name'],
+                email=email,
+                is_active=True)
+        except IntegrityError as e:
+            self.logger.error(f'User {email} unexpectedly exists.')
+            raise e
 
-        In particular, set fields in the given dictionary to be used
-        during request creation. If required, set the extra_fields field
-        from the given form data. In general, set the state field to
-        include an additional step."""
-        if computing_allowance_wrapper.requires_extra_information():
-            step_number = self.step_numbers_by_form_name[
-                'recharge_extra_fields']
-            data = form_data[step_number]
-            extra_fields = savio_project_request_recharge_extra_fields_schema()
-            for field in extra_fields:
-                extra_fields[field] = data[field]
-            request_kwargs['extra_fields'] = extra_fields
-        request_kwargs['state'] = savio_project_request_recharge_state_schema()
+        # Set the user's middle name in the UserProfile; generate a manager request.
+        try:
+            manager_profile = manager.userprofile
+        except UserProfile.DoesNotExist as e:
+            self.logger.error(
+                f'User {email} unexpectedly has no UserProfile.')
+            raise e
+        manager_profile.middle_name = data['middle_name']
+        manager_profile.upgrade_request = utc_now_offset_aware()
+        manager_profile.save()
 
-    def __handle_create_new_project(self, form_data):
+        # Create an unverified, primary EmailAddress for the new User object.
+        try:
+            EmailAddress.objects.create(
+                user=manager,
+                email=email,
+                verified=False,
+                primary=True)
+        except IntegrityError as e:
+            self.logger.error(
+                f'EmailAddress {email} unexpectedly already exists.')
+            raise e
+
+        return manager
+
+    def __handle_create_new_standalone_cluster(self, form_data):
         """Create a new project and an allocation to the primary Compute
         resource."""
         step_number = self.step_numbers_by_form_name['details']
@@ -1172,53 +979,13 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
 
         return project
 
-    def __handle_pool_with_existing_project(self, form_data):
-        """Return the requested project to pool with."""
-        step_number = \
-            self.step_numbers_by_form_name['pooled_project_selection']
-        data = form_data[step_number]
-        project = data['project']
-
-        # Validate that the project has exactly one allocation to the "Savio
-        # Compute" resource.
-        resource = get_primary_compute_resource()
-        allocations = Allocation.objects.filter(
-            project=project, resources__pk__exact=resource.pk)
-        try:
-            assert allocations.count() == 1
-        except AssertionError as e:
-            number = 'no' if allocations.count() == 0 else 'more than one'
-            self.logger.error(
-                f'Project {project.name} unexpectedly has {number} Allocation '
-                f'to Resource {resource.name}')
-            raise e
-
-        return project
-
     def __set_data_from_previous_steps(self, step, dictionary):
         """Update the given dictionary with data from previous steps."""
-        computing_allowance_form_step = \
-            self.step_numbers_by_form_name['computing_allowance']
-        if step > computing_allowance_form_step:
-            computing_allowance_form_data = self.get_cleaned_data_for_step(
-                str(computing_allowance_form_step))
-            if computing_allowance_form_data:
-                dictionary.update(computing_allowance_form_data)
-                computing_allowance_wrapper = ComputingAllowance(
-                    computing_allowance_form_data['computing_allowance'])
-                dictionary['allowance_is_one_per_pi'] = \
-                    computing_allowance_wrapper.is_one_per_pi()
-
-        allocation_period_form_step = \
-            self.step_numbers_by_form_name['allocation_period']
-        if step > allocation_period_form_step:
-            allocation_period_form_data = self.get_cleaned_data_for_step(
-                str(allocation_period_form_step))
-            if allocation_period_form_data:
-                dictionary.update(allocation_period_form_data)
-
+        details_step = self.step_numbers_by_form_name['details']
         existing_pi_step = self.step_numbers_by_form_name['existing_pi']
         new_pi_step = self.step_numbers_by_form_name['new_pi']
+        existing_manager_step = self.step_numbers_by_form_name['existing_manager']
+        new_manager_step = self.step_numbers_by_form_name['new_manager']
         if step > new_pi_step:
             existing_pi_form_data = self.get_cleaned_data_for_step(
                 str(existing_pi_step))
@@ -1239,33 +1006,28 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
                         f'New PI: {first_name} {last_name} ({email})')
                 })
 
-        pool_allocations_step = \
-            self.step_numbers_by_form_name['pool_allocations']
-        if step > pool_allocations_step:
-            computing_allowance = ComputingAllowance(
-                dictionary['computing_allowance'])
-            if computing_allowance.is_poolable():
-                pool_allocations_form_data = self.get_cleaned_data_for_step(
-                    str(pool_allocations_step))
-                pooling_requested = pool_allocations_form_data['pool']
-            else:
-                pooling_requested = False
-            dictionary.update({'breadcrumb_pooling': pooling_requested})
-
-        pooled_project_selection_step = \
-            self.step_numbers_by_form_name['pooled_project_selection']
-        details_step = self.step_numbers_by_form_name['details']
-        if step > details_step:
-            if pooling_requested:
-                pooled_project_selection_form_data = \
-                    self.get_cleaned_data_for_step(
-                        str(pooled_project_selection_step))
-                project = pooled_project_selection_form_data['project']
+        if step > new_manager_step:
+            existing_manager_form_data = self.get_cleaned_data_for_step(
+                str(existing_manager_step))
+            new_manager_form_data = self.get_cleaned_data_for_step(str(new_manager_step))
+            if existing_manager_form_data['manager'] is not None:
+                manager = existing_manager_form_data['manager']
                 dictionary.update({
-                    'breadcrumb_project': f'Project: {project.name}'
+                    'breadcrumb_manager': (
+                        f'Existing manager: {manager.first_name} {manager.last_name} '
+                        f'({manager.email})')
                 })
             else:
-                details_form_data = self.get_cleaned_data_for_step(
-                    str(details_step))
-                name = details_form_data['name']
-                dictionary.update({'breadcrumb_project': f'Project: {name}'})
+                first_name = new_manager_form_data['first_name']
+                last_name = new_manager_form_data['last_name']
+                email = new_manager_form_data['email']
+                dictionary.update({
+                    'breadcrumb_manager': (
+                        f'New manager: {first_name} {last_name} ({email})')
+                })
+
+        if step > details_step:
+            details_form_data = self.get_cleaned_data_for_step(
+                str(details_step))
+            name = details_form_data['name']
+            dictionary.update({'breadcrumb_project': f'Project: {name}'})

--- a/coldfront/core/project/views_/new_project_views/request_views.py
+++ b/coldfront/core/project/views_/new_project_views/request_views.py
@@ -1,8 +1,6 @@
 from allauth.account.models import EmailAddress
 
 from coldfront.core.allocation.models import Allocation
-from coldfront.core.allocation.models import AllocationAttribute
-from coldfront.core.allocation.models import AllocationAttributeType
 from coldfront.core.allocation.models import AllocationStatusChoice
 from coldfront.core.billing.forms import BillingIDValidationForm
 from coldfront.core.billing.utils.queries import get_or_create_billing_activity_from_full_id
@@ -46,7 +44,6 @@ from coldfront.core.user.models import UserProfile
 from coldfront.core.user.utils import access_agreement_signed
 from coldfront.core.utils.common import session_wizard_all_form_data
 from coldfront.core.utils.common import utc_now_offset_aware
-from coldfront.core.utils.common import display_time_zone_current_date
 from coldfront.core.utils.email.email_strategy import DropEmailStrategy
 
 from django.conf import settings

--- a/coldfront/core/project/views_/new_project_views/request_views.py
+++ b/coldfront/core/project/views_/new_project_views/request_views.py
@@ -983,8 +983,9 @@ class StandaloneClusterRequestWizard(LoginRequiredMixin, UserPassesTestMixin,
             raise e
 
         try:
+            resource_name = project_data["name"].upper() + " Compute"
             resource = Resource.objects.create(
-                name=project_data["name"].title(), resource_type=resource_type
+                name=resource_name, resource_type=resource_type
             )
             resource.description = project_data["description"]
             resource.save()

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -13,6 +13,7 @@
         <a id="navbar-project-reviews" class="dropdown-item" href="{% url 'project-review-list' %}">Project Reviews</a>
         {% endcomment %}
         <li><a id="navbar-user-search" class="dropdown-item" href="{% url 'user-search-home' %}">User Search</a></li>
+        <li><a class="dropdown-item" href="{% url 'new-standalone-cluster-request' %}">Create Standalone Cluster</a> </li>
         {% flag_enabled 'LRC_ONLY' as lrc_only %}
         {% if lrc_only %}
         <li><a class="dropdown-item" id="navbar-billing-id-usages" href="{% url 'billing-id-usages' %}">LBL Project IDs</a></li>


### PR DESCRIPTION
Majority code from @haudquaquam 

**Changes:**
- Adds request wizard for creating standalone clusters. The form can be found at `/project/new-standalone-cluster-request/` and a link to it can be found on the admin menu.
- Views in new_project_views/request_views.py
- Forms in new_project_forms/request_forms.py
- Templates under project/project_request/standalone_cluster folder
- The wizard asks for the name and description of the cluster -> an existing PI -> if no existing PI provided, a new PI's info -> an existing manager -> if no existing manager provided, a new manager's info -> a review-and-submit page.
- Back-end:
   - Creates a Resource object and capitalizes the given name for that object.
   - Creates a Project object and ProjectUsers using the logic from the `projects create` subcommand
     - Some of the `projects create` subcommand's logic has been refactored into `projects.utils_.new_project_utils`

**Testing**
- Manual testing wizard:
  - Navigate to `/project/new-standalone-cluster-request/`, a link to it is found on the admin menu as  "Create Standalone Cluster."
  - Go through the cluster creation
  - To test new PI and/or manager creation, do not select a PI/manager from the dropdowns. The next page will then prompt you to enter user info.
  - After successful submission, go to admin dashboard. Check to see that new Project and Resource objects were created.