### PR TITLE
Enables gsheet Integration  for condo procurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Documentation resides in a separate repository. Please request access.
 ### Miscellaneous Topics
 
 - [Deployment](bootstrap/ansible/README.md)
+- [Google Sheets Setup](bootstrap/docs/g-sheets-setup.md)
 - [REST API](coldfront/api/README.md)
 
 ## License

--- a/bootstrap/development/docs/g-sheets-setup.md
+++ b/bootstrap/development/docs/g-sheets-setup.md
@@ -1,0 +1,50 @@
+## Google Sheets Integration
+
+This project uses Google Sheets to track acitivites such as:
+- HPC hardware procurement and decommission information.
+- TBD
+
+
+
+### Setup
+
+1. **Service Account & Credentials:**
+   - Create a Google Cloud service account with Sheets API (readonly) access.
+   - Set the environment variable `GOOGLE_SERVICE_ACCOUNT_JSON_PATH` to the path of your JSON credentials.
+   - Set `DECOMISSION_SHEET_ID` to your target spreadsheet's ID.
+
+2. **Django Settings:**
+   - **`DECOMMISSION_WARNING_DAYS`**: Days before the decommission date to trigger a warning (default: `30`).
+   - **`GSHEETS_CACHE_TIMEOUT`**: Cache duration in seconds (default: `86400` for 24 hours).
+   - **`GSHEETS_DISABLE_CACHE`**: Set to `True` during development/testing to disable caching.
+
+3. ** Docker-compose environment:**
+   - Add the following to your `docker-compose.yml` file:
+     ```yaml
+     services:
+       web:
+         environment:
+           - GOOGLE_SERVICE_ACCOUNT_JSON_PATH=/path/to/your/credentials.json
+           - DECOMISSION_SHEET_ID=your-spreadsheet-id
+           - GSHEETS_DISABLE_CACHE=True
+     # ...
+     ```
+
+### Google Sheets Format
+
+- **Tabs:** The spreadsheet must include two tabs: **Savio** and **LRC**.
+- **Header:** The header is on row 3 and must include at least:
+  - `PI Email`
+  - `Expected Decomission Date` (in MM/DD/YYYY format)
+- **Data Rows:** Data starts from row 4.
+
+### HPCS Hardware Procurement Tracking
+
+Upon user login, the application:
+- Checks both the **Savio** and **LRC** tabs for a record where `PI Email` matches the logged-in user's email.
+- Parses the `Expected Decomission Date` and, if the current date is within `DECOMMISSION_WARNING_DAYS` of that date, flags the record.
+- Displays decommission alerts using a card layout that lists each field vertically for clear, readable details.
+
+---
+
+This summary should help users and developers quickly understand and set up the Google Sheets integration and the HPCS Hardware Procurement Tracking functionality.

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -220,6 +220,11 @@ DECIMAL_MAX_PLACES = 2
 ALLOCATION_MIN = Decimal('0.00')
 ALLOCATION_MAX = Decimal('100000000.00')
 
+DECOMMISSION_WARNING_DAYS = 30
+
+GSHEETS_DISABLE_CACHE = True
+
+
 # Whether to allow all jobs, bypassing all checks at job submission time.
 ALLOW_ALL_JOBS = False
 

--- a/coldfront/config/urls.py
+++ b/coldfront/config/urls.py
@@ -26,6 +26,8 @@ urlpatterns = [
     # path('grant/', include('coldfront.core.grant.urls')),
     # path('publication/', include('coldfront.core.publication.urls')),
     # path('research-output/', include('coldfront.core.research_output.urls')),
+    path('decommission-details/', portal_views.decommission_details, name='decommission_details'),
+
     path('help', TemplateView.as_view(template_name='portal/help.html'), name='help'),
 ]
 

--- a/coldfront/core/portal/templates/portal/authorized_home.html
+++ b/coldfront/core/portal/templates/portal/authorized_home.html
@@ -1,11 +1,43 @@
 {% extends "common/base.html" %} {% load common_tags %} {% block content %}
 
+{% load portal_tags %}
+
 <div class="row">
   <div class="col-lg-12">
     <h2>Welcome</h2>
     <hr>
 
     {% include 'portal/feedback_alert.html' %}
+
+  {% if decommission_alerts %}
+  <div class="alert alert-warning">
+    <strong>Decommission Notice:</strong> Your condo allocation is scheduled for decommissioning.
+    Please <a href="{% url 'decommission_details' %}">click here</a> for details.
+
+    <table class="table table-sm mt-2">
+      <thead>
+        <tr>
+          <th>Hardware Type</th>
+          <th>Expected Decomission Date</th>
+          <th>Status</th>
+          <th>Department Division</th>
+          <th>Hardware Specification Details</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for alert in decommission_alerts %}
+          <tr>
+            <td>{{ alert.record|get_item:"Hardware Type" }}</td>
+            <td>{{ alert.record|get_item:"Expected Decomission Date" }}</td>
+            <td>{{ alert.record|get_item:"Status" }}</td>
+            <td>{{ alert.record|get_item:"Department Division" }}</td>
+            <td>{{ alert.record|get_item:"Hardware Specification Details" }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% endif %}
 
     <p>If you would like to set up or update your access to a cluster, please complete the following steps.</p>
     <p>First review and sign the cluster user agreement. Only then you can join a cluster project and gain access to the cluster.</p>
@@ -112,6 +144,7 @@
     {% else %}
       <span class="alert alert-danger"><b>No Cluster Account</b></span>
     {% endif %}
+  </div>
   </div>
 </div>
 <br></br>

--- a/coldfront/core/portal/templates/portal/decommission_details.html
+++ b/coldfront/core/portal/templates/portal/decommission_details.html
@@ -1,0 +1,39 @@
+{% extends "common/base.html" %}
+{% load static %}
+
+{% block title %}
+  Condo Decommission Details
+{% endblock %}
+
+{% block content %}
+<div class="container my-4">
+  <h1>Allocated Condos</h1>
+  <hr>
+  {% if decommission_alerts %}
+    {% for alert in decommission_alerts %}
+      <div class="card mb-4">
+        <div class="card-header">
+          <strong>Cluster:</strong> {{ alert.sheet }}
+        </div>
+        <div class="card-body">
+          {# Iterate over the record dictionary to display each field #}
+          {% for key, value in alert.record.items %}
+            <div class="row mb-2">
+              <div class="col-sm-4 font-weight-bold">
+                {{ key }}:
+              </div>
+              <div class="col-sm-8">
+                {{ value }}
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="alert alert-info">
+      No decommission alerts found!
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/coldfront/core/portal/templatetags/portal_tags.py
+++ b/coldfront/core/portal/templatetags/portal_tags.py
@@ -12,3 +12,10 @@ def get_version():
 @register.simple_tag
 def get_setting(name):
     return getattr(settings, name, "")
+
+@register.filter
+def get_item(dictionary, key):
+    """Usage: {{ my_dict|get_item:"my_key" }}"""
+    if isinstance(dictionary, dict):
+        return dictionary.get(key, "")
+    return ""

--- a/coldfront/core/utils/gsheets.py
+++ b/coldfront/core/utils/gsheets.py
@@ -1,0 +1,163 @@
+import os
+from pdb import set_trace
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+import json
+import datetime
+from django.conf import settings
+from django.core.cache import cache
+
+# DECOMISSION HEADERS CONSTANTS
+DECOMISSION_SHEET_HEADERS = {
+    "email": "PI Email",
+    "name": "PI Name (first last)",
+    "expected_decomission_date": "Expected Decomission Date",
+    "hardware_type": "Hardware Type",
+    "status": "Status",
+    "department_divison": "Department Division",
+    "hardware_specification_details": "Hardware Specification Details",
+}
+
+def fetch_sheet_data(sheet_name, sheet_id, header_row=2):
+    """
+    Returns the rows from your Google Sheet as a list of lists, where each sub-list is a row.
+    The first row is expected to be the column headers.
+    """
+    service_account_file = os.environ.get("GOOGLE_SERVICE_ACCOUNT_JSON_PATH")
+    spreadsheet_id =
+    range_name = f"{sheet_name}!A1:Z"
+
+    SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+    creds = service_account.Credentials.from_service_account_file(
+        service_account_file, scopes=SCOPES
+    )
+    service = build("sheets", "v4", credentials=creds)
+
+    sheet = service.spreadsheets()
+    result = sheet.values().get(
+        spreadsheetId=spreadsheet_id,
+        range=range_name
+    ).execute()
+
+    # This gives you a list of lists, each sub-list is a row
+    csv_data = result.get('values', [])
+
+    # In this data the first two rows are title/empty.
+    # We assume that the header is in row index 2.
+    header = csv_data[header_row]
+
+    return csv_data, header
+
+def parse_decommission_data(csv_data, headers, data_start=3):
+    """
+    Parses the decommission data from the Google Sheet and returns a dictionary
+    with the PI Email as the key and the record as the value.
+
+    """
+    try:
+        headers.index(DECOMISSION_SHEET_HEADERS["email"])
+    except ValueError:
+        raise ValueError(f"Header does not contain a {DECOMISSION_SHEET_HEADERS['email']} field.")
+
+    result = {}
+    for row in csv_data[data_start:]:
+        # In case the row is shorter than the header, pad with empty strings.
+        if len(row) < len(headers):
+            for i in range(len(headers) - len(row)):
+                row.append("")
+
+        # Create a dictionary mapping header names to row values.
+        record = {headers[i]: row[i] for i in range(len(headers))}
+        # Get the PI Email value and strip any extra whitespace.
+
+        email = record.get(DECOMISSION_SHEET_HEADERS["email"], "").strip()
+        # If there is an email, use it as the key;
+        # otherwise, use the PI Name (or some other fallback).
+        if email:
+            key = email
+        else:
+            # Get a name string and replace spaces and special chars with underscores and convert to lowercase
+            name = record.get(DECOMISSION_SHEET_HEADERS["name"]
+                              , "").strip().replace(" ", "_").replace("/", ".").replace("-", "_").lower()
+            key = f"unknown_{name}"  # fallback if even PI Name is missing
+
+        # If you expect duplicate keys (say multiple records with the same email)
+        # you might want to store a list of records per key. For example:
+        if key in result:
+            # If the key already exists, ensure the value is a list.
+            if isinstance(result[key], list):
+                result[key].append(record)
+            else:
+                result[key] = [result[key], record]
+        else:
+            result[key] = record
+
+    return result, headers
+
+def get_cached_decomissions_sheet_data(sheet_name, cache_time=24 * 3600):
+    # Optionally disable caching during testing
+    if getattr(settings, "GSHEETS_DISABLE_CACHE", False):
+        csv_data,headers = fetch_sheet_data(sheet_name, os.environ.get("DECOMISSION_SHEET_ID"))
+        return parse_decommission_data(csv_data, headers)
+
+    cache_key = f"gsheet_{sheet_name}"
+    csv_data, headers  = cache.get(cache_key)
+    if csv_data is None:
+        raw_csv_data,raw_headers = fetch_sheet_data(sheet_name, os.environ.get("DECOMISSION_SHEET_ID"))
+        csv_data,headers = parse_decommission_data(raw_csv_data, raw_headers)
+        cache.set(cache_key, csv_data, cache_time)
+    return csv_data, headers
+
+def get_decommission_alerts_for_user(email, sheets=["Savio", "LRC"]):
+    """
+    Looks in both the "Savio" and "LRC" sheets for records matching the user email.
+    If a record is found, it parses the 'Expected Decomission Date' (MM/DD/YYYY) and,
+    if today is >= (expected_date - settings.DECOMMISSION_WARNING_DAYS),
+    adds it as an alert.
+
+    Returns a list of alert dictionaries. Each alert includes:
+      - "sheet": which sheet/tab the record came from.
+      - "record": a dict of the row’s data (with headers as keys).
+      - "expected_date": the original string for display.
+    """
+    alerts = []
+    warning_days = getattr(settings, "DECOMMISSION_WARNING_DAYS", 30)
+    today = datetime.date.today()
+
+    for sheet in sheets:
+        decomissioned_csv_data, headers = get_cached_decomissions_sheet_data(sheet)
+        try:
+            # Ensure the required columns exist.
+            headers.index(DECOMISSION_SHEET_HEADERS["email"])
+        except ValueError:
+            # Skip this sheet if the necessary columns are missing.
+            continue
+
+        for email, row in decomissioned_csv_data.items():
+            # Normalize row to a list of records regardless of its original type.
+            records = row if isinstance(row, list) else [row]
+            for record in records:
+                expected_date_str = record[DECOMISSION_SHEET_HEADERS["expected_decomission_date"]
+                ].strip()
+                if not expected_date_str:
+                    # Skip records without a date.
+                    continue
+                try:
+                    expected_date = datetime.datetime.strptime(expected_date_str, "%m/%d/%Y").date()
+                except ValueError:
+                    # Skip records with a misformatted date.
+                    continue
+
+                threshold_date = expected_date - datetime.timedelta(days=warning_days)
+                if today >= threshold_date:
+                    alerts.append({
+                        "sheet": sheet,
+                        "record": record,
+                        "expected_date": expected_date_str,
+                        "hardware_type": record.get(DECOMISSION_SHEET_HEADERS["hardware_type"], "").strip(),
+                        "status": record.get(DECOMISSION_SHEET_HEADERS["status"], "").strip(),
+                        "department_division": record.get(DECOMISSION_SHEET_HEADERS["department_divison"], "").strip(),
+                        "hardware_specification_details": record.get(DECOMISSION_SHEET_HEADERS["hardware_specification_details"], "").strip(),
+                    })
+
+    return alerts

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,7 @@ tqdm==4.62.3
 urllib3==1.24.2
 user-agents==2.2.0
 wcwidth==0.1.7
+pytest-django
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib


### PR DESCRIPTION
## Description

closes #546


This PR adds integration with Google Sheets for tracking HPC hardware procurement and decommission data. The new functionality pulls data from two designated tabs ("Savio" and "LRC") in a Google Spreadsheet, parses the **Expected Decomission Date** field (in MM/DD/YYYY format), and—if the logged-in user's email is found and the decommission date is within a configurable warning period—generates a decommission alert.

- **Google Sheets Integration:**
  - Added functions in `gsheets.py` to fetch, parse, and cache data from the specified Google Spreadsheet.
  - Data is cached for 24 hours (configurable via `GSHEETS_CACHE_TIMEOUT`), with an option to disable caching (`GSHEETS_DISABLE_CACHE`) during testing or development.

- **Decommission Alert Logic:**
  - Both the **Savio** and **LRC** tabs are scanned for a record matching the user's email.
  - The **Expected Decomission Date** is compared against today's date minus a configurable threshold (`DECOMMISSION_WARNING_DAYS`, defaulting to 30 days).
  - Alerts are generated if the current date is on or past the threshold.

- **User Interface:**
  - A new `decommission_details` view and URL route have been introduced to display detailed alert information.
  - Alerts are rendered using a vertical card layout for improved readability (each record is displayed as a list of fields).

- **Documentation:**
  - The README has been updated with a brief setup guide covering environment variables, necessary Django settings, and the expected Google Sheets format under the "HPCS Hardware Procurement Tracking" section.

## Type of change

 **** Please delete options that are not relevant. ****

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Verified that the application correctly fetches and caches Google Sheets data.
- Confirmed that decommission alerts are generated when a record’s expected decommission date falls within the warning threshold.
- Tested the new details view and the card layout display for clarity.
- Checked that caching can be disabled via settings for development purposes.
- Once agreed on the current flow, I'll submit the tests for the feature. 


## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [ ] I have performed a self-review of my own code
