### PR TITLE
Replace 'docker-compose' binary with 'docker compose' in Docker environment

### DIFF
--- a/bootstrap/development/docker/README.md
+++ b/bootstrap/development/docker/README.md
@@ -51,7 +51,7 @@ Note that these steps must be run from the root directory of the repo.
 
    ```bash
    export DOCKER_PROJECT_NAME=brc-dev
-   docker-compose \
+   docker compose \
        -f bootstrap/development/docker/docker-compose.yml \
        -p $DOCKER_PROJECT_NAME \
        up
@@ -83,7 +83,7 @@ Note that these steps must be run from the root directory of the repo.
     - Enter into the application shell container:
 
          ```bash
-         docker-compose -p $DOCKER_PROJECT_NAME exec app-shell bash
+         docker compose -p $DOCKER_PROJECT_NAME exec app-shell bash
          ```
 
     - From within the container, start a Django shell:

--- a/bootstrap/development/docker/scripts/docker_load_database_backup.sh
+++ b/bootstrap/development/docker/scripts/docker_load_database_backup.sh
@@ -4,11 +4,11 @@ PROJECT_NAME=$1
 RELATIVE_CONTAINER_DUMP_FILE_PATH=$2
 
 # TODO: There may be other services in the future.
-docker-compose -p $PROJECT_NAME stop web
+docker compose -p $PROJECT_NAME stop web
 
-docker-compose \
+docker compose \
     -p $PROJECT_NAME \
     exec db-postgres-shell \
     bash -c "bootstrap/development/docker/scripts/load_database_backup.sh $RELATIVE_CONTAINER_DUMP_FILE_PATH"
 
-docker-compose -p $PROJECT_NAME start web
+docker compose -p $PROJECT_NAME start web

--- a/bootstrap/development/docker/scripts/docker_run_django_scripts.sh
+++ b/bootstrap/development/docker/scripts/docker_run_django_scripts.sh
@@ -2,4 +2,4 @@
 
 PROJECT_NAME=$1
 
-docker-compose -p $PROJECT_NAME exec app-shell bash -c "bootstrap/development/docker/scripts/run_django_scripts.sh"
+docker compose -p $PROJECT_NAME exec app-shell bash -c "bootstrap/development/docker/scripts/run_django_scripts.sh"


### PR DESCRIPTION
**Context**
- Docker Desktop v4.32.0 retired the `docker-compose` binary for macOS ([release notes](https://docs.docker.com/desktop/release-notes/#for-mac-2)).

**Changes**
- Replaced calls to the binary with `docker compose` in Docker development environment scripts and documentation.

**How to Test**
- Ensure that the application stack can be started and that scripts (e.g., `docker_run_django_scripts.sh`) behave as before.