### PR TITLE
added sorting to securedirectory getUser methods

### DIFF
--- a/coldfront/core/allocation/utils_/secure_dir_utils/__init__.py
+++ b/coldfront/core/allocation/utils_/secure_dir_utils/__init__.py
@@ -78,7 +78,7 @@ class SecureDirectory(object):
                 **pending_management_request_kwargs):
             eligible_user_pks.discard(request_obj.user.pk)
 
-        return User.objects.filter(pk__in=eligible_user_pks)
+        return User.objects.filter(pk__in=eligible_user_pks).order_by('username')
 
     def get_path(self):
         """Return the path to the secure directory. Cache the path in
@@ -121,7 +121,7 @@ class SecureDirectory(object):
         for pi in pis:
             eligible_user_pks.discard(pi.pk)
 
-        return User.objects.filter(pk__in=eligible_user_pks)
+        return User.objects.filter(pk__in=eligible_user_pks).order_by('username')
 
     def user_can_manage(self, user):
         """Return whether the given User has permissions to manage this


### PR DESCRIPTION
## Description

Attempt to fix occasionally failing Github Actions test. Assuming it's because SecureDir get_user methods don't have any sorting by default.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran the test a couple times locally and it passed. Will wait on a few githubs actions runs to know for certain, just in case it's an OS-specific bug related to sorting.


## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [X] My code follows the agreed upon best practices
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if needed)
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in the appropriate modules
- [X] I have performed a self-review of my own code
