### PR TITLE
[OS/Python Upgrade] Fix Python warnings; set Q_CLUSTER settings

### DIFF
--- a/.github/workflows/django_testing_ci_python_3_13.yml
+++ b/.github/workflows/django_testing_ci_python_3_13.yml
@@ -88,13 +88,13 @@ jobs:
       run: |
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
-        pytest -m unit
+        pytest coldfront/ -m unit
 
     - name: Run pytest component tests
       run: |
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
-        pytest -m component
+        pytest coldfront/ -m component
 
     # - name: Run pytest acceptance tests
     #   run: |

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -397,5 +397,14 @@ Q_CLUSTER = {
         'port': 6379,
         'db': 0,
         'password': '{{ redis_passwd }}',
-    }
+    },
+    # No task may run longer than 'timeout' seconds.
+    # Tasks that time out are retried after 'retry' seconds since the task
+    # originally began.
+    # 'retry' must be greater than 'timeout'.
+    # This configuration assumes that no task runs longer than 24 hours. If it
+    # times out, it will be retried a day after the timeout.
+    # Docs: https://django-q2.readthedocs.io/en/master/configure.html#retry
+    'retry': 2 * 24 * 60 * 60,
+    'timeout': 24 * 60 * 60,
 }

--- a/coldfront/config/local_settings.py.sample
+++ b/coldfront/config/local_settings.py.sample
@@ -42,7 +42,7 @@ SITE_ID = 1
 REQUEST_APPROVAL_CC_LIST = []
 
 # The regex for a valid LBL billing ID (six digits, a hyphen, three digits.)
-LBL_BILLING_ID_REGEX = "^\d{6}-\d{3}$"
+LBL_BILLING_ID_REGEX = r"^\d{6}-\d{3}$"
 
 #------------------------------------------------------------------------------
 # General Center Information

--- a/coldfront/config/test_settings.py.sample
+++ b/coldfront/config/test_settings.py.sample
@@ -195,9 +195,6 @@ HARDWARE_PROCUREMENTS_CONFIG = {
 #------------------------------------------------------------------------------
 
 Q_CLUSTER = {
-    # Prevent a warning about preserving database connections when
-    # sync=True.
-    'orm': 'default',
     'retry': 2 * 24 * 60 * 60,
     'sync': True,
     'timeout': 24 * 60 * 60,

--- a/coldfront/config/test_settings.py.sample
+++ b/coldfront/config/test_settings.py.sample
@@ -195,5 +195,10 @@ HARDWARE_PROCUREMENTS_CONFIG = {
 #------------------------------------------------------------------------------
 
 Q_CLUSTER = {
+    # Prevent a warning about preserving database connections when
+    # sync=True.
+    'orm': 'default',
+    'retry': 2 * 24 * 60 * 60,
     'sync': True,
+    'timeout': 24 * 60 * 60,
 }

--- a/coldfront/core/allocation/tests/test_commands/test_start_allocation_period.py
+++ b/coldfront/core/allocation/tests/test_commands/test_start_allocation_period.py
@@ -838,13 +838,13 @@ class TestStartAllocationPeriod(TestBase):
     def extract_deactivation_message_entries(message, dry_run=False):
         """Given a line relating to Project deactivation, return the
         outputted Project ID and name."""
-        pattern_template = (
-            '{0} Project (?P<project_id>\d+) \((?P<project_name>[a-z0-9_]+)\) '
-            'and reset Service Units\.')
         if dry_run:
-            pattern = pattern_template.format('Would deactivate')
+            prefix = 'Would deactivate'
         else:
-            pattern = pattern_template.format('Deactivated')
+            prefix = 'Deactivated'
+        pattern = (
+            rf'{prefix} Project (?P<project_id>\d+) '
+            rf'\((?P<project_name>[a-z0-9_]+)\) and reset Service Units\.')
         return re.match(pattern, message).groups()
 
     @staticmethod
@@ -852,8 +852,8 @@ class TestStartAllocationPeriod(TestBase):
         """Given a line relating to request processing, return the
         outputted request ID and number of service units."""
         pattern_template = (
-            f'{{0}} {model.__name__} (?P<request_id>\d+) with '
-            f'(?P<num_service_units>[0-9.]+) service units.')
+            rf'{{0}} {model.__name__} (?P<request_id>\d+) with '
+            rf'(?P<num_service_units>[0-9.]+) service units.')
         if dry_run:
             pattern = pattern_template.format('Would process')
         else:

--- a/coldfront/core/socialaccount/adapter.py
+++ b/coldfront/core/socialaccount/adapter.py
@@ -2,7 +2,7 @@ from allauth.account.internal.emailkit import valid_email_or_none
 from allauth.account.models import EmailAddress
 from allauth.account.utils import user_email as user_email_func
 from allauth.account.utils import user_username
-from allauth.exceptions import ImmediateHttpResponse
+from allauth.core.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.providers.base import AuthProcess
 from coldfront.core.account.utils.login_activity import LoginActivityVerifier

--- a/coldfront/core/utils/tests/test_base.py
+++ b/coldfront/core/utils/tests/test_base.py
@@ -158,7 +158,7 @@ class BaseTestMixin(object):
     def parse_urls_from_str(s):
         """Return a list of URLs parsed from the given string, in the
         order that they appear."""
-        return re.findall('(?P<url>https?://[^\s]+)', s)
+        return re.findall(r'(?P<url>https?://[^\s]+)', s)
 
     @staticmethod
     def sign_user_access_agreement(user):


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

This is part of the upgrade to Rocky 8.10 and Python 3.13. Changes will be merged to an intermediate branch until everything is ready. The application may not be in a working state in this pull request.

- Fixed a variety of warnings.
- Notably, added 'retry' and 'timeout' keys to the `Q_CLUSTER` setting to suppress a warning about retry not being larger than timeout. The timeout is now set to a conservative 24 hours, with retries being attempted an additional 24 hours later. (In practice, the longest task at the moment takes less than 10 minutes.)

## Type of change

 **** Please delete options that are not relevant. ****

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Ensure that warnings raised in previous builds are not present.
- Note: Some warnings may still be present.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
