### PR TITLE
Issue 673: Add parse_academic_calendar command

### DIFF
--- a/coldfront/core/allocation/management/commands/parse_academic_calendar.py
+++ b/coldfront/core/allocation/management/commands/parse_academic_calendar.py
@@ -4,6 +4,49 @@ import pypdf
 import json
 from django.core.management.base import BaseCommand
 
+EXAMPLE_JSON ='''[
+    {
+        "name": "Fall Semester 2025",
+        "start_date": "2025-08-20",
+        "end_date": "2025-12-19"
+    },
+    {
+        "name": "Spring Semester 2026",
+        "start_date": "2026-01-13",
+        "end_date": "2026-05-15"
+    },
+    {
+        "name": "Summer Sessions 2026 - Session A",
+        "start_date": "2026-05-26",
+        "end_date": "2026-07-02"
+    },
+    {
+        "name": "Summer Sessions 2026 - Session B",
+        "start_date": "2026-06-08",
+        "end_date": "2026-08-14"
+    },
+    {
+        "name": "Summer Sessions 2026 - Session C",
+        "start_date": "2026-06-22",
+        "end_date": "2026-08-14"
+    },
+    {
+        "name": "Summer Sessions 2026 - Session D",
+        "start_date": "2026-07-06",
+        "end_date": "2026-08-14"
+    },
+    {
+        "name": "Summer Sessions 2026 - Session E",
+        "start_date": "2026-07-27",
+        "end_date": "2026-08-14"
+    },
+    {
+        "name": "Summer Sessions 2026 - Session F",
+        "start_date": "2026-07-06",
+        "end_date": "2026-07-24"
+    }
+]'''
+
 class Command(BaseCommand):
     help = 'Parse the UCB academic calendar and output JSON entries.'
 
@@ -27,20 +70,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         year = options['calendar_year']
-        first_year = int(year.split('-')[0])
         api_key = options['api_key']
         api = options['api']
         pdf_url = f'https://registrar.berkeley.edu/wp-content/uploads/UCB_AcademicCalendar_{year}.pdf'
         
-        output_json_example = {
-            'academic_year': f'{year}',
-            'semesters': [
-                {'name': 'Fall', 'start_date': f'{first_year}-08-25', 'end_date': f'{first_year}-12-15'},
-                {'name': 'Spring', 'start_date': f'{first_year + 1}-01-10', 'end_date': f'{first_year + 1}-05-20'},
-                {'name': 'Summer', 'start_date': f'{first_year + 1}-06-01', 'end_date': f'{first_year + 1}-08-15'}
-            ]
-        }
-
         # Fetch the PDF
         response = requests.get(pdf_url)
         if response.status_code != 200:
@@ -64,10 +97,9 @@ class Command(BaseCommand):
                 model='gpt-4',
                 input='You can only output JSON. Please parse the following '
                 f'UCB academic calendar text into JSON format:\n\n{text}\n\n'
-                f'Follow this JSON format:\n\n'
-                f'{json.dumps(output_json_example, indent=2)}. We only care '
+                f'Follow this JSON format:\n\n {EXAMPLE_JSON}.\n\nWe only care'
                 f'about the semester names and dates. Do not include any other '
-                f' information.'
+                f'information.'
             )
             
             parsed_data = response.output_text
@@ -79,7 +111,7 @@ class Command(BaseCommand):
         try:
             parsed_json = json.loads(parsed_data)
             self.stdout.write(self.style.SUCCESS(
-                'Parsed JSON: {}'.format(json.dumps(parsed_json, indent=2))))
+                json.dumps(parsed_json, indent=2)))
         except json.JSONDecodeError as e:
             self.stdout.write(self.style.ERROR(
                 'Failed to parse JSON: {}'.format(e)))

--- a/coldfront/core/allocation/management/commands/parse_academic_calendar.py
+++ b/coldfront/core/allocation/management/commands/parse_academic_calendar.py
@@ -1,0 +1,86 @@
+import requests
+import io
+import pypdf
+import json
+from django.core.management.base import BaseCommand
+
+class Command(BaseCommand):
+    help = 'Parse the UCB academic calendar and output JSON entries.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--calendar-year',
+            required=True,
+            help='The calendar year for the PDF to parse. e.g. "2025-26"'
+        )
+        parser.add_argument(
+            '--api-key',
+            required=True,
+            help='API key '
+        )
+        parser.add_argument(
+            '--api',
+            required=False,
+            default='openai',
+            help='API to use for processing the calendar. Default is "openai".'
+        )
+
+    def handle(self, *args, **options):
+        year = options['calendar_year']
+        first_year = int(year.split('-')[0])
+        api_key = options['api_key']
+        api = options['api']
+        pdf_url = f'https://registrar.berkeley.edu/wp-content/uploads/UCB_AcademicCalendar_{year}.pdf'
+        
+        output_json_example = {
+            'academic_year': f'{year}',
+            'semesters': [
+                {'name': 'Fall', 'start_date': f'{first_year}-08-25', 'end_date': f'{first_year}-12-15'},
+                {'name': 'Spring', 'start_date': f'{first_year + 1}-01-10', 'end_date': f'{first_year + 1}-05-20'},
+                {'name': 'Summer', 'start_date': f'{first_year + 1}-06-01', 'end_date': f'{first_year + 1}-08-15'}
+            ]
+        }
+
+        # Fetch the PDF
+        response = requests.get(pdf_url)
+        if response.status_code != 200:
+            self.stdout.write(
+                self.style.ERROR('Failed to fetch PDF at {}'.format(pdf_url)))
+            return
+        io_bytes = io.BytesIO(response.content)
+
+        # Read the PDF
+        pdf_reader = pypdf.PdfReader(io_bytes)
+        text = ''
+        for page in pdf_reader.pages:
+            text += page.extract_text()
+        parsed_data = ''
+
+        if api == 'openai':
+            from openai import OpenAI
+            client = OpenAI(api_key=api_key)
+
+            response = client.responses.create(
+                model='gpt-4',
+                input='You can only output JSON. Please parse the following '
+                f'UCB academic calendar text into JSON format:\n\n{text}\n\n'
+                f'Follow this JSON format:\n\n'
+                f'{json.dumps(output_json_example, indent=2)}. We only care '
+                f'about the semester names and dates. Do not include any other '
+                f' information.'
+            )
+            
+            parsed_data = response.output_text
+        else:
+            self.stdout.write(self.style.ERROR(
+                'Unsupported API: {}'.format(api)))
+            return
+
+        try:
+            parsed_json = json.loads(parsed_data)
+            self.stdout.write(self.style.SUCCESS(
+                'Parsed JSON: {}'.format(json.dumps(parsed_json, indent=2))))
+        except json.JSONDecodeError as e:
+            self.stdout.write(self.style.ERROR(
+                'Failed to parse JSON: {}'.format(e)))
+                

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,12 +38,14 @@ iso8601==0.1.16
 ldap3==2.9.1
 mod-wsgi
 oauth2client==4.1.3
+openai==1.93.0
 openpyxl==3.0.9
 phonenumbers==8.12.23
 psycopg2-binary
 pylint==2.12.2
 pylint-django==2.5.2
 pyparsing==2.4.7
+pypdf==5.7.0
 pytest
 pytest-django
 python-dateutil==2.8.0


### PR DESCRIPTION
## Description

Add a parse_academic_calendar command.

Note: Currently only supports the openai api. Adding more apis would require more libraries added in "requirements.txt"

Fixes #673 

## Type of change

 **** Please delete options that are not relevant. ****

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Outputs the following for "2025-26":
{
  "academic_year": "2025-26",
  "semesters": [
    {
      "name": "Fall",
      "start_date": "2025-08-20",
      "end_date": "2025-12-19"
    },
    {
      "name": "Spring",
      "start_date": "2026-01-13",
      "end_date": "2026-05-15"
    },
    {
      "name": "Summer",
      "start_date": "2026-05-26",
      "end_date": "2026-08-14"
    }
  ]

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [X] My code follows the agreed upon best practices
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (if needed)
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in the appropriate modules
- [X] I have performed a self-review of my own code
