### PR TITLE
Issue 626: Support CLI and UI validation of LBL Project IDs

### DIFF
--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,10 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv && \
-    apt install -y libfaketime && \
-    # Necessary for mod-wsgi requirement
-    apt install -y apache2-dev
+FROM coldfront-os
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,12 +1,19 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip && \
-    apt-get install -y libfaketime && \
+RUN apt update && \
+    apt install -y python3 python3-dev python3-pip python3-venv && \
+    apt install -y libfaketime && \
     # Necessary for mod-wsgi requirement
-    apt-get install -y apache2-dev
-
-COPY requirements.txt .
-RUN python3 -m pip install -r requirements.txt
+    apt install -y apache2-dev
 
 WORKDIR /var/www/coldfront_app/coldfront
+
+RUN python3 -m venv /var/www/coldfront_app/venv
+
+COPY requirements.txt .
+# Pin setuptools to avoid ImportError. Source: https://stackoverflow.com/a/78387663
+RUN /var/www/coldfront_app/venv/bin/pip install --upgrade pip wheel && \
+    /var/www/coldfront_app/venv/bin/pip install setuptools==68.2.2 && \
+    /var/www/coldfront_app/venv/bin/pip install -r requirements.txt
+
+ENV PATH="/var/www/coldfront_app/venv/bin:$PATH"

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -8,5 +8,3 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
-
-CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:latest
-
-RUN apt update && \
-    apt install -y python3 python3-dev python3-pip python3-venv
+FROM coldfront-os
 
 WORKDIR /app
 
@@ -11,3 +8,5 @@ RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
     /app/venv/bin/pip install jinja2 pyyaml
 
 ENV PATH="/app/venv/bin:$PATH"
+
+CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,8 +1,13 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip
-
-RUN pip3 install jinja2 pyyaml
+RUN apt update && \
+    apt install -y python3 python3-dev python3-pip python3-venv
 
 WORKDIR /app
+
+RUN python3 -m venv /app/venv
+
+RUN /app/venv/bin/pip install --upgrade pip setuptools wheel && \
+    /app/venv/bin/pip install jinja2 pyyaml
+
+ENV PATH="/app/venv/bin:$PATH"

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,13 +1,8 @@
-FROM ubuntu:latest
+FROM coldfront-os
 
-RUN apt update && \
-    apt install -y gnupg lsb-release wget
+RUN dnf update -y && \
+    dnf install -y gnupg wget
 
-RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt update && \
-    apt -y install postgresql-client-15
-
-WORKDIR /var/www/coldfront_app/coldfront
+RUN dnf install -y postgresql
 
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:latest
 
-RUN apt-get update && \
-    apt-get install -y gnupg lsb-release wget
+RUN apt update && \
+    apt install -y gnupg lsb-release wget
 
 RUN sh -c 'echo "deb https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-get update && \
-    apt-get -y install postgresql-client-15
+    apt update && \
+    apt -y install postgresql-client-15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -3,7 +3,7 @@ FROM coldfront-os
 RUN dnf update -y && \
     dnf install -y gnupg wget
 
-RUN dnf install -y postgresql
+RUN dnf module install -y postgresql:15
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,4 +1,4 @@
-FROM coldfront-os
+FROM coldfront-app-base
 
 RUN dnf update -y && \
     dnf install -y gnupg wget

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -5,4 +5,6 @@ RUN dnf update -y && \
 
 RUN dnf install -y postgresql
 
+WORKDIR /var/www/coldfront_app/coldfront
+
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/os.Dockerfile
+++ b/bootstrap/development/docker/images/os.Dockerfile
@@ -1,0 +1,31 @@
+FROM rockylinux/rockylinux:8.8
+
+RUN dnf update -y && \
+    dnf install -y \
+    gcc \
+    make \
+    wget \
+    openssl-devel \
+    bzip2-devel \
+    httpd-devel \
+    libffi-devel \
+    zlib-devel \
+    readline-devel \
+    redhat-rpm-config \
+    sqlite-devel
+
+RUN mkdir -p /usr/src/python310 && \
+    cd /usr/src/python310 && \
+    wget https://www.python.org/ftp/python/3.10.14/Python-3.10.14.tgz && \
+    tar -xzvf Python-3.10.14.tgz && \
+    cd Python-3.10.14 && \
+    ./configure --enable-optimizations --enable-shared && \
+    make && \
+    make install
+
+RUN rm -rf /usr/src/python310
+
+RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
+    ldconfig
+
+# TODO: libfaketime

--- a/bootstrap/development/docker/scripts/build_images.sh
+++ b/bootstrap/development/docker/scripts/build_images.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+docker build -f bootstrap/development/docker/images/os.Dockerfile -t coldfront-os .
 docker build -f bootstrap/development/docker/images/app-config.Dockerfile -t coldfront-app-config bootstrap/development/docker
 docker build -f bootstrap/development/docker/images/app-base.Dockerfile -t coldfront-app-base .
 docker build -f bootstrap/development/docker/images/app-shell.Dockerfile -t coldfront-app-shell .

--- a/bootstrap/development/docker/scripts/create_env_file.sh
+++ b/bootstrap/development/docker/scripts/create_env_file.sh
@@ -24,4 +24,3 @@ fi
 
 echo "DB_NAME=$DB_NAME" > $ENV_FILE_PATH
 echo "WEB_PORT=$PORT" >> $ENV_FILE_PATH
-

--- a/bootstrap/development/docker/scripts/docker_generate_secrets.sh
+++ b/bootstrap/development/docker/scripts/docker_generate_secrets.sh
@@ -8,8 +8,11 @@ else
     wd=$PWD
 fi
 
+# Do not mount directly onto /app, since the venv is located there and would be
+# wiped out.
 docker run -it \
-    -v $wd/bootstrap/development/docker:/app \
+    -v $wd/bootstrap/development/docker/config:/app/config \
+    -v $wd/bootstrap/development/docker/scripts:/app/scripts \
+    -v $wd/bootstrap/development/docker/secrets:/app/secrets \
     coldfront-app-config:latest \
     python3 scripts/generate_secrets.py
-

--- a/bootstrap/development/docker/scripts/docker_generate_settings.sh
+++ b/bootstrap/development/docker/scripts/docker_generate_settings.sh
@@ -22,8 +22,11 @@ cp coldfront/config/local_strings.py.sample coldfront/config/local_strings.py
 cp bootstrap/ansible/main.copyme bootstrap/development/docker/config/main.yml
 
 # Re-generate the Django development settings file.
+# Do not mount directly onto /app, since the venv is located there and would be
+# wiped out.
 (docker run -it \
     -v $wd/bootstrap/ansible/settings_template.tmpl:/tmp/settings_template.tmpl \
-    -v $wd/bootstrap/development/docker:/app \
+    -v $wd/bootstrap/development/docker/config:/app/config \
+    -v $wd/bootstrap/development/docker/scripts:/app/scripts \
     coldfront-app-config:latest \
     python3 scripts/generate_django_settings_file.py $DEPLOYMENT) 2>/dev/null > coldfront/config/dev_settings.py

--- a/coldfront/core/billing/forms.py
+++ b/coldfront/core/billing/forms.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.validators import MinLengthValidator
 from django.core.validators import RegexValidator
+from django.utils.safestring import mark_safe
 
 from coldfront.core.billing.models import BillingActivity
 from coldfront.core.billing.utils.queries import get_billing_activity_from_full_id
@@ -69,10 +70,12 @@ class BillingIDValidationForm(BillingIDValidityMixin, forms.Form):
     
 class BillingIDValidateManyForm(forms.Form):
     billing_ids = forms.CharField(
-        help_text='Example: \n123456-789',
+        help_text=mark_safe('Example:<br />123456-789<br />987654-321'),
         label='Project IDs',
         required=True,
-        widget=forms.Textarea)
+        widget=forms.Textarea(
+            attrs={'placeholder': 'Put each Project ID on its own line.'}
+        ))
     
     def clean(self):
         cleaned_data = super().clean()

--- a/coldfront/core/billing/forms.py
+++ b/coldfront/core/billing/forms.py
@@ -66,7 +66,17 @@ class BillingIDValidationForm(BillingIDValidityMixin, forms.Form):
         self.validate_billing_id(
             billing_id, ignore_invalid=not self.enforce_validity)
         return billing_id
-
+    
+class BillingIDValidateManyForm(forms.Form):
+    billing_ids = forms.CharField(
+        help_text='Example: \n123456-789',
+        label='Project IDs',
+        required=True,
+        widget=forms.Textarea)
+    
+    def clean(self):
+        cleaned_data = super().clean()
+        return cleaned_data
 
 class BillingIDCreationForm(BillingIDValidityMixin, forms.Form):
 

--- a/coldfront/core/billing/management/commands/billing_ids.py
+++ b/coldfront/core/billing/management/commands/billing_ids.py
@@ -23,7 +23,7 @@ from coldfront.core.utils.common import add_argparse_dry_run_argument
 
 class Command(BaseCommand):
 
-    help = 'Create and set billing IDs.'
+    help = 'Create, set, or validate billing IDs.'
 
     logger = logging.getLogger(__name__)
 
@@ -37,6 +37,7 @@ class Command(BaseCommand):
         self._add_create_subparser(subparsers)
         self._add_list_subparser(subparsers)
         self._add_set_subparser(subparsers)
+        self._add_validate_subparser(subparsers)
 
     def handle(self, *args, **options):
         """Call the handler for the provided subcommand."""
@@ -103,6 +104,17 @@ class Command(BaseCommand):
         add_billing_id_argument(user_account_parser)
         add_ignore_invalid_argument(user_account_parser)
         add_argparse_dry_run_argument(user_account_parser)
+
+    @staticmethod
+    def _add_validate_subparser(parsers):
+        parser = parsers.add_parser(
+            'validate', help=('Takes a billing ID as input and prints out "Valid" or "Invalid."'))
+
+        parser.add_argument(
+            'billings_ids', 
+            help=('A space-separated list of billings ids (e.g., 123456-789) to be validated.'),
+            nargs='+',
+            type=str)
 
     @staticmethod
     def _get_billing_activity_or_error(full_id):
@@ -262,6 +274,18 @@ class Command(BaseCommand):
             user = self._get_user_or_error(options['username'])
             self._handle_set_user_account(
                 user, billing_activity, dry_run=dry_run)
+            
+    def _handle_validate(self, *args, **options):
+        """Handle the 'validate' subcommand."""
+        for full_id in options['billings_ids']:
+            if is_billing_id_well_formed(full_id):
+                billing_activity = self._get_billing_activity_or_error(full_id)
+                append_str = 'Valid'
+                if not is_billing_id_valid(billing_activity.full_id()):
+                    append_str = 'Invalid'
+                print(billing_activity.full_id() + ':', append_str)
+            else:
+                raise CommandError(f'Billing ID {full_id} is malformed.')
 
     def _handle_set_project_default(self, project, billing_activity,
                                     dry_run=False):

--- a/coldfront/core/billing/templates/billing/billing_id_usages_search.html
+++ b/coldfront/core/billing/templates/billing/billing_id_usages_search.html
@@ -20,6 +20,10 @@
   <i class="fas fa-plus" aria-hidden="true"></i>
   Create
 </a>
+<a class="class btn btn-primary" href="{% url 'billing-id-validate' %}">
+  <i class="fas" aria-hidden="true"></i>
+  Validate
+</a>
 <hr>
 {% endif %}
 

--- a/coldfront/core/billing/templates/billing/billing_id_validate.html
+++ b/coldfront/core/billing/templates/billing/billing_id_validate.html
@@ -1,0 +1,28 @@
+{% extends "common/base.html" %}
+{% load common_tags %}
+{% load crispy_forms_tags %}
+{% load static %}
+
+{% block title %}
+  Validate LBL Project IDs
+{% endblock %}
+
+{% block content %}
+
+<h1>Validate LBL Project IDs</h1>
+<p>Put each Project ID on its own line.</p>
+<hr>
+
+<form method="post">
+  {% csrf_token %}
+  {{ form|crispy }}
+  <input type="submit" class="btn btn-primary" value="Validate">
+</form>
+
+<script>
+  $("#navbar-main > ul > li.active").removeClass("active");
+  $("#navbar-admin").addClass("active");
+  $("#navbar-billing-id-usages").addClass("active");
+</script>
+
+{% endblock %}

--- a/coldfront/core/billing/templates/billing/billing_id_validate.html
+++ b/coldfront/core/billing/templates/billing/billing_id_validate.html
@@ -10,7 +10,11 @@
 {% block content %}
 
 <h1>Validate LBL Project IDs</h1>
-<p>Put each Project ID on its own line.</p>
+<p>
+    To test the validity of multiple Project IDs, put each on its own line. The form checks whether
+    each Project ID is well-formed, and if it is well-formed, it checks the validity of each ID. Do
+    not put extra text or spaces, else the form will consider the ID malformed.
+</p>
 <hr>
 
 <form method="post">

--- a/coldfront/core/billing/tests/test_commands/test_billing_ids.py
+++ b/coldfront/core/billing/tests/test_commands/test_billing_ids.py
@@ -106,6 +106,28 @@ class TestBillingIds(TestBillingBase):
         billing_activity = get_billing_activity_from_full_id(billing_id)
         self.assertTrue(isinstance(billing_activity, BillingActivity))
 
+    def test_validate_malformed(self):
+        """Test that, when the given billing ID is malformed, the
+        'validate' subcommand raises an error."""
+        billing_id = '12345-67'
+        self.assertIsNone(get_billing_activity_from_full_id(billing_id))
+        self.assertFalse(is_billing_id_well_formed(billing_id))
+
+        with self.assertRaises(CommandError) as cm:
+            self.command.validate([billing_id])
+        self.assertIn('is malformed', str(cm.exception))
+
+    def test_validate_nonexistant(self):
+        """Test that, when the given billing ID does not exist, the
+        'validate' subcommand raises an error."""
+        billing_id = '123456-789'
+        self.assertIsNone(get_billing_activity_from_full_id(billing_id))
+        self.assertTrue(is_billing_id_well_formed(billing_id))
+
+        with self.assertRaises(CommandError) as cm:
+            self.command.validate([billing_id])
+        self.assertIn('does not exist', str(cm.exception))
+
     # TODO: test_list
 
     @enable_deployment('LRC')
@@ -400,6 +422,15 @@ class BillingIdsCommand(object):
         """Call the 'create' subcommand with the given billing ID, and
         flag values."""
         args = ['create', billing_id]
+        self._add_flags_to_args(args, **flags)
+        return self.call_subcommand(*args)
+    
+    def validate(self, billing_ids, **flags):
+        """Call the 'validate' subcommand with the given billing IDs, and
+        flag values."""
+        args = ['validate']
+        for billing_id in billing_ids:
+            args.append(billing_id)
         self._add_flags_to_args(args, **flags)
         return self.call_subcommand(*args)
 

--- a/coldfront/core/billing/tests/test_forms/test_billing_id_validate_many_form.py
+++ b/coldfront/core/billing/tests/test_forms/test_billing_id_validate_many_form.py
@@ -1,0 +1,57 @@
+from django.contrib.messages import get_messages
+
+from coldfront.core.billing.tests.test_billing_base import TestBillingBase
+from coldfront.core.billing.tests.test_commands.test_billing_ids import BillingIdsCommand
+from coldfront.core.billing.utils.queries import get_billing_activity_from_full_id
+
+class TestBillingIDValidateManyForm(TestBillingBase):
+    """A class for testing BillingIDValidateManyForm."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+        self.create_test_user()
+        self.sign_user_access_agreement(self.user)
+        self.client.login(username=self.user.username, password=self.password)
+        self.user.is_superuser = True
+        self.user.save()
+
+        self.command = BillingIdsCommand()
+
+    def test_malformed_billing_ids(self):
+        malformed_billing_id = "12345-78"
+        response = self.client.post("/billing/validate/", data={"billing_ids": malformed_billing_id})
+        messages = list(get_messages(response.wsgi_request))
+        
+        self.assertEqual(len(messages), 1)
+
+        self.assertIn(malformed_billing_id + ": Malformed", messages[0].message)
+
+    def test_billing_ids_correctness(self):
+        unused_id = "123456-789"
+        self.assertIsNone(get_billing_activity_from_full_id(unused_id))
+
+        used_id_invalid = "123456-001"
+        self.assertIsNone(get_billing_activity_from_full_id(used_id_invalid))
+        _, error = self.command.create(used_id_invalid, ignore_invalid=True)
+        self.assertFalse(error)
+
+        used_id_valid = "123456-002"
+        self.assertIsNone(get_billing_activity_from_full_id(used_id_valid))
+        _, error = self.command.create(used_id_valid)
+        self.assertFalse(error)
+
+        billing_ids = unused_id + '\n' + used_id_invalid + '\n' + used_id_valid
+        response = self.client.post("/billing/validate/", data={"billing_ids": billing_ids})
+        messages = list(get_messages(response.wsgi_request))
+        
+        self.assertEqual(len(messages), 1)
+
+        self.assertIn(unused_id + ": Invalid", messages[0].message)
+        self.assertIn(used_id_invalid + ": Invalid", messages[0].message)
+        self.assertIn(used_id_valid + ": Valid", messages[0].message)
+
+
+
+
+

--- a/coldfront/core/billing/tests/test_views/test_billing_id_validate_view.py
+++ b/coldfront/core/billing/tests/test_views/test_billing_id_validate_view.py
@@ -1,0 +1,39 @@
+from coldfront.core.utils.tests.test_base import TestBase
+
+from http import HTTPStatus
+
+class TestBillingIDValidateView(TestBase):
+    """A class for testing BillingIDValidateView."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+        self.create_test_user()
+        self.sign_user_access_agreement(self.user)
+        self.client.login(username=self.user.username, password=self.password)
+
+    def test_permissions_get(self):
+        """Test that the correct users have permissions to perform GET
+        requests."""
+
+        url = "/billing/validate/"
+
+        # Unauthenticated user.
+        self.client.logout()
+        response = self.client.get(url)
+        self.assert_redirects_to_login(response, next_url=url)
+
+        # Non superuser
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
+
+        # Superuser
+        self.user.is_superuser = True
+        self.user.save()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+        self.user.is_superuser = False
+        self.user.save()
+
+

--- a/coldfront/core/billing/urls.py
+++ b/coldfront/core/billing/urls.py
@@ -17,6 +17,9 @@ with flagged_paths('LRC_ONLY') as path:
         path('usages/',
              admin_views.BillingIDUsagesSearchView.as_view(),
              name='billing-id-usages'),
+        path('validate/',
+             admin_views.BillingIDValidateView.as_view(),
+             name='billing-id-validate'),
     ]
 
 

--- a/coldfront/core/billing/views/admin_views.py
+++ b/coldfront/core/billing/views/admin_views.py
@@ -338,7 +338,7 @@ class BillingIDValidateView(LoginRequiredMixin, UserPassesTestMixin, FormView):
                         append_str = "Invalid"
 
                 validation_results += ( f'{full_id}: {append_str}, ' )
-        messages.success(self.request, validation_results)
+        messages.success(self.request, validation_results.strip(', '))
         return super().form_valid(form)
 
 


### PR DESCRIPTION
Branched off of docker_rocky8_python10 from @matthew-li.

**The following was added:**
- A subcommand of the `billing_ids` command named `validate` that takes a space-separated list of billing IDs as input and prints out "Valid" or "Invalid" for each of those IDs.
- A view at the URL `/billing/validate/` that takes a list of newline-separated billing IDs as input and displays a message which shows whether each billing ID was "Valid," "Invalid," or "Malformed."
  - Added a "Validate" button in the billing ID usages page (Admin > LBL Project IDs) that links to the view.
  - Same permissions as the other billings views.
- Basic unit testing.

**Testing**
- Manual Testing:
   - Navigate to `/billing/validate` or click the `Validate` button on `/billing/usages/`
- Unit Testing:
   - Basic unit testing can be found at `coldfront.core.billing.tests.test_commands.test_billing_ids`.