### PR TITLE
[OS/Python Upgrade] Deny 80/tcp traffic when Cloudflare is enabled in new Ansible playbook

### DIFF
--- a/bootstrap/ansible-almalinux8/playbook.yml
+++ b/bootstrap/ansible-almalinux8/playbook.yml
@@ -512,19 +512,29 @@
               block:
                 # 443/tcp should only be allowed in Cloudflare IP ranges.
                 # https://commons.lbl.gov/pages/viewpage.action?pageId=203489943
-                - name: Do not permit https traffic in public zone
-                  ansible.posix.firewalld:
-                    zone: public
-                    service: https
-                    state: disabled
-                    permanent: true
 
-                - name: Deny 443/tcp in public zone
+                # 80/tcp should not be allowed in the public zone or the Cloudflare zone.
+                # https://commons.lbl.gov/spaces/cpp/pages/81660736/Open+Web+Server+Requirements#OpenWebServerRequirements-Requirement4%3ASSLconfiguredon443%2Ftcp
+
+                - name: Do not permit http or https traffic in public zone
                   ansible.posix.firewalld:
                     zone: public
-                    port: 443/tcp
+                    service: "{{ item }}"
                     state: disabled
                     permanent: true
+                  loop:
+                    - http
+                    - https
+
+                - name: Deny 80/tcp and 443/tcp in public zone
+                  ansible.posix.firewalld:
+                    zone: public
+                    port: "{{ item }}"
+                    state: disabled
+                    permanent: true
+                  loop:
+                    - 80/tcp
+                    - 443/tcp
 
                 - name: Create firewalld zone for Cloudflare IP ranges
                   ansible.posix.firewalld:
@@ -547,15 +557,19 @@
                     state: enabled
                   loop: "{{ cloudflare_ip_ranges }}"
 
-                - name: Permit http and https traffic in Cloudflare zone
+                - name: Do not permit http traffic in Cloudflare zone
                   ansible.posix.firewalld:
                     zone: cloudflare
-                    service: "{{ item }}"
+                    service: http
+                    state: disabled
+                    permanent: true
+
+                - name: Permit https traffic in Cloudflare zone
+                  ansible.posix.firewalld:
+                    zone: cloudflare
+                    service: https
                     state: enabled
                     permanent: true
-                  loop:
-                    - http
-                    - https
 
                 # Log the original client IP address of each request instead of the Cloudflare IP.
                 # Source: https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs#C5XWe97z77b3XZV


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

This is part of the upgrade to Rocky 8.10 and Python 3.13. Changes will be merged to an intermediate branch until everything is ready. The application may not be in a working state in this pull request.

- Updated the new Ansible playbook to deny 80/tcp traffic when Cloudflare is enabled, per Berkeley Lab [policy](https://commons.lbl.gov/spaces/cpp/pages/81660736/Open+Web+Server+Requirements#OpenWebServerRequirements-Requirement4%3ASSLconfiguredon443%2Ftcp).

## Type of change

 **** Please delete options that are not relevant. ****

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

N/A

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
