### PR TITLE
Add maintenance mode that redirects regular users to 503 page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ prod_settings.py
 staging_settings.py
 local_settings.py
 local_strings.py
+maintenance_mode_state.txt
 password_reset_subject.txt
 coldfront.db*
 *.code-workspace

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -17,7 +17,7 @@ djangoprojname: coldfront
 
 enable_django_debug_toolbar: false
 # Prevent non-staff, non-superusers from accessing website pages.
-enable_maintenance_mode: true
+enable_maintenance_mode: false
 
 ###############################################################################
 # BRC/LRC Config

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -16,6 +16,8 @@ reponame: coldfront
 djangoprojname: coldfront
 
 enable_django_debug_toolbar: false
+# Prevent non-staff, non-superusers from accessing website pages.
+enable_maintenance_mode: true
 
 ###############################################################################
 # BRC/LRC Config

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -401,3 +401,22 @@ Q_CLUSTER = {
         'password': '{{ redis_passwd }}',
     }
 }
+
+#------------------------------------------------------------------------------
+# django-maintenance-mode settings
+#------------------------------------------------------------------------------
+
+# Note: This should be the last-defined middleware.
+EXTRA_EXTRA_MIDDLEWARE += [
+    'maintenance_mode.middleware.MaintenanceModeMiddleware',
+]
+
+{% if enable_maintenance_mode is defined and enable_maintenance_mode | bool -%}
+MAINTENANCE_MODE = True
+{%- else -%}
+MAINTENANCE_MODE = False
+{%- endif %}
+MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
+MAINTENANCE_MODE_IGNORE_ANONYMOUS_USER = True
+MAINTENANCE_MODE_IGNORE_STAFF = True
+MAINTENANCE_MODE_IGNORE_SUPERUSER = True

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -413,10 +413,19 @@ EXTRA_EXTRA_MIDDLEWARE += [
 
 {% if enable_maintenance_mode is defined and enable_maintenance_mode | bool -%}
 MAINTENANCE_MODE = True
-{%- else -%}
-MAINTENANCE_MODE = False
-{%- endif %}
+# In maintenance mode, users may still log in by manually accessing the login
+# URLs. All other views are blocked for non-staff, non-superuser users.
 MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
-MAINTENANCE_MODE_IGNORE_ANONYMOUS_USER = True
 MAINTENANCE_MODE_IGNORE_STAFF = True
 MAINTENANCE_MODE_IGNORE_SUPERUSER = True
+MAINTENANCE_MODE_IGNORE_URLS = [
+    r'^/accounts/cilogon/login/$',
+    r'^/accounts/cilogon/login/callback/$',
+    # TODO: Uncomment this line to allow API access in maintenance mode.
+    #  Users authenticated for the API via token authentication are
+    #  treated as anonymous, so they are blocked unless they are staff
+    #  or superuser.
+    # r'^/api',
+    r'^/user/logout$',  # Note: There is no trailing slash.
+]
+{%- endif %}

--- a/bootstrap/ansible/settings_template.tmpl
+++ b/bootstrap/ansible/settings_template.tmpl
@@ -415,7 +415,6 @@ EXTRA_EXTRA_MIDDLEWARE += [
 MAINTENANCE_MODE = True
 # In maintenance mode, users may still log in by manually accessing the login
 # URLs. All other views are blocked for non-staff, non-superuser users.
-MAINTENANCE_MODE_IGNORE_ADMIN_SITE = True
 MAINTENANCE_MODE_IGNORE_STAFF = True
 MAINTENANCE_MODE_IGNORE_SUPERUSER = True
 MAINTENANCE_MODE_IGNORE_URLS = [

--- a/coldfront/config/settings.py
+++ b/coldfront/config/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS += [
     'django_q',
     'simple_history',
     'durationwidget',
+    'maintenance_mode',
 ]
 
 # Fork-specific Additional Apps
@@ -145,6 +146,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'django_settings_export.settings_export',
+                'maintenance_mode.context_processors.maintenance_mode',
                 'coldfront.core.utils.context_processors.allocation_navbar_visibility',
                 'coldfront.core.utils.context_processors.constance_config',
                 'coldfront.core.utils.context_processors.current_allowance_year_allocation_period',

--- a/coldfront/templates/503.html
+++ b/coldfront/templates/503.html
@@ -1,0 +1,19 @@
+{% extends "common/base.html" %} 
+{% load static %}
+
+{% block title %}
+{{ PORTAL_NAME }} - Maintenance
+{% endblock %}
+
+
+{% block content %}
+
+<div class="row justify-content-center">
+    <div class="col-lg-6 col-xs-12">
+        <div class="alert alert-danger" role="alert">
+          <i class="fas fa-exclamation-triangle" aria-hidden="true"></i>  The system is currently undergoing maintenance.
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ django-filter==2.3.0
 django-flags==5.0.10
 django-formtools==2.2
 django-googledrive-storage==1.6.0
+django-maintenance-mode
 django-model-utils==4.1.1
 django-phonenumber-field==5.1.0
 django-picklefield==2.0


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

This pull request adds a "maintenance mode" that, when enabled, causes non-staff, non-superuser users to be redirected to a maintenance page with the following text: "The system is currently undergoing maintenance.".

- Installed `django-maintenance-mode`.
- Updated the settings template to configure it when it should be enabled.
    - Updated settings so that only staff and superuser users can access website pages during maintenance. They must log in by manually accessing login URLs.
    - Added a way to manually allow API access in maintenance mode (by uncommenting a line).
- Added a YML configuration flag `enable_maintenance_mode` to toggle the mode.

## Type of change

 **** Please delete options that are not relevant. ****

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Toggle the YML configuration variable and regenerate settings. Ensure that the settings are set or not.
- When enabled:
    - Ensure that website pages have the maintenance message.
    - To log in, directly access the login URL defined in `settings_template.tmpl`. Ensure that a staff/superuser can access website pages as normal.
        - While a regular user may authenticate by this method, they should not be able to do anything on the site itself.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
