### PR TITLE
Install libfaketime in base Docker image

### DIFF
--- a/bootstrap/development/docker/images/os.Dockerfile
+++ b/bootstrap/development/docker/images/os.Dockerfile
@@ -3,6 +3,7 @@ FROM rockylinux/rockylinux:8.8
 RUN dnf update -y && \
     dnf install -y \
     gcc \
+    git \
     make \
     wget \
     openssl-devel \
@@ -28,4 +29,10 @@ RUN rm -rf /usr/src/python310
 RUN echo "/usr/local/lib" > /etc/ld.so.conf.d/local.conf && \
     ldconfig
 
-# TODO: libfaketime
+# Install libfaketime.
+RUN git clone https://github.com/wolfcw/libfaketime.git /opt/libfaketime && \
+    cd /opt/libfaketime && \
+    make && \
+    make install && \
+    dnf clean all && \
+    rm -rf /opt/libfaketime


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

Some functionality may only be tested at certain times of the year. For example, the command `start_allocation_period`, which runs processing to allocate service units to projects under which renewals were requested, may only be run once the provided period has started.

`libfaketime` enables the current date and time of the machine to be mocked to test functionality like this beforehand. It had been used before, but had not been incorporated into the Docker development environment.

- Installed `libfaketime` in the `os` Docker image, which is inherited by other images.
- Updated the [documentation](https://github.com/ucb-rit/mybrc-mylrc-docs/blob/main/docs/how-to-guides/how-to-transition-from-one-allowance-year-to-the-next.md#testing-a-transition) on transitioning between allowance years to discuss how to use the tool.

## Type of change

 **** Please delete options that are not relevant. ****

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Re-run the step for rebuilding Docker images on this branch.
- Follow the instructions in the documentation linked above to run the Docker Compose stack with fake times in some services (e.g., `app-shell`, `web`).
- Within the shell in one of those services, run the `date` command. Ensure that the outputted date matches the fake time that was set.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
