### PR TITLE
Issue 656: Bug when adding vector users 

### DIFF
--- a/coldfront/core/project/utils_/new_project_user_utils.py
+++ b/coldfront/core/project/utils_/new_project_user_utils.py
@@ -51,12 +51,12 @@ def add_vector_user_to_designated_savio_project(user_obj, email_strategy=None):
     user_role = ProjectUserRoleChoice.objects.get(name='User')
     active_status = ProjectUserStatusChoice.objects.get(name='Active')
 
-    project_user_exists = ProjectUser.objects.filter(
-        project=project_obj, user=user_obj).exists()
+    project_user_query = ProjectUser.objects.filter(
+        project=project_obj, user=user_obj)
     with transaction.atomic():
         run_runner = False
-        if project_user_exists:
-            project_user_obj = project_user_exists.first()
+        if project_user_query.exists():
+            project_user_obj = project_user_query.first()
             if project_user_obj.status != active_status:
                 project_user_obj.status = active_status
                 project_user_obj.save()


### PR DESCRIPTION
## Description

When a user is added to (or joins) a project on the Vector cluster, our policy is to automatically grant them access to a specific project on the Savio cluster (namely, the one specified in the SAVIO_PROJECT_FOR_VECTOR_USERS setting). This PR fixes that issue.

Fixes #656

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a test case and ran it, ensuring it passed. Also manually tested by joining vector projects.


## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [X] My code follows the agreed upon best practices
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if needed)
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in the appropriate modules
- [X] I have performed a self-review of my own code
