### PR TITLE
Allow user to specify Docker image tags; reference them in Compose file

### DIFF
--- a/bootstrap/development/docker/README.md
+++ b/bootstrap/development/docker/README.md
@@ -8,6 +8,9 @@ Note that these steps must be run from the root directory of the repo.
    sh bootstrap/development/docker/scripts/build_images.sh
    ```
 
+   Notes:
+      - An optional argument may be specified to build the images with a specific tag. This may be useful for testing updated images (e.g., from different branches) without overriding existing images.
+
 2. Retrieve a `cilogon.yml` file containing CILogon credentials that will be provided for you. Place it in the Docker configuration directory.
 
    ```bash
@@ -63,6 +66,7 @@ Note that these steps must be run from the root directory of the repo.
 
    Notes:
      - Some services (e.g., `web`) are expected to be failing at this point.
+     - If the `IMAGE_TAG` environment variable is set, Docker Compose will use images with the specified tag.
 
 7. Run Django scripts to set up the database and perform other tasks. You must provide the name of your Docker project.
 

--- a/bootstrap/development/docker/docker-compose.yml
+++ b/bootstrap/development/docker/docker-compose.yml
@@ -25,10 +25,10 @@ services:
       - ./config/redis.conf:/usr/local/etc/redis/redis.conf
 
   email-server:
-    image: coldfront-email-server
+    image: coldfront-email-server:${IMAGE_TAG:-latest}
 
   db-postgres-shell:
-    image: coldfront-db-postgres-shell
+    image: coldfront-db-postgres-shell:${IMAGE_TAG:-latest}
     environment:
       POSTGRES_HOST: db-postgres
       POSTGRES_DB: ${DB_NAME}
@@ -42,12 +42,12 @@ services:
       - ../../..:/var/www/coldfront_app/coldfront
 
   app-shell:
-    image: coldfront-app-shell
+    image: coldfront-app-shell:${IMAGE_TAG:-latest}
     volumes:
       - ../../..:/var/www/coldfront_app/coldfront
 
   web:
-    image: coldfront-web
+    image: coldfront-web:${IMAGE_TAG:-latest}
     ports:
       - ${WEB_PORT}:80
     volumes:

--- a/bootstrap/development/docker/images/app-base.Dockerfile
+++ b/bootstrap/development/docker/images/app-base.Dockerfile
@@ -1,4 +1,5 @@
-FROM coldfront-os
+ARG BASE_IMAGE_TAG=latest
+FROM coldfront-os:${BASE_IMAGE_TAG}
 
 WORKDIR /var/www/coldfront_app/coldfront
 

--- a/bootstrap/development/docker/images/app-config.Dockerfile
+++ b/bootstrap/development/docker/images/app-config.Dockerfile
@@ -1,4 +1,5 @@
-FROM coldfront-os
+ARG BASE_IMAGE_TAG=latest
+FROM coldfront-os:${BASE_IMAGE_TAG}
 
 WORKDIR /app
 

--- a/bootstrap/development/docker/images/app-shell.Dockerfile
+++ b/bootstrap/development/docker/images/app-shell.Dockerfile
@@ -1,3 +1,4 @@
-FROM coldfront-app-base
+ARG BASE_IMAGE_TAG=latest
+FROM coldfront-app-base:${BASE_IMAGE_TAG}
 
 CMD ["sleep", "infinity"]

--- a/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
+++ b/bootstrap/development/docker/images/db-postgres-shell.Dockerfile
@@ -1,4 +1,5 @@
-FROM coldfront-app-base
+ARG BASE_IMAGE_TAG=latest
+FROM coldfront-app-base:${BASE_IMAGE_TAG}
 
 RUN dnf update -y && \
     dnf install -y gnupg wget

--- a/bootstrap/development/docker/images/email-server.Dockerfile
+++ b/bootstrap/development/docker/images/email-server.Dockerfile
@@ -1,3 +1,4 @@
-FROM coldfront-app-base
+ARG BASE_IMAGE_TAG=latest
+FROM coldfront-app-base:${BASE_IMAGE_TAG}
 
 CMD ["python3", "-m", "smtpd", "-d", "-n", "-c", "DebuggingServer", "0.0.0.0:1025"]

--- a/bootstrap/development/docker/images/web.Dockerfile
+++ b/bootstrap/development/docker/images/web.Dockerfile
@@ -1,3 +1,4 @@
-FROM coldfront-app-base
+ARG BASE_IMAGE_TAG=latest
+FROM coldfront-app-base:${BASE_IMAGE_TAG}
 
 CMD ["python3", "manage.py", "runserver", "0.0.0.0:80"]

--- a/bootstrap/development/docker/scripts/build_images.sh
+++ b/bootstrap/development/docker/scripts/build_images.sh
@@ -1,9 +1,41 @@
 #!/bin/bash
 
-docker build -f bootstrap/development/docker/images/os.Dockerfile -t coldfront-os .
-docker build -f bootstrap/development/docker/images/app-config.Dockerfile -t coldfront-app-config bootstrap/development/docker
-docker build -f bootstrap/development/docker/images/app-base.Dockerfile -t coldfront-app-base .
-docker build -f bootstrap/development/docker/images/app-shell.Dockerfile -t coldfront-app-shell .
-docker build -f bootstrap/development/docker/images/web.Dockerfile -t coldfront-web .
-docker build -f bootstrap/development/docker/images/email-server.Dockerfile -t coldfront-email-server .
-docker build -f bootstrap/development/docker/images/db-postgres-shell.Dockerfile -t coldfront-db-postgres-shell .
+if [ -z "$1" ]; then
+  IMAGE_TAG="latest"
+else
+  IMAGE_TAG="$1"
+fi
+
+docker build \
+    -f bootstrap/development/docker/images/os.Dockerfile \
+    -t coldfront-os:$IMAGE_TAG .
+
+docker build \
+    -f bootstrap/development/docker/images/app-config.Dockerfile \
+    --build-arg BASE_IMAGE_TAG=$IMAGE_TAG \
+    -t coldfront-app-config:$IMAGE_TAG bootstrap/development/docker
+
+docker build \
+    -f bootstrap/development/docker/images/app-base.Dockerfile \
+    --build-arg BASE_IMAGE_TAG=$IMAGE_TAG \
+    -t coldfront-app-base:$IMAGE_TAG .
+
+docker build \
+    -f bootstrap/development/docker/images/app-shell.Dockerfile \
+    --build-arg BASE_IMAGE_TAG=$IMAGE_TAG \
+    -t coldfront-app-shell:$IMAGE_TAG .
+
+docker build \
+    -f bootstrap/development/docker/images/web.Dockerfile \
+    --build-arg BASE_IMAGE_TAG=$IMAGE_TAG \
+    -t coldfront-web:$IMAGE_TAG .
+
+docker build \
+    -f bootstrap/development/docker/images/email-server.Dockerfile \
+    --build-arg BASE_IMAGE_TAG=$IMAGE_TAG \
+    -t coldfront-email-server:$IMAGE_TAG .
+
+docker build \
+    -f bootstrap/development/docker/images/db-postgres-shell.Dockerfile \
+    --build-arg BASE_IMAGE_TAG=$IMAGE_TAG \
+    -t coldfront-db-postgres-shell:$IMAGE_TAG .


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

- Updated the Docker images to allow the user to specify a tag (defaulting to `latest`).
- Updated the script for building the images to optionally take a tag as input.
- Updated the Docker Compose file to reference specific tags:
    - If the `IMAGE_TAG` environment variable is set, images with that tag are used.
    - Otherwise, the `latest` images are used.
- Discussed these options in the Docker `README.md`.

This enables a developer to build a separate set of images (e.g., when testing a different branch) without overriding their existing images.

## Type of change

 **** Please delete options that are not relevant. ****

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Review the changes to `README.md`.
- Run `build_images.sh` both with and without an optional argument. Ensure that images are built and tagged successfully.
- Bring up the Docker Compose stack both with and without specifying an `IMAGE_TAG` environment variable. Ensure that the correct images are used.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
