### PR TITLE
[OS/Python Upgrade] Retain support for Bootstrap 4 after django-crispy-forms upgrade

### DIFF
--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -34,6 +34,7 @@ INSTALLED_APPS = [
 # Additional Apps
 INSTALLED_APPS += [
     'crispy_forms',
+    'crispy_bootstrap4',
     'sslserver',
     'django_q',
     'simple_history',
@@ -179,6 +180,7 @@ MESSAGE_TAGS = {
     messages.ERROR: 'danger',
 }
 
+CRISPY_ALLOWED_TEMPLATE_PACKS = 'bootstrap4'
 CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 STATIC_URL = '/static/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ bibtexparser
 blessed
 chardet
 coverage
+crispy-bootstrap4
 Django
 django-allauth
 django-constance


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

This is part of the upgrade to Rocky 8.10 and Python 3.13. Changes will be merged to an intermediate branch until everything is ready. The application may not be in a working state in this pull request.

- Included `crispy-bootstrap4` as a dependency, which provides template packs for Bootstrap 4, which were removed by an update to the `django-crispy-forms` dependency.

## Type of change

 **** Please delete options that are not relevant. ****

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Verify that any view that includes a crispy form renders rather than raising an error.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
