### PR TITLE
[OS/Python Upgrade] Auth bug fixes: update util import; use POST, not GET, to login/logout

### DIFF
--- a/coldfront/core/portal/templates/portal/nonauthorized_home.html
+++ b/coldfront/core/portal/templates/portal/nonauthorized_home.html
@@ -38,20 +38,29 @@
   {% if sso_enabled %}
     {% flag_enabled 'BRC_ONLY' as brc_only %}
     {% if brc_only %}
-    <a class="btn btn-primary btn-lg" href="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:berkeley.edu' %}" role="button">
-      <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-      CalNet: Log In
-    </a>
+    <form action="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:berkeley.edu' %}" method="post" style="display:inline;">
+      {% csrf_token %}
+      <button class="btn btn-primary btn-lg" type="submit" role="button">
+        <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+        CalNet: Log In
+      </button>
+    </form>
     {% else %}
-    <a class="btn btn-primary btn-lg" href="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:lbl.gov' %}" role="button">
-      <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-      Berkeley Lab: Log In
-    </a>
+    <form action="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:lbl.gov' %}" method="post" style="display:inline;">
+      {% csrf_token %}
+      <button class="btn btn-primary btn-lg" type="submit" role="button">
+        <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+        Berkeley Lab: Log In
+      </button>
+    </form>
     {% endif %}
-    <a class="btn btn-secondary btn-lg" href="{% url 'login' %}" role="button">
-      <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-      Other: Log In
-    </a>
+    <form action="{% url 'login' %}" method="post" style="display:inline;">
+      {% csrf_token %}
+      <button class="btn btn-secondary btn-lg" type="submit" role="button">
+        <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+        Other: Log In
+      </button>
+    </form>
   {% endif %}
 </p>
 

--- a/coldfront/core/socialaccount/adapter.py
+++ b/coldfront/core/socialaccount/adapter.py
@@ -1,10 +1,10 @@
+from allauth.account.internal.emailkit import valid_email_or_none
 from allauth.account.models import EmailAddress
 from allauth.account.utils import user_email as user_email_func
 from allauth.account.utils import user_username
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.providers.base import AuthProcess
-from allauth.utils import valid_email_or_none
 from coldfront.core.account.utils.login_activity import LoginActivityVerifier
 from coldfront.core.utils.context_processors import portal_and_program_names
 from collections import defaultdict

--- a/coldfront/core/socialaccount/tests/mocking.py
+++ b/coldfront/core/socialaccount/tests/mocking.py
@@ -1,0 +1,69 @@
+import json
+import requests
+from unittest.mock import Mock
+
+
+# Note: This is a copy of django-allauth's `tests/mocking.py`. The contents were
+# previously included in the package, under `allauth.tests`, but were moved out.
+
+
+class MockedResponse:
+    def __init__(self, status_code, content, headers=None):
+        if headers is None:
+            headers = {}
+
+        self.status_code = status_code
+        if isinstance(content, dict):
+            content = json.dumps(content)
+            headers["content-type"] = "application/json"
+        self.content = content.encode("utf8")
+        self.headers = headers
+
+    def json(self):
+        return json.loads(self.text)
+
+    def raise_for_status(self):
+        pass
+
+    @property
+    def ok(self):
+        return self.status_code // 100 == 2
+
+    @property
+    def text(self):
+        return self.content.decode("utf8")
+
+
+class mocked_response:
+    def __init__(self, *responses, callback=None):
+        self.callback = callback
+        self.responses = list(responses)
+
+    def __enter__(self):
+        self.orig_get = requests.Session.get
+        self.orig_post = requests.Session.post
+        self.orig_request = requests.Session.request
+
+        def mockable_request(f):
+            def new_f(*args, **kwargs):
+                if self.callback:
+                    response = self.callback(*args, **kwargs)
+                    if response is not None:
+                        return response
+                if self.responses:
+                    resp = self.responses.pop(0)
+                    if isinstance(resp, dict):
+                        resp = MockedResponse(200, resp)
+                    return resp
+                return f(*args, **kwargs)
+
+            return Mock(side_effect=new_f)
+
+        requests.Session.get = mockable_request(requests.Session.get)
+        requests.Session.post = mockable_request(requests.Session.post)
+        requests.Session.request = mockable_request(requests.Session.request)
+
+    def __exit__(self, type, value, traceback):
+        requests.Session.get = self.orig_get
+        requests.Session.post = self.orig_post
+        requests.Session.request = self.orig_request

--- a/coldfront/core/socialaccount/tests/test_cilogon_account_adapter.py
+++ b/coldfront/core/socialaccount/tests/test_cilogon_account_adapter.py
@@ -15,12 +15,12 @@ from django.utils.http import urlencode
 from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
 from allauth.socialaccount.providers.base import AuthProcess
-from allauth.tests import MockedResponse
-from allauth.tests import mocked_response
 from flags.state import disable_flag
 from flags.state import enable_flag
 from flags.state import flag_enabled
 
+from coldfront.core.socialaccount.tests.mocking import MockedResponse
+from coldfront.core.socialaccount.tests.mocking import mocked_response
 from coldfront.core.utils.tests.test_base import TestBase
 
 import json

--- a/coldfront/core/user/templates/user/sso_login_brc.html
+++ b/coldfront/core/user/templates/user/sso_login_brc.html
@@ -48,10 +48,13 @@ Log In
           <br><br>
         </p>
         <p>
-          <a href="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:berkeley.edu' %}" class="btn btn-primary btn-lg" role="button">
-            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-            Log In
-          </a>
+          <form action="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:berkeley.edu' %}" method="post" style="display:inline;">
+            {% csrf_token %}
+            <button class="btn btn-primary btn-lg" type="submit" role="button">
+              <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+              Log In
+            </button>
+          </form>
         </p>
         <hr>
       </div>
@@ -68,10 +71,13 @@ Log In
           I do not have a CalNet ID, but I do have a Berkeley Lab Identity.
         </p>
         <p>
-          <a href="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:lbl.gov' %}" class="btn btn-secondary btn-lg" role="button">
-            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-            Log In
-          </a>
+          <form action="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:lbl.gov' %}" method="post" style="display:inline;">
+            {% csrf_token %}
+            <button class="btn btn-secondary btn-lg" type="submit" role="button">
+              <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+              Log In
+            </button>
+          </form>
         </p>
         <hr>
       </div>
@@ -88,10 +94,13 @@ Log In
           I do not have a CalNet ID, and I do not have a Berkeley Lab Identity.
         </p>
         <p>
-          <a href="{% provider_login_url 'cilogon' process='login' auth_params='initialidp=https://accounts.google.com/o/oauth2/auth' %}" class="btn btn-secondary btn-lg" role="button">
-            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-            Log In
-          </a>
+          <form action="{% provider_login_url 'cilogon' process='login' auth_params='initialidp=https://accounts.google.com/o/oauth2/auth' %}" method="post" style="display:inline;">
+            {% csrf_token %}
+            <button class="btn btn-secondary btn-lg" type="submit" role="button">
+              <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+              Log In
+            </button>
+          </form>
         </p>
         <hr>
       </div>

--- a/coldfront/core/user/templates/user/sso_login_lrc.html
+++ b/coldfront/core/user/templates/user/sso_login_lrc.html
@@ -26,10 +26,13 @@ Log In
           <br><br>
         </p>
         <p>
-          <a href="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:lbl.gov' %}" class="btn btn-primary btn-lg" role="button">
-            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-            Log In
-          </a>
+          <form action="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:lbl.gov' %}" method="post" style="display:inline;">
+            {% csrf_token %}
+            <button class="btn btn-primary btn-lg" type="submit" role="button">
+              <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+              Log In
+            </button>
+          </form>
         </p>
         <hr>
       </div>
@@ -46,10 +49,13 @@ Log In
           I do not have a Berkeley Lab Identity, but I do have a CalNet ID.
         </p>
         <p>
-          <a href="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:berkeley.edu' %}" class="btn btn-secondary btn-lg" role="button">
-            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-            Log In
-          </a>
+          <form action="{% provider_login_url 'cilogon' process='login' auth_params='idphint=urn:mace:incommon:berkeley.edu' %}" method="post" style="display:inline;">
+            {% csrf_token %}
+            <button class="btn btn-secondary btn-lg" type="submit" role="button">
+              <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+              Log In
+            </button>
+          </form>
         </p>
         <hr>
       </div>
@@ -66,10 +72,13 @@ Log In
           I do not have a Berkeley Lab Identity, and I do not have a CalNet ID.
         </p>
         <p>
-          <a href="{% provider_login_url 'cilogon' process='login' auth_params='initialidp=https://accounts.google.com/o/oauth2/auth' %}" class="btn btn-secondary btn-lg" role="button">
-            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-            Log In
-          </a>
+          <form action="{% provider_login_url 'cilogon' process='login' auth_params='initialidp=https://accounts.google.com/o/oauth2/auth' %}" method="post" style="display:inline;">
+            {% csrf_token %}
+            <button class="btn btn-secondary btn-lg" type="submit" role="button">
+              <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+              Log In
+            </button>
+          </form>
         </p>
         <hr>
       </div>

--- a/coldfront/templates/common/navbar_login.html
+++ b/coldfront/templates/common/navbar_login.html
@@ -4,6 +4,11 @@
   </a>
   <div class="dropdown-menu">
     <a id="navbar-user-user-profile" class="dropdown-item" href="{% url 'user-profile' %}"><i class="fas fa-user-circle" aria-hidden="true"></i> User Profile</a>
-    <a class="dropdown-item" href="{% url 'logout' %}"><i class="fas fa-sign-out-alt" aria-hidden="true"></i> Log Out</a>
+    <form action="{% url 'logout' %}" method="post" style="display:inline;">
+      {% csrf_token %}
+      <button class="dropdown-item" type="submit">
+        <i class="fas fa-sign-out-alt" aria-hidden="true"></i> Log Out
+      </button>
+    </form>
   </div>
 </li>

--- a/coldfront/templates/common/nonauthorized_navbar.html
+++ b/coldfront/templates/common/nonauthorized_navbar.html
@@ -21,10 +21,13 @@
       </ul>
       <ul class="navbar-nav ml-auto">
         <li id="navbar-login" class="nav-item">
-          <a class="nav-link" href="{% url 'login' %}">
-            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
-            Log In
-          </a>
+          <form action="{% url 'login' %}" method="post" style="display:inline;">
+            {% csrf_token %}
+            <button class="nav-link" type="submit" style="background:none;border:none;">
+              <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+              Log In
+            </button>
+          </form>
         </li>
         {% flag_enabled 'BASIC_AUTH_ENABLED' as basic_auth_enabled %}
         {% if basic_auth_enabled %}


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

This is part of the upgrade to Rocky 8.10 and Python 3.13. Changes will be merged to an intermediate branch until everything is ready. The application may not be in a working state in this pull request.

- Corrected an import of a `django-allauth` utility method `valid_email_or_none`, given that it was moved.
- Updated login buttons to make POST, not GET requests, per `django-allauth`'s suggestion. After an update to the package, an additional redirect screen with a "Continue" button was introduced when a GET request was made, which would have changed and lengthened the process for users.
- Updated navbar login/logout buttons so that they also make POST, not GET, requests.
- Included the contents of `django-allauth`'s `tests/mocking.py`, which were previously included in the package and importable, for testing purposes.

## Type of change

 **** Please delete options that are not relevant. ****

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Ensure that no `ImportError` for the utility function is raised when visiting the home page.
- Ensure that clicking the logging buttons on the home page and the dedicated SSO login page do not redirect to an additional screen. The flow should be: portal login page > CILogon > selected provider > portal authorized home.
- Ensure that clicking in the "Log In" and "Log Out" buttons in the navbar behave as before. Logging out in particular should not raise a 405.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
