### PR TITLE
Require first & last name on project requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ overrides.yml
 New Project Request MOUs
 Secure Directory Request MOUs
 Service Units Purchase Request MOUs
+tmp/credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ overrides.yml
 New Project Request MOUs
 Secure Directory Request MOUs
 Service Units Purchase Request MOUs
-tmp/credentials.json

--- a/bootstrap/development/docker/README.md
+++ b/bootstrap/development/docker/README.md
@@ -50,11 +50,11 @@ Note that these steps must be run from the root directory of the repo.
 6. Start the application stack. Specify a unique Docker [project name](https://docs.docker.com/compose/project-name/) so that resources are placed within a Docker namespace. Examples: "brc-dev", "lrc-dev".
 
    ```bash
-   export DOCKER_PROJECT_NAME=brc-dev
+`   export DOCKER_PROJECT_NAME=brc-dev
    docker-compose \
        -f bootstrap/development/docker/docker-compose.yml \
        -p $DOCKER_PROJECT_NAME \
-       up
+       up`
    ```
 
    Notes:

--- a/coldfront/core/allocation/utils.py
+++ b/coldfront/core/allocation/utils.py
@@ -237,6 +237,30 @@ def prorated_allocation_amount(amount, dt, allocation_period):
     return Decimal(f'{math.floor(amount):.2f}')
 
 
+def calculate_service_units_to_allocate(computing_allowance,
+                                        request_time, allocation_period=None):
+    """Return the number of service units to allocate to a new project
+    request or allowance renewal request with the given
+    ComputingAllowance, if it were to be made at the given datetime. If
+    the request is associated with an AllocationPeriod, use it to
+    determine the number. Prorate as needed."""
+    kwargs = {}
+    if allocation_period is not None:
+        kwargs['is_timed'] = True
+        kwargs['allocation_period'] = allocation_period
+
+    computing_allowance_interface = ComputingAllowanceInterface()
+    num_service_units = Decimal(
+        computing_allowance_interface.service_units_from_name(
+            computing_allowance.get_name(), **kwargs))
+
+    if computing_allowance.are_service_units_prorated():
+        num_service_units = prorated_allocation_amount(
+            num_service_units, request_time, allocation_period)
+
+    return num_service_units
+
+
 def review_cluster_access_requests_url():
     domain = settings.CENTER_BASE_URL
     view = reverse('allocation-cluster-account-request-list')

--- a/coldfront/core/project/management/commands/projects.py
+++ b/coldfront/core/project/management/commands/projects.py
@@ -421,7 +421,6 @@ class Command(BaseCommand):
                 raise CommandError(
                     f'"{input_allocation_period}" already ended.')
             elif utc_now_offset_aware().date() < allocation_period.start_date:
-                # TODO: Should I raise an error
                 raise CommandError(
                     f'"{input_allocation_period}" has not begun yet.')
         

--- a/coldfront/core/project/management/commands/projects.py
+++ b/coldfront/core/project/management/commands/projects.py
@@ -100,6 +100,7 @@ class Command(BaseCommand):
             'renew',
             help=(
                 'Renew ICA projects that have the Inactive status.'
+                'This command will approve and process the request.'
                 ))
         
         parser.add_argument(
@@ -108,7 +109,8 @@ class Command(BaseCommand):
         parser.add_argument(
             'username',
             help=(
-                'The username of the user making the request.'),
+                'The username of the user making the request.'
+                'The requester should be the project Principal Investigator.'),
             type=str)
         
         parser.add_argument(
@@ -227,7 +229,6 @@ class Command(BaseCommand):
         status = AllocationRenewalRequestStatusChoice.objects.get(name='Under Review')
         computing_allowance = Resource.objects.get(
             name='Instructional Computing Allowance')
-        # TODO:
         pi = requester
 
         request = AllocationRenewalRequest.objects.create(
@@ -378,6 +379,11 @@ class Command(BaseCommand):
         except Project.DoesNotExist:
             raise CommandError(
                 f'A Project with name "{project_name}" does not exist.')
+        else:
+            if not project_name.startswith("ic_"):
+                raise CommandError(
+                    f'The project with name "{project_name}" is not an ICA.'
+                )
         
         input_username = options['username']
         requester = None

--- a/coldfront/core/project/management/commands/projects.py
+++ b/coldfront/core/project/management/commands/projects.py
@@ -255,7 +255,9 @@ class Command(BaseCommand):
                 utc_now_offset_aware().isoformat()
             request.save()
 
-            num_service_units = Decimal(ComputingAllowanceInterface().service_units_from_name(BRCAllowances.ICA))
+            num_service_units = Decimal(ComputingAllowanceInterface().service_units_from_name(
+                BRCAllowances.ICA,
+                is_timed=True, allocation_period=allocation_period))
             approval_runner = AllocationRenewalApprovalRunner(
                 request, num_service_units, email_strategy=DropEmailStrategy())
             approval_runner.run()

--- a/coldfront/core/project/management/commands/projects.py
+++ b/coldfront/core/project/management/commands/projects.py
@@ -234,6 +234,8 @@ class Command(BaseCommand):
 
         Assumptions:
             - The ComputingAllowance is renewable.
+            - (TODO: Temporary) The ComputingAllowance is not one per
+              PI.
             - The PI is an active PI of the project.
             - The requester is an active Manager or PI of the project.
             - The allowance is being renewed under the same project
@@ -418,6 +420,14 @@ class Command(BaseCommand):
                 f'Computing allowance "{computing_allowance.get_name()}" is '
                 f'not renewable.')
 
+        # TODO: There are some allowances which a PI may only have one of.
+        #  Disallow renewals of these until business logic (in progress) is in
+        #  place to enforce this constraint.
+        if computing_allowance.is_one_per_pi():
+            raise CommandError(
+                'Renewals of computing allowances that are limited per PI are '
+                'not currently supported by this command.')
+
         active_project_user_status = ProjectUserStatusChoice.objects.get(
             name='Active')
         manager_project_user_role = ProjectUserRoleChoice.objects.get(
@@ -492,9 +502,6 @@ class Command(BaseCommand):
         num_service_units = calculate_service_units_to_allocate(
             computing_allowance, request_time,
             allocation_period=allocation_period)
-
-        # TODO (in progress): Add business logic to ensure that the PI is
-        #  allowed to have a renewal request made under them.
 
         return {
             'project': project,

--- a/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
@@ -10,7 +10,7 @@ from coldfront.core.allocation.models import AllocationAttributeUsage, \
     AllocationUserAttributeUsage
 from coldfront.core.project.models import Project, ProjectStatusChoice, \
     ProjectUserStatusChoice, ProjectUserRoleChoice, ProjectUser
-from coldfront.core.project.utils import get_project_compute_allocation
+from coldfront.core.allocation.utils import get_project_compute_allocation
 from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.project.tests.test_commands.test_service_units_base import TestSUBase
 

--- a/coldfront/core/project/tests/test_commands/test_ica_renewal.py
+++ b/coldfront/core/project/tests/test_commands/test_ica_renewal.py
@@ -1,0 +1,121 @@
+from decimal import Decimal
+from io import StringIO
+
+from django.core.management import call_command
+
+from coldfront.api.statistics.utils import create_project_allocation
+from coldfront.core.project.tests.test_commands.test_service_units_base import \
+    TestSUBase
+from coldfront.core.project.models import Project
+from coldfront.core.project.models import ProjectUser
+from coldfront.core.project.models import ProjectStatusChoice
+from coldfront.core.project.models import ProjectUserRoleChoice
+from coldfront.core.project.models import ProjectUserStatusChoice
+from coldfront.core.allocation.models import AllocationPeriod
+from coldfront.core.resource.models import Resource
+from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
+
+
+class TestICARenewal(TestSUBase):
+    def setUp(self):
+        super().setUp()
+
+        self.create_test_user()
+        self.sign_user_access_agreement(self.user)
+        self.client.login(username=self.user.username, password=self.password)
+
+        computing_allowance = Resource.objects.get(
+            name='Instructional Computing Allowance')
+        computing_allowance_interface = ComputingAllowanceInterface()
+        project_name_prefix = computing_allowance_interface.code_from_name(
+            computing_allowance.name)
+        self.num_service_units = Decimal(
+            computing_allowance_interface.service_units_from_name(
+                computing_allowance.name))
+        
+        # Create an inactive project and make self.user the PI
+        project_name = f'{project_name_prefix}project'
+        inactive_project_status = ProjectStatusChoice.objects.get(name='Inactive')
+        inactive_project = Project.objects.create(
+            name=project_name,
+            title=project_name,
+            status=inactive_project_status
+        )
+
+        pi_role = ProjectUserRoleChoice.objects.get(
+            name='Principal Investigator')
+        active_project_user_status = ProjectUserStatusChoice.objects.get(
+            name='Active')
+        ProjectUser.objects.create(
+            project=inactive_project,
+            role=pi_role,
+            status=active_project_user_status,
+            user=self.user)
+        
+        self.existing_service_units = Decimal('0.00')
+        accounting_allocation_objects = create_project_allocation(
+            inactive_project, self.existing_service_units)
+        self.compute_allocation = accounting_allocation_objects.allocation
+        self.service_units_attribute = \
+            accounting_allocation_objects.allocation_attribute
+        
+        self.command = RenewalCommand()
+
+    def test_renew_valid_allocation_period(self):
+        """Test that 'renew' raises an error if the
+        allocation period is invalid."""
+        allocation_period = AllocationPeriod.objects.get(name="Fall Semester 2022")
+
+        computing_allowance = Resource.objects.get(
+            name='Instructional Computing Allowance')
+        project_name_prefix = ComputingAllowanceInterface().code_from_name(
+            computing_allowance.name)
+        project_name = f'{project_name_prefix}project'
+
+        output, error = self.command.renew(project_name, self.user.username, 
+                            allocation_period, self.user.username)
+        
+        self.assertIn('AllocationPeriod already ended', output)
+        
+    def test_renew_updates_service_units(self):
+        allocation_period = AllocationPeriod.objects.get(name="Summer Sessions 2024 - Session B")
+
+        computing_allowance = Resource.objects.get(
+            name='Instructional Computing Allowance')
+        computing_allowance_interface = ComputingAllowanceInterface()
+        project_name_prefix =  computing_allowance_interface.code_from_name(
+            computing_allowance.name)
+        project_name = f'{project_name_prefix}project'
+
+        output, error = self.command.renew(project_name, self.user.username, 
+                            allocation_period, self.user.username)
+
+        self.assertEqual(self.num_service_units, self.existing_service_units)
+        
+
+class RenewalCommand(object):
+    """A wrapper class over the 'projects' management command."""
+
+    command_name = "projects"
+    def call_subcommand(self, name, *args):
+        """Call the subcommand with the given name and arguments. Return
+        output written to stdout and stderr."""
+        out, err = StringIO(), StringIO()
+        args = [self.command_name, name, *args]
+        kwargs = {'stdout': out, 'stderr': err}
+        call_command(*args, **kwargs)
+        return out.getvalue(), err.getvalue()
+    
+    def renew(self, name, username, allocation_period, pi_username, **flags):
+        """Call the 'renew' subcommand with the given positional arguments."""
+        args = ['renew', name, username, allocation_period, pi_username]
+        self._add_flags_to_args(args, **flags)
+        return self.call_subcommand(*args)
+
+    @staticmethod
+    def _add_flags_to_args(args, **flags):
+        """Given a list of arguments to the command and a dict of flag
+        values, add the latter to the former."""
+        for key in ('dry_run', 'ignore_invalid'):
+            if flags.get(key, False):
+                args.append(f'--{key}')

--- a/coldfront/core/project/tests/test_commands/test_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_projects.py
@@ -5,16 +5,20 @@ from django.conf import settings
 from django.core.management import call_command
 from django.core.management import CommandError
 from django.db.models import Q
+from django.contrib.auth.models import User
 
 from coldfront.api.statistics.utils import create_project_allocation
 
 from coldfront.core.allocation.models import AllocationPeriod
+from coldfront.core.allocation.models import AllocationRenewalRequest
+from coldfront.core.allocation.models import AllocationRenewalRequestStatusChoice
 from coldfront.core.project.tests.test_commands.test_service_units_base import TestSUBase
 from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectStatusChoice
 from coldfront.core.project.models import ProjectUser
 from coldfront.core.project.models import ProjectUserRoleChoice
 from coldfront.core.project.models import ProjectUserStatusChoice
+from coldfront.core.project.utils_.renewal_utils import get_current_allowance_year_period
 from coldfront.core.resource.models import Resource
 from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
 from coldfront.core.utils.common import utc_now_offset_aware
@@ -130,8 +134,15 @@ class TestProjectsRenew(TestProjectsBase):
             Decimal(self.service_units_attribute.value),
             self.num_service_units)
 
+        request = AllocationRenewalRequest.objects.get(
+            requester=self.user,
+            pi=self.user,
+            pre_project=project
+        )
+        self.assertEqual(
+            AllocationRenewalRequestStatusChoice.objects.get(name="Complete"),
+            request.status)
         # TODO: Also test:
-        #  That a request gets created and it's in the "Complete" state
         #  That only a processing email is sent
 
     def test_validate_project(self):
@@ -146,28 +157,201 @@ class TestProjectsRenew(TestProjectsBase):
                 'invalid project name', self.allocation_period,
                 self.user.username, self.user.username)
         self.assertIn('A Project with name', str(cm.exception))
-        # TODO: Refactor the "not successful" checks into a block for reuse.
-        still_inactive_proj = Project.objects.get(name=self.project_name)
+        self.assertProjectInactive(self.project_name)
+        self.service_units_attribute.refresh_from_db()
         self.assertEqual(
-            still_inactive_proj.status,
-            ProjectStatusChoice.objects.get(name='Inactive'))
+            Decimal(self.service_units_attribute.value),
+            settings.ALLOCATION_MIN)
+    
+    def test_validate_computing_allowance(self):
+        """Test that computing allowance that cannot be renewed fail 
+        correctly (e.g., Recharge, Condo)."""
+        
+        non_renewable_resources = ['Condo Allocation', 'Recharge Allocation']
+        computing_allowance_interface = ComputingAllowanceInterface()
+        for resource_name in non_renewable_resources:
+            computing_allowance = Resource.objects.get(
+                name=resource_name)
+            project_name_prefix = computing_allowance_interface.code_from_name(
+                computing_allowance.name)
+            project_name = project_name_prefix + "testproject"
+            Project.objects.create(
+                name=project_name,
+                title=project_name,
+                status=ProjectStatusChoice.objects.get(name='Inactive'))
+            
+            with self.assertRaises(CommandError) as cm:
+                self.command.renew(
+                    project_name, self.allocation_period,
+                    self.user.username, self.user.username)
+            self.assertIn('is not renewable', str(cm.exception))
+            self.assertProjectInactive(project_name)
+            
+    def test_validate_requester(self):
+        """Test that requesters who do not exist, or are not an active
+        manager/PI fail correctly."""
+
+        project = Project.objects.get(name=self.project_name)
+        self.assertEqual(
+            project.status, ProjectStatusChoice.objects.get(name='Inactive'))
+
+        # Requester who is not manager/PI is invalid.
+        invalid_requester = User.objects.create(
+            email='invalid@gmail.com',
+            first_name='invalid',
+            last_name='invalid',
+            username='invalid_requester'
+        )
+        ProjectUser.objects.create(
+            project=project,
+            role=ProjectUserRoleChoice.objects.get(name="User"),
+            status=ProjectUserStatusChoice.objects.get(name='Active'),
+            user=invalid_requester)
+        
+        # Requester who is removed from project is invalid, even if Manager/PI
+        removed_requester = User.objects.create(
+            email='removed@gmail.com',
+            first_name='removed',
+            last_name='removed',
+            username='removed_requester'
+        )
+        ProjectUser.objects.create(
+            project=project,
+            role=ProjectUserRoleChoice.objects.get(name="Manager"),
+            status=ProjectUserStatusChoice.objects.get(name='Removed'),
+            user=removed_requester)
+        
+        invalid_usernames = [invalid_requester.username,
+                             removed_requester.username]
+        for invalid_username in invalid_usernames:
+            with self.assertRaises(CommandError) as cm:
+                self.command.renew(
+                    project.name, self.allocation_period,
+                    self.user.username, invalid_username)
+            self.assertIn(
+                f'Requester {invalid_username} is not an active member',
+                str(cm.exception))
+            self.assertProjectInactive(project.name)
+            self.service_units_attribute.refresh_from_db()
+            self.assertEqual(
+                Decimal(self.service_units_attribute.value),
+                settings.ALLOCATION_MIN)
+    
+    def test_validate_pi(self):
+        """Test that PI's who do not exist or are not active fail correctly."""
+
+        project = Project.objects.get(name=self.project_name)
+        self.assertEqual(
+            project.status, ProjectStatusChoice.objects.get(name='Inactive'))
+        
+        nonexistant_pi_username = 'nonexistant_pi_username'
+        with self.assertRaises(CommandError) as cm:
+                self.command.renew(
+                    project.name, self.allocation_period,
+                    nonexistant_pi_username, self.user.username)
+        self.assertIn(
+            f'User with username "{nonexistant_pi_username}" does not exist',
+            str(cm.exception))
+        self.assertProjectInactive(project.name)
+
+        # Active User (manager) who is on project but not PI
+        invalid_pi = User.objects.create(
+            email='manager@gmail.com',
+            first_name='manager',
+            last_name='manager',
+            username='invalid_pi'
+        )
+        ProjectUser.objects.create(
+            project=project,
+            role=ProjectUserRoleChoice.objects.get(name="Manager"),
+            status=ProjectUserStatusChoice.objects.get(name='Active'),
+            user=invalid_pi)
+        
+        # Removed PI
+        removed_pi = User.objects.create(
+            email='removedPI@gmail.com',
+            first_name='removed',
+            last_name='removed',
+            username='removed_pi'
+        )
+        ProjectUser.objects.create(
+            project=project,
+            role=ProjectUserRoleChoice.objects.get(
+                name="Principal Investigator"),
+            status=ProjectUserStatusChoice.objects.get(name='Removed'),
+            user=removed_pi)
+        invalid_pis = [invalid_pi.username, removed_pi.username]
+        for invalid_pi in invalid_pis:
+            with self.assertRaises(CommandError) as cm:
+                self.command.renew(
+                    project.name, self.allocation_period,
+                    invalid_pi, self.user.username)
+            self.assertIn(
+                f'{invalid_pi} is not an active PI',
+                str(cm.exception))
+            self.assertProjectInactive(project.name)
+            self.service_units_attribute.refresh_from_db()
+            self.assertEqual(
+                Decimal(self.service_units_attribute.value),
+                settings.ALLOCATION_MIN)
+
+    def test_validate_allocation_period(self):
+        """Test that AllocationPeriods which do not exist, are not valid for the
+        given computing allowance, or are not current fail correctly."""
+
+        project = Project.objects.get(name=self.project_name)
+        self.assertEqual(
+            project.status, ProjectStatusChoice.objects.get(name='Inactive'))
+        
+        nonexistant_alloc_period = "I don't exist!"
+        with self.assertRaises(CommandError) as cm:
+                self.command.renew(
+                    project.name, nonexistant_alloc_period,
+                    self.user.username, self.user.username)
+        self.assertIn(
+            f'AllocationPeriod "{nonexistant_alloc_period}" does not exist.',
+            str(cm.exception))
+        self.assertProjectInactive(project.name)
+
+        # Allowance Year allocation periods are not for ICA projects
+        cur_allowance_year = get_current_allowance_year_period()
+
+        with self.assertRaises(CommandError) as cm:
+            self.command.renew(
+                project.name, cur_allowance_year.name,
+                self.user.username, self.user.username)
+        self.assertIn(
+            f'"{cur_allowance_year.name}" is not a valid AllocationPeriod',
+            str(cm.exception))
+        self.assertProjectInactive(project.name)
+
+        # Non-current allocation period
+        past_alloc_period = AllocationPeriod.objects.filter(
+            Q(name__startswith='Fall') |
+            Q(name__startswith='Summer') |
+            Q(name__startswith='Spring'),
+            end_date__lt=utc_now_offset_aware())[0]
+        
+        with self.assertRaises(CommandError) as cm:
+            self.command.renew(
+                project.name, past_alloc_period,
+                self.user.username, self.user.username)
+        self.assertIn(
+            f'AllocationPeriod already ended',
+            str(cm.exception))
+        self.assertProjectInactive(project.name)
+
         self.service_units_attribute.refresh_from_db()
         self.assertEqual(
             Decimal(self.service_units_attribute.value),
             settings.ALLOCATION_MIN)
 
-    # TODO
-    #   test_validate_computing_allowance
-    #     ComputingAllowance isn't renewable (e.g., Recharge, Condo)
-    #   test_validate_requester
-    #     Requester validation: doesn't exist; isn't active manager/PI
-    #   test_validate_pi
-    #     PI validation: doesn't exist; isn't active PI
-    #   test_validate_allocation_period
-    #     AllocationPeriod doesn't exist
-    #     AllocationPeriod isn't valid for project's computing allowance
-    #     AllocationPeriod isn't current
-
+    def assertProjectInactive(self, project_name):
+        """ Test that a project has Inactive status. """
+        still_inactive_proj = Project.objects.get(name=project_name)
+        self.assertEqual(
+            still_inactive_proj.status,
+            ProjectStatusChoice.objects.get(name='Inactive'))
 
 class ProjectsCommand(object):
     """A wrapper class over the 'projects' management command."""

--- a/coldfront/core/project/tests/test_commands/test_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_projects.py
@@ -151,6 +151,7 @@ class TestProjectsRenew(TestProjectsBase):
                 'value': str(num_service_units),
             })
 
+    @enable_deployment('BRC')
     def test_dry_run(self):
         """Test that the request would be successful but the dry run
         ensures that the project is not updated."""
@@ -169,6 +170,7 @@ class TestProjectsRenew(TestProjectsBase):
             Decimal(self.service_units_attribute.value),
             settings.ALLOCATION_MIN)
 
+    @enable_deployment('BRC')
     def test_success(self):
         """Test that a successful request updates a project's status
         to 'Active' and the service units to the correct amount."""
@@ -201,6 +203,7 @@ class TestProjectsRenew(TestProjectsBase):
         # TODO: Also test:
         #  That only a processing email is sent
 
+    @enable_deployment('BRC')
     def test_validate_project(self):
         """Test that, if the project is invalid, the command raises an
         error, and does not proceed."""
@@ -219,6 +222,7 @@ class TestProjectsRenew(TestProjectsBase):
             Decimal(self.service_units_attribute.value),
             settings.ALLOCATION_MIN)
 
+    @enable_deployment('BRC')
     def test_validate_computing_allowance_non_renewable(self):
         """Test that computing allowances that cannot be renewed fail
         correctly (e.g., Recharge, Condo)."""
@@ -245,6 +249,7 @@ class TestProjectsRenew(TestProjectsBase):
 
     # TODO: Retire this test case once support for these allowances has been
     #  added.
+    @enable_deployment('BRC')
     def test_validate_computing_allowance_one_per_pi(self):
         """Test that computing allowances which a PI may only have one
         of fail correctly."""
@@ -269,6 +274,7 @@ class TestProjectsRenew(TestProjectsBase):
             self.assertIn('not currently supported', str(cm.exception))
             self._assert_project_inactive(project_name)
 
+    @enable_deployment('BRC')
     def test_validate_requester(self):
         """Test that requesters who do not exist, or are not an active
         manager/PI fail correctly."""
@@ -318,6 +324,7 @@ class TestProjectsRenew(TestProjectsBase):
                 Decimal(self.service_units_attribute.value),
                 settings.ALLOCATION_MIN)
 
+    @enable_deployment('BRC')
     def test_validate_pi(self):
         """Test that PIs who do not exist or are not active fail
         correctly."""
@@ -376,6 +383,7 @@ class TestProjectsRenew(TestProjectsBase):
                 Decimal(self.service_units_attribute.value),
                 settings.ALLOCATION_MIN)
 
+    @enable_deployment('BRC')
     def test_validate_allocation_period(self):
         """Test that AllocationPeriods which do not exist, are not valid
         for the given computing allowance, or are not current fail

--- a/coldfront/core/project/tests/test_commands/test_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_projects.py
@@ -1,10 +1,10 @@
+from datetime import timedelta
 from decimal import Decimal
 from io import StringIO
 
 from django.conf import settings
 from django.core.management import call_command
 from django.core.management import CommandError
-from django.db.models import Q
 from django.contrib.auth.models import User
 
 from coldfront.api.statistics.utils import create_project_allocation
@@ -20,13 +20,21 @@ from coldfront.core.project.models import ProjectUserRoleChoice
 from coldfront.core.project.models import ProjectUserStatusChoice
 from coldfront.core.project.utils_.renewal_utils import get_current_allowance_year_period
 from coldfront.core.resource.models import Resource
+from coldfront.core.resource.models import ResourceAttributeType
+from coldfront.core.resource.models import TimedResourceAttribute
+from coldfront.core.resource.utils_.allowance_utils.constants import BRCAllowances
+from coldfront.core.resource.utils_.allowance_utils.computing_allowance import ComputingAllowance
 from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
-from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.common import display_time_zone_current_date
+from coldfront.core.utils.tests.test_base import enable_deployment
 
 
 class TestProjectsBase(TestSUBase):
     """A base class for tests of the projects management command."""
-    pass
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._command = ProjectsCommand()
 
 
 class TestProjectsCreate(TestProjectsBase):
@@ -41,6 +49,7 @@ class TestProjectsRenew(TestProjectsBase):
     """A class for testing the 'renew' subcommand of the 'projects'
     management command."""
 
+    @enable_deployment('BRC')
     def setUp(self):
         super().setUp()
 
@@ -48,25 +57,17 @@ class TestProjectsRenew(TestProjectsBase):
         self.sign_user_access_agreement(self.user)
         self.client.login(username=self.user.username, password=self.password)
 
-        computing_allowance = Resource.objects.get(
-            name='Instructional Computing Allowance')
+        self._ica_computing_allowance = ComputingAllowance(
+            Resource.objects.get(name=BRCAllowances.ICA))
         computing_allowance_interface = ComputingAllowanceInterface()
         project_name_prefix = computing_allowance_interface.code_from_name(
-            computing_allowance.name)
-        
-        valid_alloc_periods = AllocationPeriod.objects.filter(
-            Q(name__startswith='Fall') |
-            Q(name__startswith='Summer') |
-            Q(name__startswith='Spring'),
-            start_date__lt=utc_now_offset_aware(),
-            end_date__gt=utc_now_offset_aware())
-        self.allocation_period = valid_alloc_periods[0]
-        
-        self.num_service_units = Decimal(
-            computing_allowance_interface.service_units_from_name(
-                computing_allowance.name, is_timed=True, 
-                allocation_period=self.allocation_period))
-        
+            self._ica_computing_allowance.get_name())
+
+        # An arbitrary number of service units to grant to ICAs in these tests.
+        self._ica_num_service_units = Decimal('1000000.00')
+
+        self._set_up_allocation_periods()
+
         # Create an inactive project and make self.user the PI
         self.project_name = f'{project_name_prefix}project'
         inactive_project_status = ProjectStatusChoice.objects.get(
@@ -74,8 +75,7 @@ class TestProjectsRenew(TestProjectsBase):
         inactive_project = Project.objects.create(
             name=self.project_name,
             title=self.project_name,
-            status=inactive_project_status
-        )
+            status=inactive_project_status)
 
         pi_role = ProjectUserRoleChoice.objects.get(
             name='Principal Investigator')
@@ -86,15 +86,70 @@ class TestProjectsRenew(TestProjectsBase):
             role=pi_role,
             status=active_project_user_status,
             user=self.user)
-        
-        self.existing_service_units = settings.ALLOCATION_MIN
+
         accounting_allocation_objects = create_project_allocation(
-            inactive_project, self.existing_service_units)
-        self.compute_allocation = accounting_allocation_objects.allocation
+            inactive_project, settings.ALLOCATION_MIN)
         self.service_units_attribute = \
             accounting_allocation_objects.allocation_attribute
-        
-        self.command = ProjectsCommand()
+
+    def _assert_project_inactive(self, project_name):
+        """Assert that a project has the Inactive status."""
+        still_inactive_proj = Project.objects.get(name=project_name)
+        self.assertEqual(
+            still_inactive_proj.status,
+            ProjectStatusChoice.objects.get(name='Inactive'))
+
+    def _set_up_allocation_periods(self):
+        """Create AllocationPeriods to potentially renew under."""
+        # Delete existing ICA AllocationPeriods.
+        AllocationPeriod.objects.filter(
+            self._ica_computing_allowance.get_period_filters()).delete()
+
+        today = display_time_zone_current_date()
+        year = today.year
+
+        self.past_ica_period = AllocationPeriod.objects.create(
+            name=f'Spring Semester {year}',
+            start_date=today - timedelta(days=100),
+            end_date=today - timedelta(days=1))
+        self.current_ica_period = AllocationPeriod.objects.create(
+            name=f'Summer Sessions {year}',
+            start_date=today - timedelta(days=50),
+            end_date=today + timedelta(days=50))
+        self.future_ica_period = AllocationPeriod.objects.create(
+            name=f'Fall Semester {year + 1}',
+            start_date=today + timedelta(days=1),
+            end_date=today + timedelta(days=100))
+
+        ica_periods = (
+            self.past_ica_period,
+            self.current_ica_period,
+            self.future_ica_period,
+        )
+        for period in ica_periods:
+            self._set_service_units_to_be_allocated_for_period(
+                self._ica_computing_allowance, period,
+                self._ica_num_service_units)
+
+    def _set_service_units_to_be_allocated_for_period(self, computing_allowance,
+                                                      allocation_period,
+                                                      num_service_units):
+        """Define the number of service units that should be granted to
+        as part of the given ComputingAllowance under the given
+        AllocationPeriod."""
+        assert isinstance(computing_allowance, ComputingAllowance)
+        assert isinstance(allocation_period, AllocationPeriod)
+        assert isinstance(num_service_units, Decimal)
+        resource_attribute_type = ResourceAttributeType.objects.get(
+            name='Service Units')
+        TimedResourceAttribute.objects.update_or_create(
+            resource_attribute_type=resource_attribute_type,
+            resource=computing_allowance.get_resource(),
+            start_date=allocation_period.start_date,
+            end_date=allocation_period.end_date,
+            defaults={
+                'value': str(num_service_units),
+            })
 
     def test_dry_run(self):
         """Test that the request would be successful but the dry run
@@ -102,8 +157,8 @@ class TestProjectsRenew(TestProjectsBase):
         project = Project.objects.get(name=self.project_name)
         self.assertEqual(project.status, 
                          ProjectStatusChoice.objects.get(name='Inactive'))
-        output, error = self.command.renew(
-            self.project_name, self.allocation_period, self.user.username,
+        output, error = self._command.renew(
+            self.project_name, self.current_ica_period, self.user.username,
             self.user.username, dry_run=True)
         
         self.assertFalse(error)
@@ -118,29 +173,30 @@ class TestProjectsRenew(TestProjectsBase):
         """Test that a successful request updates a project's status
         to 'Active' and the service units to the correct amount."""
         project = Project.objects.get(name=self.project_name)
-        self.assertEqual(project.status,
-                         ProjectStatusChoice.objects.get(name='Inactive'))
+        self.assertEqual(
+            project.status,
+            ProjectStatusChoice.objects.get(name='Inactive'))
 
-        output, error = self.command.renew(
-            self.project_name, self.allocation_period, self.user.username,
+        output, error = self._command.renew(
+            self.project_name, self.current_ica_period, self.user.username,
             self.user.username)
 
         self.assertFalse(error)
         now_active_proj = Project.objects.get(name=self.project_name)
-        self.assertEqual(now_active_proj.status,
-                         ProjectStatusChoice.objects.get(name='Active'))
+        self.assertEqual(
+            now_active_proj.status,
+            ProjectStatusChoice.objects.get(name='Active'))
         self.service_units_attribute.refresh_from_db()
         self.assertEqual(
             Decimal(self.service_units_attribute.value),
-            self.num_service_units)
+            self._ica_num_service_units)
 
         request = AllocationRenewalRequest.objects.get(
             requester=self.user,
             pi=self.user,
-            pre_project=project
-        )
+            pre_project=project)
         self.assertEqual(
-            AllocationRenewalRequestStatusChoice.objects.get(name="Complete"),
+            AllocationRenewalRequestStatusChoice.objects.get(name='Complete'),
             request.status)
         # TODO: Also test:
         #  That only a processing email is sent
@@ -153,44 +209,69 @@ class TestProjectsRenew(TestProjectsBase):
             project.status, ProjectStatusChoice.objects.get(name='Inactive'))
 
         with self.assertRaises(CommandError) as cm:
-            self.command.renew(
-                'invalid project name', self.allocation_period,
+            self._command.renew(
+                'invalid project name', self.current_ica_period,
                 self.user.username, self.user.username)
         self.assertIn('A Project with name', str(cm.exception))
-        self.assertProjectInactive(self.project_name)
+        self._assert_project_inactive(self.project_name)
         self.service_units_attribute.refresh_from_db()
         self.assertEqual(
             Decimal(self.service_units_attribute.value),
             settings.ALLOCATION_MIN)
-    
-    def test_validate_computing_allowance(self):
-        """Test that computing allowance that cannot be renewed fail 
+
+    def test_validate_computing_allowance_non_renewable(self):
+        """Test that computing allowances that cannot be renewed fail
         correctly (e.g., Recharge, Condo)."""
-        
-        non_renewable_resources = ['Condo Allocation', 'Recharge Allocation']
         computing_allowance_interface = ComputingAllowanceInterface()
+        non_renewable_resources = [BRCAllowances.CO, BRCAllowances.RECHARGE]
         for resource_name in non_renewable_resources:
-            computing_allowance = Resource.objects.get(
-                name=resource_name)
+            computing_allowance = ComputingAllowance(
+                Resource.objects.get(name=resource_name))
+            assert not computing_allowance.is_renewable()
             project_name_prefix = computing_allowance_interface.code_from_name(
-                computing_allowance.name)
-            project_name = project_name_prefix + "testproject"
+                computing_allowance.get_name())
+            project_name = project_name_prefix + 'testproject'
             Project.objects.create(
                 name=project_name,
                 title=project_name,
                 status=ProjectStatusChoice.objects.get(name='Inactive'))
-            
+
             with self.assertRaises(CommandError) as cm:
-                self.command.renew(
-                    project_name, self.allocation_period,
+                self._command.renew(
+                    project_name, self.current_ica_period,
                     self.user.username, self.user.username)
             self.assertIn('is not renewable', str(cm.exception))
-            self.assertProjectInactive(project_name)
-            
+            self._assert_project_inactive(project_name)
+
+    # TODO: Retire this test case once support for these allowances has been
+    #  added.
+    def test_validate_computing_allowance_one_per_pi(self):
+        """Test that computing allowances which a PI may only have one
+        of fail correctly."""
+        computing_allowance_interface = ComputingAllowanceInterface()
+        one_per_pi_resources = [BRCAllowances.FCA, BRCAllowances.PCA]
+        for resource_name in one_per_pi_resources:
+            computing_allowance = ComputingAllowance(
+                Resource.objects.get(name=resource_name))
+            assert computing_allowance.is_one_per_pi()
+            project_name_prefix = computing_allowance_interface.code_from_name(
+                computing_allowance.get_name())
+            project_name = project_name_prefix + 'testproject'
+            Project.objects.create(
+                name=project_name,
+                title=project_name,
+                status=ProjectStatusChoice.objects.get(name='Inactive'))
+
+            with self.assertRaises(CommandError) as cm:
+                self._command.renew(
+                    project_name, self.current_ica_period,
+                    self.user.username, self.user.username)
+            self.assertIn('not currently supported', str(cm.exception))
+            self._assert_project_inactive(project_name)
+
     def test_validate_requester(self):
         """Test that requesters who do not exist, or are not an active
         manager/PI fail correctly."""
-
         project = Project.objects.get(name=self.project_name)
         self.assertEqual(
             project.status, ProjectStatusChoice.objects.get(name='Inactive'))
@@ -204,10 +285,10 @@ class TestProjectsRenew(TestProjectsBase):
         )
         ProjectUser.objects.create(
             project=project,
-            role=ProjectUserRoleChoice.objects.get(name="User"),
+            role=ProjectUserRoleChoice.objects.get(name='User'),
             status=ProjectUserStatusChoice.objects.get(name='Active'),
             user=invalid_requester)
-        
+
         # Requester who is removed from project is invalid, even if Manager/PI
         removed_requester = User.objects.create(
             email='removed@gmail.com',
@@ -217,42 +298,42 @@ class TestProjectsRenew(TestProjectsBase):
         )
         ProjectUser.objects.create(
             project=project,
-            role=ProjectUserRoleChoice.objects.get(name="Manager"),
+            role=ProjectUserRoleChoice.objects.get(name='Manager'),
             status=ProjectUserStatusChoice.objects.get(name='Removed'),
             user=removed_requester)
-        
+
         invalid_usernames = [invalid_requester.username,
                              removed_requester.username]
         for invalid_username in invalid_usernames:
             with self.assertRaises(CommandError) as cm:
-                self.command.renew(
-                    project.name, self.allocation_period,
+                self._command.renew(
+                    project.name, self.current_ica_period,
                     self.user.username, invalid_username)
             self.assertIn(
                 f'Requester {invalid_username} is not an active member',
                 str(cm.exception))
-            self.assertProjectInactive(project.name)
+            self._assert_project_inactive(project.name)
             self.service_units_attribute.refresh_from_db()
             self.assertEqual(
                 Decimal(self.service_units_attribute.value),
                 settings.ALLOCATION_MIN)
-    
-    def test_validate_pi(self):
-        """Test that PI's who do not exist or are not active fail correctly."""
 
+    def test_validate_pi(self):
+        """Test that PIs who do not exist or are not active fail
+        correctly."""
         project = Project.objects.get(name=self.project_name)
         self.assertEqual(
             project.status, ProjectStatusChoice.objects.get(name='Inactive'))
-        
-        nonexistant_pi_username = 'nonexistant_pi_username'
+
+        nonexistent_pi_username = 'nonexistent_pi_username'
         with self.assertRaises(CommandError) as cm:
-                self.command.renew(
-                    project.name, self.allocation_period,
-                    nonexistant_pi_username, self.user.username)
+            self._command.renew(
+                project.name, self.current_ica_period,
+                nonexistent_pi_username, self.user.username)
         self.assertIn(
-            f'User with username "{nonexistant_pi_username}" does not exist',
+            f'User with username "{nonexistent_pi_username}" does not exist',
             str(cm.exception))
-        self.assertProjectInactive(project.name)
+        self._assert_project_inactive(project.name)
 
         # Active User (manager) who is on project but not PI
         invalid_pi = User.objects.create(
@@ -263,10 +344,10 @@ class TestProjectsRenew(TestProjectsBase):
         )
         ProjectUser.objects.create(
             project=project,
-            role=ProjectUserRoleChoice.objects.get(name="Manager"),
+            role=ProjectUserRoleChoice.objects.get(name='Manager'),
             status=ProjectUserStatusChoice.objects.get(name='Active'),
             user=invalid_pi)
-        
+
         # Removed PI
         removed_pi = User.objects.create(
             email='removedPI@gmail.com',
@@ -277,81 +358,79 @@ class TestProjectsRenew(TestProjectsBase):
         ProjectUser.objects.create(
             project=project,
             role=ProjectUserRoleChoice.objects.get(
-                name="Principal Investigator"),
+                name='Principal Investigator'),
             status=ProjectUserStatusChoice.objects.get(name='Removed'),
             user=removed_pi)
         invalid_pis = [invalid_pi.username, removed_pi.username]
         for invalid_pi in invalid_pis:
             with self.assertRaises(CommandError) as cm:
-                self.command.renew(
-                    project.name, self.allocation_period,
+                self._command.renew(
+                    project.name, self.current_ica_period,
                     invalid_pi, self.user.username)
             self.assertIn(
                 f'{invalid_pi} is not an active PI',
                 str(cm.exception))
-            self.assertProjectInactive(project.name)
+            self._assert_project_inactive(project.name)
             self.service_units_attribute.refresh_from_db()
             self.assertEqual(
                 Decimal(self.service_units_attribute.value),
                 settings.ALLOCATION_MIN)
 
     def test_validate_allocation_period(self):
-        """Test that AllocationPeriods which do not exist, are not valid for the
-        given computing allowance, or are not current fail correctly."""
-
+        """Test that AllocationPeriods which do not exist, are not valid
+        for the given computing allowance, or are not current fail
+        correctly."""
         project = Project.objects.get(name=self.project_name)
         self.assertEqual(
             project.status, ProjectStatusChoice.objects.get(name='Inactive'))
-        
-        nonexistant_alloc_period = "I don't exist!"
-        with self.assertRaises(CommandError) as cm:
-                self.command.renew(
-                    project.name, nonexistant_alloc_period,
-                    self.user.username, self.user.username)
-        self.assertIn(
-            f'AllocationPeriod "{nonexistant_alloc_period}" does not exist.',
-            str(cm.exception))
-        self.assertProjectInactive(project.name)
 
-        # Allowance Year allocation periods are not for ICA projects
+        nonexistent_alloc_period = 'I don\'t exist!'
+        with self.assertRaises(CommandError) as cm:
+            self._command.renew(
+                project.name, nonexistent_alloc_period,
+                self.user.username, self.user.username)
+        self.assertIn(
+            f'AllocationPeriod "{nonexistent_alloc_period}" does not exist.',
+            str(cm.exception))
+        self._assert_project_inactive(project.name)
+
+        # "Allowance Year" allocation periods are not for ICA projects
         cur_allowance_year = get_current_allowance_year_period()
 
         with self.assertRaises(CommandError) as cm:
-            self.command.renew(
+            self._command.renew(
                 project.name, cur_allowance_year.name,
                 self.user.username, self.user.username)
         self.assertIn(
             f'"{cur_allowance_year.name}" is not a valid AllocationPeriod',
             str(cm.exception))
-        self.assertProjectInactive(project.name)
+        self._assert_project_inactive(project.name)
 
-        # Non-current allocation period
-        past_alloc_period = AllocationPeriod.objects.filter(
-            Q(name__startswith='Fall') |
-            Q(name__startswith='Summer') |
-            Q(name__startswith='Spring'),
-            end_date__lt=utc_now_offset_aware())[0]
-        
+        # Ended allocation period
         with self.assertRaises(CommandError) as cm:
-            self.command.renew(
-                project.name, past_alloc_period,
+            self._command.renew(
+                project.name, self.past_ica_period,
                 self.user.username, self.user.username)
         self.assertIn(
-            f'AllocationPeriod already ended',
+            'AllocationPeriod already ended',
             str(cm.exception))
-        self.assertProjectInactive(project.name)
+        self._assert_project_inactive(project.name)
+
+        # Not started allocation period
+        with self.assertRaises(CommandError) as cm:
+            self._command.renew(
+                project.name, self.future_ica_period,
+                self.user.username, self.user.username)
+        self.assertIn(
+            'AllocationPeriod does not start until',
+            str(cm.exception))
+        self._assert_project_inactive(project.name)
 
         self.service_units_attribute.refresh_from_db()
         self.assertEqual(
             Decimal(self.service_units_attribute.value),
             settings.ALLOCATION_MIN)
 
-    def assertProjectInactive(self, project_name):
-        """ Test that a project has Inactive status. """
-        still_inactive_proj = Project.objects.get(name=project_name)
-        self.assertEqual(
-            still_inactive_proj.status,
-            ProjectStatusChoice.objects.get(name='Inactive'))
 
 class ProjectsCommand(object):
     """A wrapper class over the 'projects' management command."""

--- a/coldfront/core/project/tests/test_views/test_new_project_views/test_savio_project_request_wizard.py
+++ b/coldfront/core/project/tests/test_views/test_new_project_views/test_savio_project_request_wizard.py
@@ -11,6 +11,7 @@ from http import HTTPStatus
 class TestSavioProjectRequestWizard(TestBase):
     """A class for testing SavioProjectRequestWizard."""
 
+
     @enable_deployment('BRC')
     def setUp(self):
         """Set up test data."""
@@ -27,18 +28,20 @@ class TestSavioProjectRequestWizard(TestBase):
         project."""
         return reverse('new-project-request')
 
-    @enable_deployment('BRC')
-    def test_post_creates_request(self):
-        """Test that a POST request creates a
-        SavioProjectAllocationRequest."""
-        self.assertEqual(SavioProjectAllocationRequest.objects.count(), 0)
-        self.assertEqual(Project.objects.count(), 0)
-
-        computing_allowance = self.get_predominant_computing_allowance()
-        allocation_period = get_current_allowance_year_period()
+    def get_form_preparation_data(self, computing_allowance=None, allocation_period=None, pi=None, name='name',
+                      title='title', description='a' * 20, scope_and_intent='b' * 20,
+                      computational_aspects='c' * 20):
+        """Prepare the form data for the wizard."""
+        if computing_allowance is None:
+            computing_allowance = self.get_predominant_computing_allowance()
+        if allocation_period is None:
+            allocation_period = get_current_allowance_year_period()
+        if pi is None:
+            pi = self.user
 
         view_name = 'savio_project_request_wizard'
         current_step_key = f'{view_name}-current_step'
+
         computing_allowance_form_data = {
             '0-computing_allowance': computing_allowance.pk,
             current_step_key: '0',
@@ -48,7 +51,7 @@ class TestSavioProjectRequestWizard(TestBase):
             current_step_key: '1',
         }
         existing_pi_form_data = {
-            '2-PI': self.user.pk,
+            '2-PI': pi.pk,
             current_step_key: '2',
         }
         pool_allocations_data = {
@@ -56,14 +59,14 @@ class TestSavioProjectRequestWizard(TestBase):
             current_step_key: '6',
         }
         details_data = {
-            '8-name': 'name',
-            '8-title': 'title',
-            '8-description': 'a' * 20,
+            '8-name': name,
+            '8-title': title,
+            '8-description': description,
             current_step_key: '8',
         }
         survey_data = {
-            '10-scope_and_intent': 'b' * 20,
-            '10-computational_aspects': 'c' * 20,
+            '10-scope_and_intent': scope_and_intent,
+            '10-computational_aspects': computational_aspects,
             current_step_key: '10',
         }
         form_data = [
@@ -74,6 +77,19 @@ class TestSavioProjectRequestWizard(TestBase):
             details_data,
             survey_data,
         ]
+        return form_data, details_data, survey_data
+
+    @enable_deployment('BRC')
+    def test_post_creates_request(self):
+        """Test that a POST request creates a
+        SavioProjectAllocationRequest."""
+        self.assertEqual(SavioProjectAllocationRequest.objects.count(), 0)
+        self.assertEqual(Project.objects.count(), 0)
+
+        computing_allowance = self.get_predominant_computing_allowance()
+        allocation_period = get_current_allowance_year_period()
+
+        form_data, details_data, survey_data = self.get_form_preparation_data()
 
         url = self.request_url()
         for i, data in enumerate(form_data):
@@ -110,4 +126,29 @@ class TestSavioProjectRequestWizard(TestBase):
             survey_data['10-computational_aspects'])
         self.assertEqual(request.status.name, 'Under Review')
 
-    # TODO
+    @enable_deployment('BRC')
+    def test_post_fails_without_user_last_name(self):
+        """Test that a user without a last name cannot create a request."""
+
+        self.user.last_name = ''
+        self.user.save()
+
+        self.assertEqual(SavioProjectAllocationRequest.objects.count(), 0)
+        self.assertEqual(Project.objects.count(), 0)
+
+        form_data, _, _ = self.get_form_preparation_data()
+
+        url = self.request_url()
+        for i, data in enumerate(form_data):
+            response = self.client.post(url, data, follow=True)
+            print(response.content)
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+            # Once the error message is displayed, we break to check if the request was created
+            if b'You must set your first and last name on your account' in response.content:
+                break
+
+        # Assert that the request was not created (1 from the test above)
+        requests = SavioProjectAllocationRequest.objects.all()
+        self.assertEqual(requests.count(), 1)
+        projects = Project.objects.all()
+        self.assertEqual(projects.count(), 1)

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -6,6 +6,7 @@ from coldfront.core.allocation.models import AllocationRenewalRequest
 from coldfront.core.allocation.models import AllocationRenewalRequestStatusChoice
 from coldfront.core.allocation.models import AllocationStatusChoice
 from coldfront.core.allocation.utils import get_project_compute_allocation
+from coldfront.core.allocation.utils import prorated_allocation_amount
 from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
 from coldfront.core.project.models import ProjectStatusChoice

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -579,6 +579,33 @@ def allocation_renewal_request_state_status(request):
         name='Under Review')
 
 
+def set_allocation_renewal_request_eligibility(request, status, justification,
+                                               timestamp=None):
+    """Update the given AllocationRenewalRequest to note whether the PI
+    of the request is eligible for renewal, with the following:
+        - A str 'status' denoting eligibility (one of 'Pending',
+          'Approved', 'Denied'),
+        - A str 'justification' with admin comments, and
+        - An optional str ISO 8601 'timestamp'. If one is not given, the
+          current time is used.
+
+    Based on 'status', also update the status of the request (e.g., if
+    the PI is ineligible, the request's status should have status
+    'Denied'.
+    """
+    if timestamp is not None:
+        assert isinstance(timestamp, str)
+    else:
+        timestamp = utc_now_offset_aware().isoformat()
+    request.state['eligibility'] = {
+        'status': status,
+        'justification': justification,
+        'timestamp': timestamp,
+    }
+    request.status = allocation_renewal_request_state_status(request)
+    request.save()
+
+
 class AllocationRenewalRunnerBase(object):
     """A base class that Runners for handling AllocationRenewalsRequests
     should inherit from."""

--- a/coldfront/core/project/views.py
+++ b/coldfront/core/project/views.py
@@ -56,6 +56,7 @@ from coldfront.core.user.utils import CombinedUserSearch, access_agreement_signe
 from coldfront.core.utils.common import (get_domain_url, import_from_settings)
 from coldfront.core.utils.email.email_strategy import EnqueueEmailStrategy
 from coldfront.core.utils.mail import send_email, send_email_template
+from coldfront.core.utils.permissions import permissions_required, check_first_last_name
 
 from flags.state import flag_enabled
 
@@ -630,6 +631,7 @@ class ProjectCreateView(LoginRequiredMixin, UserPassesTestMixin, CreateView):
     template_name_suffix = '_create_form'
     fields = ['title', 'description', 'field_of_science', ]
 
+    @permissions_required(check_first_last_name)
     def test_func(self):
         """ UserPassesTestMixin Tests"""
         if self.request.user.is_superuser:

--- a/coldfront/core/project/views_/join_views/request_views.py
+++ b/coldfront/core/project/views_/join_views/request_views.py
@@ -29,6 +29,7 @@ from coldfront.core.project.utils import send_project_join_notification_email
 from coldfront.core.project.views import ProjectListView
 from coldfront.core.user.utils_.host_user_utils import is_lbl_employee
 from coldfront.core.user.utils_.host_user_utils import needs_host
+from coldfront.core.utils.permissions import permissions_required, check_first_last_name
 
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ class ProjectJoinView(LoginRequiredMixin, UserPassesTestMixin, TemplateView):
 
     logger = logging.getLogger(__name__)
 
+    @permissions_required(check_first_last_name)
     def test_func(self):
         project_obj = get_object_or_404(Project, pk=self.kwargs.get('pk'))
         user_obj = self.request.user

--- a/coldfront/core/project/views_/new_project_views/request_views.py
+++ b/coldfront/core/project/views_/new_project_views/request_views.py
@@ -34,6 +34,8 @@ from coldfront.core.user.models import UserProfile
 from coldfront.core.user.utils import access_agreement_signed
 from coldfront.core.utils.common import session_wizard_all_form_data
 from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.permissions import permissions_required, check_first_last_name
+
 
 from django.conf import settings
 from django.contrib import messages
@@ -58,6 +60,7 @@ class ProjectRequestView(LoginRequiredMixin, UserPassesTestMixin,
                          TemplateView):
     template_name = 'project/project_request/project_request.html'
 
+    @permissions_required(check_first_last_name)
     def test_func(self):
         if self.request.user.is_superuser:
             return True

--- a/coldfront/core/project/views_/renewal_views/approval_views.py
+++ b/coldfront/core/project/views_/renewal_views/approval_views.py
@@ -11,6 +11,7 @@ from coldfront.core.project.utils_.renewal_utils import AllocationRenewalProcess
 from coldfront.core.project.utils_.renewal_utils import allocation_renewal_request_denial_reason
 from coldfront.core.project.utils_.renewal_utils import allocation_renewal_request_latest_update_timestamp
 from coldfront.core.project.utils_.renewal_utils import allocation_renewal_request_state_status
+from coldfront.core.project.utils_.renewal_utils import set_allocation_renewal_request_eligibility
 from coldfront.core.resource.utils_.allowance_utils.computing_allowance import ComputingAllowance
 from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
 from coldfront.core.utils.common import display_time_zone_current_date
@@ -375,15 +376,9 @@ class AllocationRenewalRequestReviewEligibilityView(LoginRequiredMixin,
         form_data = form.cleaned_data
         status = form_data['status']
         justification = form_data['justification']
-        timestamp = utc_now_offset_aware().isoformat()
-        self.request_obj.state['eligibility'] = {
-            'status': status,
-            'justification': justification,
-            'timestamp': timestamp,
-        }
-        self.request_obj.status = allocation_renewal_request_state_status(
-            self.request_obj)
-        self.request_obj.save()
+
+        set_allocation_renewal_request_eligibility(
+            self.request_obj, status, justification)
 
         if status == 'Denied':
             runner = AllocationRenewalDenialRunner(self.request_obj)

--- a/coldfront/core/project/views_/renewal_views/request_views.py
+++ b/coldfront/core/project/views_/renewal_views/request_views.py
@@ -34,6 +34,8 @@ from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAl
 from coldfront.core.user.utils import access_agreement_signed
 from coldfront.core.utils.common import session_wizard_all_form_data
 from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.permissions import permissions_required, check_first_last_name
+
 
 from decimal import Decimal
 
@@ -60,6 +62,7 @@ class AllocationRenewalLandingView(LoginRequiredMixin, UserPassesTestMixin,
                                    TemplateView):
     template_name = 'project/project_renewal/request_landing.html'
 
+    @permissions_required(check_first_last_name)
     def test_func(self):
         if self.request.user.is_superuser:
             return True

--- a/coldfront/core/resource/utils_/allowance_utils/computing_allowance.py
+++ b/coldfront/core/resource/utils_/allowance_utils/computing_allowance.py
@@ -1,3 +1,5 @@
+from django.db.models import Q
+
 from flags.state import flag_enabled
 
 from coldfront.core.resource.models import Resource
@@ -130,6 +132,27 @@ class ComputingAllowance(object):
     def get_name(self):
         """Return the name of the underlying Resource."""
         return self._name
+
+    def get_period_filters(self):
+        """Return a Django Q object that can be used to filter for
+        AllocationPeriods associated with the allowance.
+
+        If none are applicable, return None.
+        """
+        yearly_q = Q(name__startswith='Allowance Year')
+        if flag_enabled('BRC_ONLY'):
+            if self.is_yearly():
+                return yearly_q
+            elif self.is_instructional():
+                instructional_q = (
+                    Q(name__startswith='Fall Semester') |
+                    Q(name__startswith='Spring Semester') |
+                    Q(name__startswith='Summer Sessions'))
+                return instructional_q
+        if flag_enabled('LRC_ONLY'):
+            if self.is_yearly():
+                return yearly_q
+        return None
 
     def get_resource(self):
         """Return the underlying Resource."""

--- a/coldfront/core/resource/utils_/allowance_utils/computing_allowance.py
+++ b/coldfront/core/resource/utils_/allowance_utils/computing_allowance.py
@@ -109,7 +109,7 @@ class ComputingAllowance(object):
         return self.is_periodic()
 
     def is_renewal_supported(self):
-        """Return whether there is support for renewing the
+        """Return whether there is UI support for renewing the
         allowance."""
         allowance_names = []
         if flag_enabled('BRC_ONLY'):

--- a/coldfront/core/utils/permissions.py
+++ b/coldfront/core/utils/permissions.py
@@ -1,0 +1,38 @@
+from functools import wraps
+from django.contrib import messages
+from django.urls import reverse
+from django.utils.html import format_html
+
+
+
+def permissions_required(*permissions):
+    """
+    Decorator to check if a user has all specified permissions before allowing them to access a view.
+    The decorator is used to wrap a test_func from UserPassesTestMixin, which allows granular refactoring of
+    the permission check logic on test_func without having to change the permission logic.
+
+    :param permissions: variable number of functions where each returns True if the user has the permission, False otherwise
+    :return:
+    """
+    def decorator(test_func):
+        @wraps(test_func)
+        def wrapper(view_instance, *args, **kwargs):
+            # Check if all provided permissions return True
+            if not all(permission(view_instance.request) for permission in permissions):
+                return False
+            return test_func(view_instance, *args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def check_first_last_name(request):
+    """
+    Check if the user has set their first and last name on their account before allowing them to make requests.
+    :param request:
+    :return:
+    """
+    if request.user.first_name == '' or request.user.last_name == '':
+        profile_url = request.build_absolute_uri(reverse('user-profile'))
+        messages.error(request, format_html(f'You must set your first and last name on your account before you can make requests. Update your profile <a href="{profile_url}">here</a>.'))
+        return False
+    return True

--- a/coldfront/templates/common/messages.html
+++ b/coldfront/templates/common/messages.html
@@ -3,7 +3,7 @@
     <button type="button" class="close" data-dismiss="alert" aria-label="Close">
       <span aria-hidden="true">&times;</span>
     </button>
-    {{ message }}
+    {{ message|safe }}
   </div>
 {% endfor %}
 

--- a/coldfront/templates/error_with_message.html
+++ b/coldfront/templates/error_with_message.html
@@ -11,7 +11,7 @@
 <div class="row justify-content-center">
     <div class="col-lg-10 col-xs-12">
         <div class="alert alert-danger" role="alert">
-          {{ message }}
+            {{ message|safe }}
         </div>
     </div>
 </div>

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,3 +56,4 @@ tqdm==4.62.3
 urllib3==1.24.2
 user-agents==2.2.0
 wcwidth==0.1.7
+pytest-django


### PR DESCRIPTION
## Description

* Adds a permissions.py file as an initial step to centeralize
  permissions across the app.

* Adds first and last name check to the test_func on requests to create or join a project.

* Creates a generic wrapper decorator to be used around test_func to
  allow gradual progressive refactor of test_func towards a  more
  centralized and modular permissions management solution.

Fixes #605 

## Type of change

 **** Please delete options that are not relevant. ****

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration ****

1. Last name was removed from a user account and saved.
2. Clicked on project and attempted to create project - Saw the error message. 
3. Clicked on project and attempted to join a project - Saw the error message. 


## PR Self Evaluation
strikethrough things that don’t make sense for your PR

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
~- [ ] I have made corresponding changes to the documentation (if needed)~
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
