### PR TITLE
Configure Apache process/thread count in Ansible

### DIFF
--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -71,6 +71,9 @@ stream_logs_to_stdout: false
 # Apache settings
 #------------------------------------------------------------------------------
 
+# The number of threads to run per Apache process.
+apache_num_threads_per_process: 10
+
 # The name of the copy of the generated WSGI template in the Apache directory.
 # TODO: For LRC, use the substring 'cf_mylrc'.
 wsgi_conf_file_name: cf_mybrc_wsgi.conf

--- a/bootstrap/ansible/playbook.yml
+++ b/bootstrap/ansible/playbook.yml
@@ -539,6 +539,10 @@
 
         # Configure Apache.
 
+        - name: Set apache_num_processes based on number of CPUs
+          set_fact:
+            apache_num_processes: "{{ apache_num_processes | default(ansible_processor_vcpus | default(ansible_processor_count) | default(4)) }}"
+
         - name: Create a WSGI configuration file from a template if SSL is disabled
           template:
             src: "{{ git_prefix }}/{{ reponame }}/bootstrap/ansible/wsgi_conf.tmpl"

--- a/bootstrap/ansible/wsgi_conf.tmpl
+++ b/bootstrap/ansible/wsgi_conf.tmpl
@@ -15,7 +15,7 @@ WSGIPassAuthorization On
         Require all granted
     </Directory>
 
-    WSGIDaemonProcess coldfront python-path={{ git_prefix }}/{{ reponame }} python-home={{ git_prefix }}/venv/ processes=2 threads=15 display-name=coldfront
+    WSGIDaemonProcess coldfront python-path={{ git_prefix }}/{{ reponame }} python-home={{ git_prefix }}/venv/ processes={{ apache_num_processes }} threads={{ apache_num_threads_per_process }} display-name=coldfront
     WSGIProcessGroup coldfront
 
     WSGIScriptAlias / {{ git_prefix }}/{{ reponame }}/{{ djangoprojname }}/config/wsgi.py process-group=coldfront

--- a/bootstrap/ansible/wsgi_conf_ssl.tmpl
+++ b/bootstrap/ansible/wsgi_conf_ssl.tmpl
@@ -32,7 +32,7 @@ WSGIPassAuthorization On
         Require all granted
     </Directory>
 
-    WSGIDaemonProcess coldfront python-path={{ git_prefix }}/{{ reponame }} python-home={{ git_prefix }}/venv/ processes=2 threads=15 display-name=coldfront
+    WSGIDaemonProcess coldfront python-path={{ git_prefix }}/{{ reponame }} python-home={{ git_prefix }}/venv/ processes={{ apache_num_processes }} threads={{ apache_num_threads_per_process }} display-name=coldfront
     WSGIProcessGroup coldfront
 
     WSGIScriptAlias / {{ git_prefix }}/{{ reponame }}/{{ djangoprojname }}/config/wsgi.py process-group=coldfront


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

- For Ansible-based deployments, set the number of Apache processes to the number of CPUs on the machine, instead of using a hard-coded number.
- Made the number of threads per Apache process configurable (default 10).

## Type of change

 **** Please delete options that are not relevant. ****

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- On an Ansible-based deployment, add `apache_num_threads_per_process` to `main.yml`.
- Re-run the Ansible playbook and ensure that the correct number of processes and threads are set.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
