### PR TITLE
Add command to notify project owners that FCA/PCA renewal for next year is available

### DIFF
--- a/coldfront/core/allocation/management/commands/send_allowance_renewal_available_emails.py
+++ b/coldfront/core/allocation/management/commands/send_allowance_renewal_available_emails.py
@@ -56,7 +56,7 @@ class Command(BaseCommand):
 
         num_emails = len(email_strategy.get_queue())
         if dry_run:
-            message = f'Would send {num_emails} emails.'
+            message = f'Would send emails to {num_emails} projects.'
             self.stdout.write(self.style.WARNING(message))
         else:
             user_confirmation = input(

--- a/coldfront/core/allocation/management/commands/send_allowance_renewal_available_emails.py
+++ b/coldfront/core/allocation/management/commands/send_allowance_renewal_available_emails.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING(message))
         else:
             user_confirmation = input(
-                'This will send emails to {num_emails} projects. Are you sure '
+                f'This will send emails to {num_emails} projects. Are you sure '
                 f'you wish to proceed? [Y/y/N/n]: ')
             if user_confirmation.strip().lower() != 'y':
                 self.stdout.write(self.style.WARNING('Operation cancelled.'))

--- a/coldfront/core/allocation/management/commands/send_allowance_renewal_available_emails.py
+++ b/coldfront/core/allocation/management/commands/send_allowance_renewal_available_emails.py
@@ -1,0 +1,73 @@
+import logging
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand
+
+from flags.state import flag_enabled
+
+from coldfront.core.project.utils_.renewal_utils import AllowanceRenewalAvailableEmailSender
+from coldfront.core.project.utils_.renewal_utils import get_current_allowance_year_period
+from coldfront.core.project.utils_.renewal_utils import get_next_allowance_year_period
+from coldfront.core.resource.models import Resource
+from coldfront.core.resource.utils_.allowance_utils.computing_allowance import ComputingAllowance
+from coldfront.core.resource.utils_.allowance_utils.constants import BRCAllowances
+from coldfront.core.resource.utils_.allowance_utils.constants import LRCAllowances
+from coldfront.core.utils.common import add_argparse_dry_run_argument
+from coldfront.core.utils.email.email_strategy import EnqueueEmailStrategy
+
+
+class Command(BaseCommand):
+
+    help = (
+        'Send emails to active projects with FCAs (BRC) or PCAs (LRC), '
+        'notifying them that they may renew their computing allowance for the '
+        'upcoming allowance year.')
+
+    logger = logging.getLogger(__name__)
+
+    # TODO: Consider only sending the email to projects that have not yet
+    #  renewed, so that this command can be safely re-run for subsequent emails.
+
+    def add_arguments(self, parser):
+        add_argparse_dry_run_argument(parser)
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+
+        current_allowance_year = get_current_allowance_year_period()
+        next_allowance_year = get_next_allowance_year_period()
+
+        if flag_enabled('BRC_ONLY'):
+            computing_allowance_name = BRCAllowances.FCA
+        elif flag_enabled('LRC_ONLY'):
+            computing_allowance_name = LRCAllowances.PCA
+        else:
+            raise ImproperlyConfigured(
+                'Exactly one of BRC_ONLY, LRC_ONLY should be enabled.')
+        computing_allowance = ComputingAllowance(
+            Resource.objects.get(name=computing_allowance_name))
+
+        email_strategy = EnqueueEmailStrategy()
+
+        email_sender = AllowanceRenewalAvailableEmailSender(
+            current_allowance_year, next_allowance_year, computing_allowance,
+            email_strategy=email_strategy)
+        email_sender.run()
+
+        num_emails = len(email_strategy.get_queue())
+        if dry_run:
+            message = f'Would send {num_emails} emails.'
+            self.stdout.write(self.style.WARNING(message))
+        else:
+            user_confirmation = input(
+                'This will send emails to {num_emails} projects. Are you sure '
+                f'you wish to proceed? [Y/y/N/n]: ')
+            if user_confirmation.strip().lower() != 'y':
+                self.stdout.write(self.style.WARNING('Operation cancelled.'))
+                return
+
+            email_strategy.send_queued_emails()
+
+            sent_message = (
+                f'Sent emails to {num_emails} projects. Check logs for errors.')
+            self.stdout.write(self.style.SUCCESS(sent_message))

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -691,7 +691,7 @@ class AllowanceRenewalAvailableEmailSender(object):
                 self._allowance_name_long)
         self._num_service_units = \
             self._computing_allowance_interface.service_units_from_name(
-                self._computing_allowance.get_name())
+                self._allowance_name_long)
 
         self._email_strategy = validate_email_strategy_or_get_default(
             email_strategy=email_strategy)

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -691,7 +691,8 @@ class AllowanceRenewalAvailableEmailSender(object):
                 self._allowance_name_long)
         self._num_service_units = \
             self._computing_allowance_interface.service_units_from_name(
-                self._allowance_name_long)
+                self._allowance_name_long, is_timed=True,
+                allocation_period=self._next_allocation_period)
 
         self._email_strategy = validate_email_strategy_or_get_default(
             email_strategy=email_strategy)

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -38,6 +38,7 @@ from django.db.models import Q
 from django.urls import reverse
 from urllib.parse import urljoin
 
+import io
 import logging
 import os
 
@@ -700,7 +701,7 @@ class AllowanceRenewalAvailableEmailSender(object):
                     project, self._current_allocation_period,
                     self._next_allocation_period, self._num_service_units)
             except Exception as e:
-                self.logger.exception(
+                logger.exception(
                     f'Failed to process allowance renewal reminder email for '
                     f'Project {project.name} ({project.pk}). Details:\n{e}')
                 failures.append(project)
@@ -711,7 +712,8 @@ class AllowanceRenewalAvailableEmailSender(object):
         is not ready."""
         try:
             call_command(
-                'audit_allocation_period', self._next_allocation_period.name)
+                'audit_allocation_period', self._next_allocation_period.name,
+                stdout=io.StringIO(), stderr=io.StringIO())
         except AuditFailure as e:
             raise e
 

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -290,7 +290,7 @@ def send_allocation_renewal_available_email(project,
 
     subject = (
         f'Action Required: Renew {project.name} '
-        f'{computing_allowance_name_long}(s)')
+        f'{computing_allowance_name_long}')
 
     context = {
         'project_name': project.name,

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -1,4 +1,5 @@
 from coldfront.api.statistics.utils import set_project_user_allocation_value
+from coldfront.core.allocation.management.commands.audit_allocation_period import AuditFailure
 from coldfront.core.allocation.models import AllocationAttribute
 from coldfront.core.allocation.models import AllocationAttributeType
 from coldfront.core.allocation.models import AllocationPeriod
@@ -6,7 +7,6 @@ from coldfront.core.allocation.models import AllocationRenewalRequest
 from coldfront.core.allocation.models import AllocationRenewalRequestStatusChoice
 from coldfront.core.allocation.models import AllocationStatusChoice
 from coldfront.core.allocation.utils import get_project_compute_allocation
-from coldfront.core.allocation.utils import prorated_allocation_amount
 from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
 from coldfront.core.project.models import ProjectStatusChoice
@@ -19,6 +19,7 @@ from coldfront.core.resource.utils_.allowance_utils.computing_allowance import C
 from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
 from coldfront.core.statistics.models import ProjectTransaction
 from coldfront.core.statistics.models import ProjectUserTransaction
+from coldfront.core.utils.common import build_absolute_url
 from coldfront.core.utils.common import display_time_zone_current_date
 from coldfront.core.utils.common import import_from_settings
 from coldfront.core.utils.common import project_detail_url
@@ -26,15 +27,19 @@ from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.utils.common import validate_num_service_units
 from coldfront.core.utils.email.email_strategy import validate_email_strategy_or_get_default
 from coldfront.core.utils.mail import send_email_template
+
 from collections import namedtuple
 from decimal import Decimal
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.core.management import call_command
 from django.db import transaction
 from django.db.models import Q
 from django.urls import reverse
 from urllib.parse import urljoin
+
 import logging
+import os
 
 
 logger = logging.getLogger(__name__)
@@ -264,6 +269,55 @@ def pis_with_renewal_requests_pks(allocation_period, computing_allowance=None,
     return set(
         AllocationRenewalRequest.objects.filter(
             f).values_list('pi__pk', flat=True))
+
+
+def send_allocation_renewal_available_email(project, current_allocation_period,
+                                            next_allocation_period,
+                                            num_service_units):
+    """Send a notification email to applicable project managers and PIs
+    of the given Project, notifying them that the project's computing
+    allowance, which is active under the given current AllocationPeriod,
+    will expire soon, and will need to be renewed for the given next
+    AllocationPeriod, which will grant the given number of service
+    units."""
+    email_enabled = import_from_settings('EMAIL_ENABLED', False)
+    if not email_enabled:
+        return
+
+    computing_allowance_name_short = None
+
+    subject = (
+        f'Action Required: Renew {project.name} '
+        f'{computing_allowance_name_short}')
+
+    context = {
+        'project_name': project.name,
+        'computing_allowance_name_short': computing_allowance_name_short,
+        'current_allocation_period_end_date': \
+            current_allocation_period.end_date,
+        'next_allocation_period_start_date': next_allocation_period.start_date,
+        'next_allocation_period_end_date': next_allocation_period.end_date,
+        'next_allocation_period_name': next_allocation_period.name,
+        'project_detail_url': project_detail_url(project),
+        'num_service_units': num_service_units,
+        'requests_url': build_absolute_url(reverse('request-hub')),
+        'general_renewal_url': build_absolute_url(
+            reverse('renew-pi-allocation-landing')),
+        'support_email': settings.CENTER_HELP_EMAIL,
+        'signature': settings.EMAIL_SIGNATURE,
+    }
+
+    sender = settings.EMAIL_SENDER
+    receiver_list = project.managers_and_pis_emails()
+
+    template_dir = 'email/project_renewal'
+    template_base_name = 'project_renewal_available'
+    template_name = os.path.join(template_dir, f'{template_base_name}.txt')
+    html_template = os.path.join(template_dir, f'{template_base_name}.html')
+
+    send_email_template(
+        subject, template_name, context, sender, receiver_list,
+        html_template=html_template)
 
 
 def send_allocation_renewal_request_approval_email(request, num_service_units):
@@ -605,6 +659,83 @@ def set_allocation_renewal_request_eligibility(request, status, justification,
     }
     request.status = allocation_renewal_request_state_status(request)
     request.save()
+
+
+class AllowanceRenewalAvailableEmailSender(object):
+    """A class that sends emails to eligible project owners, notifying
+    them that allowance renewal is available."""
+
+    def __init__(self, current_allocation_period, next_allocation_period,
+                 computing_allowance, email_strategy=None):
+        assert isinstance(current_allocation_period, AllocationPeriod)
+        assert isinstance(next_allocation_period, AllocationPeriod)
+        assert isinstance(computing_allowance, ComputingAllowance)
+
+        self._current_allocation_period = current_allocation_period
+
+        self._next_allocation_period = next_allocation_period
+        self._assert_allocation_period_ready()
+
+        self._computing_allowance = computing_allowance
+        assert self._computing_allowance.is_renewable()
+        assert self._computing_allowance.is_renewal_supported()
+
+        self._computing_allowance_interface = ComputingAllowanceInterface()
+        self._num_service_units = \
+            self._computing_allowance_interface.service_units_from_name(
+                self._computing_allowance.get_name())
+
+        self._email_strategy = validate_email_strategy_or_get_default(
+            email_strategy=email_strategy)
+
+    def run(self):
+        """Gather a list of relevant Projects, and send emails to them
+        using the email strategy. Return a list of Projects for which
+        email processing failed."""
+        eligible_projects = self._get_eligible_projects()
+        failures = []
+        for project in eligible_projects:
+            try:
+                self._process_email(
+                    project, self._current_allocation_period,
+                    self._next_allocation_period, self._num_service_units)
+            except Exception as e:
+                self.logger.exception(
+                    f'Failed to process allowance renewal reminder email for '
+                    f'Project {project.name} ({project.pk}). Details:\n{e}')
+                failures.append(project)
+        return failures
+
+    def _assert_allocation_period_ready(self):
+        """Raise an AuditFailure if the provided next AllocationPeriod
+        is not ready."""
+        try:
+            call_command(
+                'audit_allocation_period', self._next_allocation_period.name)
+        except AuditFailure as e:
+            raise e
+
+    def _get_eligible_projects(self):
+        """Return a list of Projects that are eligible to receive a
+        reminder email: currently "Active" ones that have the
+        computing allowance."""
+        project_name_prefix = \
+            self._computing_allowance_interface.code_from_name(
+                self._computing_allowance.get_name())
+        active_projects_with_allowance = Project.objects.filter(
+            name__startswith=project_name_prefix,
+            status__name='Active')
+        return active_projects_with_allowance
+
+    def _process_email(self, project, current_allocation_period,
+                       next_allocation_period, num_service_units):
+        """Process, via the email strategy, an email for the given
+        Project."""
+        email_method = send_allocation_renewal_available_email
+        email_args = (
+            project, current_allocation_period, next_allocation_period,
+            num_service_units)
+        self._email_strategy.process_email(email_method, *email_args)
 
 
 class AllocationRenewalRunnerBase(object):

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -301,7 +301,7 @@ def send_allocation_renewal_available_email(project,
         'next_allocation_period_start_date': next_allocation_period.start_date,
         'next_allocation_period_end_date': next_allocation_period.end_date,
         'next_allocation_period_name': next_allocation_period.name,
-        'project_detail_url': project_detail_url(project),
+        'project_detail_url': build_absolute_url(project_detail_url(project)),
         'num_service_units': num_service_units,
         'requests_url': build_absolute_url(reverse('request-hub')),
         'general_renewal_url': build_absolute_url(

--- a/coldfront/core/project/utils_/renewal_utils.py
+++ b/coldfront/core/project/utils_/renewal_utils.py
@@ -308,6 +308,7 @@ def send_allocation_renewal_available_email(project,
             reverse('renew-pi-allocation-landing')),
         'support_email': settings.CENTER_HELP_EMAIL,
         'signature': settings.EMAIL_SIGNATURE,
+        'signature_html': settings.EMAIL_SIGNATURE.replace('\n', '<br>'),
     }
 
     sender = settings.EMAIL_SENDER

--- a/coldfront/templates/email/project_renewal/project_renewal_available.html
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.html
@@ -24,4 +24,4 @@
 <p>If you have any questions, please contact us at {{ support_email }}.</p>
 
 <p>Thank you,<br>
-{{ signature }}</p>
+{{ signature_html|safe }}</p>

--- a/coldfront/templates/email/project_renewal/project_renewal_available.html
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.html
@@ -1,6 +1,6 @@
 <p>Dear project managers of {{ project_name }},</p>
 
-<p>Your {{ computing_allowance_name_short }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.</p>
+<p>Your {{ computing_allowance_name_long }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.</p>
 
 <p>To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:</p>
 

--- a/coldfront/templates/email/project_renewal/project_renewal_available.html
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.html
@@ -1,4 +1,5 @@
 {% load feature_flags %}
+{% flag_enabled 'LRC_ONLY' as lrc_only %}
 
 <p>Dear project managers of {{ project_name }},</p>
 
@@ -9,6 +10,7 @@
 <ol>
   <li>Visit the <a href="{{ project_detail_url }}">project</a> page, and click on the "Renew Allowance" button.</li>
   <li>Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately.)</li>
+  {% if lrc_only %}<li>If the project's LBL Project ID is invalid, you will be prompted to provide a valid one.</li>{% endif %}
   <li>Fill out the usage survey. Note: This is not the final step of the renewal form.</li>
   <li>Review your selections and submit.</li>
 </ol>
@@ -23,7 +25,6 @@
 
 <p>If a PI would like to move their {{ computing_allowance_name_short }} to a different project, their pooling preferences may be updated <a href="{{ general_renewal_url }}">here</a>.</p>
 
-{% flag_enabled 'LRC_ONLY' as lrc_only %}
 <p>Please take this opportunity to review the project's users, and remove any inactive users on the project page. {% if lrc_only %}Note that removal from the project does not delete the user's cluster account, so monthly user account fees may still apply. To request user cluster account deletion, please contact us.{% endif %}</p>
 
 <p>If you have any questions, please contact us at {{ support_email }}.</p>

--- a/coldfront/templates/email/project_renewal/project_renewal_available.html
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.html
@@ -6,7 +6,7 @@
 
 <ol>
   <li>Visit the <a href="{{ project_detail_url }}">project</a> page, and click on the "Renew Allowance" button.</li>
-  <li>Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately).</li>
+  <li>Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately.)</li>
   <li>Fill out the usage survey. Note: This is not the final step of the renewal form.</li>
   <li>Review your selections and submit.</li>
 </ol>

--- a/coldfront/templates/email/project_renewal/project_renewal_available.html
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.html
@@ -1,8 +1,8 @@
-Dear project managers of {{ project_name }},
+<p>Dear project managers of {{ project_name }},</p>
 
-Your {{ computing_allowance_name_short }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
+<p>Your {{ computing_allowance_name_short }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.</p>
 
-To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:
+<p>To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:</p>
 
 <ol>
   <li>Visit the <a href="{{ project_detail_url }}">project</a> page, and click on the "Renew Allowance" button.</li>
@@ -11,7 +11,7 @@ To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:
   <li>Review your selections and submit.</li>
 </ol>
 
-Here is what to expect after making a request:
+<p>Here is what to expect after making a request:</p>
 
 <ul>
   <li>You and the PI should see a project renewal request on the <a href="{{ requests_url }}">Requests</a> page.</li>
@@ -19,9 +19,9 @@ Here is what to expect after making a request:
   <li>If approved, the request will be processed on {{ next_allocation_period_start_date }}, and {{ num_service_units }} service units will be allocated to {{ project_name }}. You and the PI will be notified by email.</li>
 </ul>
 
-If a PI would like to move their {{ computing_allowance_name_short }} to a different project, their pooling preferences may be updated <a href="{{ general_renewal_url }}">here</a>.
+<p>If a PI would like to move their {{ computing_allowance_name_short }} to a different project, their pooling preferences may be updated <a href="{{ general_renewal_url }}">here</a>.</p>
 
-If you have any questions, please contact us at {{ support_email }}.
+<p>If you have any questions, please contact us at {{ support_email }}.</p>
 
-Thank you,
-{{ signature }}
+<p>Thank you,<br>
+{{ signature }}</p>

--- a/coldfront/templates/email/project_renewal/project_renewal_available.html
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.html
@@ -1,3 +1,5 @@
+{% load feature_flags %}
+
 <p>Dear project managers of {{ project_name }},</p>
 
 <p>Your {{ computing_allowance_name_long }} will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.</p>
@@ -20,6 +22,9 @@
 </ul>
 
 <p>If a PI would like to move their {{ computing_allowance_name_short }} to a different project, their pooling preferences may be updated <a href="{{ general_renewal_url }}">here</a>.</p>
+
+{% flag_enabled 'LRC_ONLY' as lrc_only %}
+<p>Please take this opportunity to review the project's users, and remove any inactive users on the project page. {% if lrc_only %}Note that removal from the project does not delete the user's cluster account, so monthly user account fees may still apply. To request user cluster account deletion, please contact us.{% endif %}</p>
 
 <p>If you have any questions, please contact us at {{ support_email }}.</p>
 

--- a/coldfront/templates/email/project_renewal/project_renewal_available.html
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.html
@@ -1,6 +1,6 @@
 <p>Dear project managers of {{ project_name }},</p>
 
-<p>Your {{ computing_allowance_name_long }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.</p>
+<p>Your {{ computing_allowance_name_long }} will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.</p>
 
 <p>To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:</p>
 

--- a/coldfront/templates/email/project_renewal/project_renewal_available.html
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.html
@@ -1,0 +1,27 @@
+Dear project managers of {{ project_name }},
+
+Your {{ computing_allowance_name_short }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
+
+To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:
+
+<ol>
+  <li>Visit the <a href="{{ project_detail_url }}">project</a> page, and click on the "Renew Allowance" button.</li>
+  <li>Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately).</li>
+  <li>Fill out the usage survey. Note: This is not the final step of the renewal form.</li>
+  <li>Review your selections and submit.</li>
+</ol>
+
+Here is what to expect after making a request:
+
+<ul>
+  <li>You and the PI should see a project renewal request on the <a href="{{ requests_url }}">Requests</a> page.</li>
+  <li>The request will be reviewed and approved a few days before {{ next_allocation_period_start_date }}. You and the PI will be notified by email.</li>
+  <li>If approved, the request will be processed on {{ next_allocation_period_start_date }}, and {{ num_service_units }} service units will be allocated to {{ project_name }}. You and the PI will be notified by email.</li>
+</ul>
+
+If a PI would like to move their {{ computing_allowance_name_short }} to a different project, their pooling preferences may be updated <a href="{{ general_renewal_url }}">here</a>.
+
+If you have any questions, please contact us at {{ support_email }}.
+
+Thank you,
+{{ signature }}

--- a/coldfront/templates/email/project_renewal/project_renewal_available.txt
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.txt
@@ -1,13 +1,14 @@
-{% load feature_flags %}Dear project managers of {{ project_name }},
+{% load feature_flags %}{% flag_enabled 'LRC_ONLY' as lrc_only %}Dear project managers of {{ project_name }},
 
 Your {{ computing_allowance_name_long }} will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
 
 To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:
 
-1. Visit the project page: {{ project_detail_url }}, and click on the "Renew Allowance" button.
-2. Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately.)
-3. Fill out the usage survey. Note: This is not the final step of the renewal form.
-4. Review your selections and submit.
+- Visit the project page: {{ project_detail_url }}, and click on the "Renew Allowance" button.
+- Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately.){% if lrc_only %}
+- If the project's LBL Project ID is invalid, you will be prompted to provide a valid one.{% endif %}
+- Fill out the usage survey. Note: This is not the final step of the renewal form.
+- Review your selections and submit.
 
 Here is what to expect after making a request:
 
@@ -17,7 +18,7 @@ Here is what to expect after making a request:
 
 If a PI would like to move their {{ computing_allowance_name_short }} to a different project, their pooling preferences may be updated here: {{ general_renewal_url }}.
 
-{% flag_enabled 'LRC_ONLY' as lrc_only %}Please take this opportunity to review the project's users, and remove any inactive users on the project page. {% if lrc_only %}Note that removal from the project does not delete the user's cluster account, so monthly user account fees may still apply. To request user cluster account deletion, please contact us.{% endif %}
+Please take this opportunity to review the project's users, and remove any inactive users on the project page. {% if lrc_only %}Note that removal from the project does not delete the user's cluster account, so monthly user account fees may still apply. To request user cluster account deletion, please contact us.{% endif %}
 
 If you have any questions, please contact us at {{ support_email }}.
 

--- a/coldfront/templates/email/project_renewal/project_renewal_available.txt
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.txt
@@ -1,6 +1,6 @@
 Dear project managers of {{ project_name }},
 
-Your {{ computing_allowance_name_long }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
+Your {{ computing_allowance_name_long }} will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
 
 To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:
 

--- a/coldfront/templates/email/project_renewal/project_renewal_available.txt
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.txt
@@ -1,4 +1,4 @@
-Dear project managers of {{ project_name }},
+{% load feature_flags %}Dear project managers of {{ project_name }},
 
 Your {{ computing_allowance_name_long }} will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
 
@@ -16,6 +16,8 @@ Here is what to expect after making a request:
 - If approved, the request will be processed on {{ next_allocation_period_start_date }}, and {{ num_service_units }} service units will be allocated to {{ project_name }}. You and the PI will be notified by email.
 
 If a PI would like to move their {{ computing_allowance_name_short }} to a different project, their pooling preferences may be updated here: {{ general_renewal_url }}.
+
+{% flag_enabled 'LRC_ONLY' as lrc_only %}Please take this opportunity to review the project's users, and remove any inactive users on the project page. {% if lrc_only %}Note that removal from the project does not delete the user's cluster account, so monthly user account fees may still apply. To request user cluster account deletion, please contact us.{% endif %}
 
 If you have any questions, please contact us at {{ support_email }}.
 

--- a/coldfront/templates/email/project_renewal/project_renewal_available.txt
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.txt
@@ -5,7 +5,7 @@ Your {{ computing_allowance_name_long }} will expire on {{ current_allocation_pe
 To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:
 
 1. Visit the project page: {{ project_detail_url }}, and click on the "Renew Allowance" button.
-2. Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately).
+2. Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately.)
 3. Fill out the usage survey. Note: This is not the final step of the renewal form.
 4. Review your selections and submit.
 

--- a/coldfront/templates/email/project_renewal/project_renewal_available.txt
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.txt
@@ -1,0 +1,23 @@
+Dear project managers of {{ project_name }},
+
+Your {{ computing_allowance_name_short }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
+
+To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:
+
+1. Visit the project page: {{ project_detail_url }}, and click on the "Renew Allowance" button.
+2. Select the "{{ next_allocation_period_name }}" period and the PI. (If there are multiple PIs, they must be renewed separately).
+3. Fill out the usage survey. Note: This is not the final step of the renewal form.
+4. Review your selections and submit.
+
+Here is what to expect after making a request:
+
+- You and the PI should see a project renewal request on the Requests page: {{ requests_url }}.
+- The request will be reviewed and approved a few days before {{ next_allocation_period_start_date }}. You and the PI will be notified by email.
+- If approved, the request will be processed on {{ next_allocation_period_start_date }}, and {{ num_service_units }} service units will be allocated to {{ project_name }}. You and the PI will be notified by email.
+
+If a PI would like to move their {{ computing_allowance_name_short }} to a different project, their pooling preferences may be updated here: {{ general_renewal_url }}.
+
+If you have any questions, please contact us at {{ support_email }}.
+
+Thank you,
+{{ signature }}

--- a/coldfront/templates/email/project_renewal/project_renewal_available.txt
+++ b/coldfront/templates/email/project_renewal/project_renewal_available.txt
@@ -1,6 +1,6 @@
 Dear project managers of {{ project_name }},
 
-Your {{ computing_allowance_name_short }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
+Your {{ computing_allowance_name_long }}(s) will expire on {{ current_allocation_period_end_date }}. You may now request to renew the free allowance for {{ next_allocation_period_name }}, which runs from {{ next_allocation_period_start_date }} to {{ next_allocation_period_end_date }}.
 
 To renew a PI's {{ computing_allowance_name_short }} under {{ project_name }}:
 


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

- Added a management command `send_allowance_renewal_available_emails` that notifies active FCA (MyBRC) / PCA (MyLRC) project PIs and managers that renewal for the next allowance year is available.
    - Emails are only sent if a readiness audit of the period passes (see the `audit_allocation_period` command).
    - A `--dry_run` flag may be provided to test.
- Added supporting utilities.

It is the administrator's responsibility not to run the command repeatedly.

## Type of change

 **** Please delete options that are not relevant. ****

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- For convenience, create a branch off of `upgrade/rocky8-python3.13-main` and merge this into the new branch. Visit `localhost:8025` to view queued emails.
- Run the command with `--dry_run`.
- Run the command without `--dry_run`. Ensure that it requires user confirmation before proceeding. Review queued emails.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code