### PR TITLE
fixed requester lookup on project removal requests

### DIFF
--- a/coldfront/core/project/views_/removal_views.py
+++ b/coldfront/core/project/views_/removal_views.py
@@ -268,7 +268,7 @@ class ProjectRemovalRequestListView(LoginRequiredMixin,
                 project_removal_request_list = \
                     project_removal_request_list.filter(
                         requester__username__icontains=data.get(
-                            'username'))
+                            'requester'))
 
         return project_removal_request_list.order_by(order_by)
 

--- a/coldfront/core/project/views_/removal_views.py
+++ b/coldfront/core/project/views_/removal_views.py
@@ -267,7 +267,7 @@ class ProjectRemovalRequestListView(LoginRequiredMixin,
             if data.get('requester'):
                 project_removal_request_list = \
                     project_removal_request_list.filter(
-                        requester__user__username__icontains=data.get(
+                        requester__username__icontains=data.get(
                             'username'))
 
         return project_removal_request_list.order_by(order_by)


### PR DESCRIPTION
## Description

Fix requester field lookup on project removal requests. The issue was the code thought the requester was a ProjectUser but it was actually just a user.

Fixes #(issue number) 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Asserted that looking up a user by requester name worked without erroring.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [X] My code follows the agreed upon best practices
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if needed)
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in the appropriate modules
- [X] I have performed a self-review of my own code
