### PR TITLE
Add search, filtering, pagination for project-related request list views

### DIFF
--- a/coldfront/core/project/forms_/new_project_forms/approval_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/approval_forms.py
@@ -1,5 +1,4 @@
 from coldfront.core.project.models import Project
-from coldfront.core.project.models import SavioProjectAllocationRequest
 from coldfront.core.resource.utils_.allowance_utils.interface import get_computing_allowance_interface
 
 from django import forms
@@ -15,19 +14,25 @@ from django.core.validators import RegexValidator
 
 class SavioProjectAllocationRequestSearchForm(forms.Form):
     project = forms.ModelChoiceField(
-        queryset=Project.objects.filter(
-            pk__in=SavioProjectAllocationRequest.objects.values('project')
-        ).order_by('name'),
+        queryset=Project.objects.none(),
         label='Project',
         required=False,
     )
     pi = forms.ModelChoiceField(
-        queryset=User.objects.filter(
-            pk__in=SavioProjectAllocationRequest.objects.values('pi')
-        ).order_by('username'),
+        queryset=User.objects.none(),
         label='PI',
         required=False,
     )
+
+    def __init__(self, *args, request_queryset=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if request_queryset is not None:
+            self.fields['project'].queryset = Project.objects.filter(
+                pk__in=request_queryset.values('project')
+            ).order_by('name')
+            self.fields['pi'].queryset = User.objects.filter(
+                pk__in=request_queryset.values('pi')
+            ).order_by('username')
 
 
 class SavioProjectReviewSetupForm(forms.Form):

--- a/coldfront/core/project/forms_/new_project_forms/approval_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/approval_forms.py
@@ -1,4 +1,3 @@
-from coldfront.core.allocation.models import AllocationPeriod
 from coldfront.core.project.models import Project
 from coldfront.core.project.models import SavioProjectAllocationRequest
 from coldfront.core.resource.utils_.allowance_utils.interface import get_computing_allowance_interface
@@ -15,23 +14,18 @@ from django.core.validators import RegexValidator
 
 
 class SavioProjectAllocationRequestSearchForm(forms.Form):
+    project = forms.ModelChoiceField(
+        queryset=Project.objects.filter(
+            pk__in=SavioProjectAllocationRequest.objects.values('project')
+        ).order_by('name'),
+        label='Project',
+        required=False,
+    )
     pi = forms.ModelChoiceField(
         queryset=User.objects.filter(
             pk__in=SavioProjectAllocationRequest.objects.values('pi')
         ).order_by('username'),
         label='PI',
-        required=False,
-    )
-    requester = forms.ModelChoiceField(
-        queryset=User.objects.filter(
-            pk__in=SavioProjectAllocationRequest.objects.values('requester')
-        ).order_by('username'),
-        label='Requester',
-        required=False,
-    )
-    allocation_period = forms.ModelChoiceField(
-        queryset=AllocationPeriod.objects.order_by('start_date'),
-        label='Allocation Period',
         required=False,
     )
 

--- a/coldfront/core/project/forms_/new_project_forms/approval_forms.py
+++ b/coldfront/core/project/forms_/new_project_forms/approval_forms.py
@@ -1,7 +1,10 @@
+from coldfront.core.allocation.models import AllocationPeriod
 from coldfront.core.project.models import Project
+from coldfront.core.project.models import SavioProjectAllocationRequest
 from coldfront.core.resource.utils_.allowance_utils.interface import get_computing_allowance_interface
 
 from django import forms
+from django.contrib.auth.models import User
 from django.core.validators import MinLengthValidator
 from django.core.validators import RegexValidator
 
@@ -9,6 +12,28 @@ from django.core.validators import RegexValidator
 # =============================================================================
 # BRC: SAVIO
 # =============================================================================
+
+
+class SavioProjectAllocationRequestSearchForm(forms.Form):
+    pi = forms.ModelChoiceField(
+        queryset=User.objects.filter(
+            pk__in=SavioProjectAllocationRequest.objects.values('pi')
+        ).order_by('username'),
+        label='PI',
+        required=False,
+    )
+    requester = forms.ModelChoiceField(
+        queryset=User.objects.filter(
+            pk__in=SavioProjectAllocationRequest.objects.values('requester')
+        ).order_by('username'),
+        label='Requester',
+        required=False,
+    )
+    allocation_period = forms.ModelChoiceField(
+        queryset=AllocationPeriod.objects.order_by('start_date'),
+        label='Allocation Period',
+        required=False,
+    )
 
 
 class SavioProjectReviewSetupForm(forms.Form):

--- a/coldfront/core/project/forms_/renewal_forms/approval_forms.py
+++ b/coldfront/core/project/forms_/renewal_forms/approval_forms.py
@@ -21,13 +21,6 @@ class AllocationRenewalRequestSearchForm(forms.Form):
         label='PI',
         required=False,
     )
-    requester = forms.ModelChoiceField(
-        queryset=User.objects.filter(
-            pk__in=AllocationRenewalRequest.objects.values('requester')
-        ).order_by('username'),
-        label='Requester',
-        required=False,
-    )
     allocation_period = forms.ModelChoiceField(
         queryset=AllocationPeriod.objects.order_by('start_date'),
         label='Allocation Period',

--- a/coldfront/core/project/forms_/renewal_forms/approval_forms.py
+++ b/coldfront/core/project/forms_/renewal_forms/approval_forms.py
@@ -2,27 +2,37 @@ from django import forms
 from django.contrib.auth.models import User
 
 from coldfront.core.allocation.models import AllocationPeriod
-from coldfront.core.allocation.models import AllocationRenewalRequest
 from coldfront.core.project.models import Project
 
 
 class AllocationRenewalRequestSearchForm(forms.Form):
     project = forms.ModelChoiceField(
-        queryset=Project.objects.filter(
-            pk__in=AllocationRenewalRequest.objects.values('post_project')
-        ).order_by('name'),
+        queryset=Project.objects.none(),
         label='Project',
         required=False,
     )
     pi = forms.ModelChoiceField(
-        queryset=User.objects.filter(
-            pk__in=AllocationRenewalRequest.objects.values('pi')
-        ).order_by('username'),
+        queryset=User.objects.none(),
         label='PI',
         required=False,
     )
     allocation_period = forms.ModelChoiceField(
-        queryset=AllocationPeriod.objects.order_by('start_date'),
+        queryset=AllocationPeriod.objects.none(),
         label='Allocation Period',
         required=False,
     )
+
+    def __init__(self, *args, request_queryset=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        if request_queryset is not None:
+            self.fields['project'].queryset = Project.objects.filter(
+                pk__in=request_queryset.values('post_project')
+            ).order_by('name')
+            self.fields['pi'].queryset = User.objects.filter(
+                pk__in=request_queryset.values('pi')
+            ).order_by('username')
+            self.fields['allocation_period'].queryset = (
+                AllocationPeriod.objects.filter(
+                    pk__in=request_queryset.values('allocation_period')
+                ).order_by('start_date')
+            )

--- a/coldfront/core/project/forms_/renewal_forms/approval_forms.py
+++ b/coldfront/core/project/forms_/renewal_forms/approval_forms.py
@@ -1,0 +1,35 @@
+from django import forms
+from django.contrib.auth.models import User
+
+from coldfront.core.allocation.models import AllocationPeriod
+from coldfront.core.allocation.models import AllocationRenewalRequest
+from coldfront.core.project.models import Project
+
+
+class AllocationRenewalRequestSearchForm(forms.Form):
+    project = forms.ModelChoiceField(
+        queryset=Project.objects.filter(
+            pk__in=AllocationRenewalRequest.objects.values('post_project')
+        ).order_by('name'),
+        label='Project',
+        required=False,
+    )
+    pi = forms.ModelChoiceField(
+        queryset=User.objects.filter(
+            pk__in=AllocationRenewalRequest.objects.values('pi')
+        ).order_by('username'),
+        label='PI',
+        required=False,
+    )
+    requester = forms.ModelChoiceField(
+        queryset=User.objects.filter(
+            pk__in=AllocationRenewalRequest.objects.values('requester')
+        ).order_by('username'),
+        label='Requester',
+        required=False,
+    )
+    allocation_period = forms.ModelChoiceField(
+        queryset=AllocationPeriod.objects.order_by('start_date'),
+        label='Allocation Period',
+        required=False,
+    )

--- a/coldfront/core/project/templates/project/project_renewal/project_renewal_request_list.html
+++ b/coldfront/core/project/templates/project/project_renewal/project_renewal_request_list.html
@@ -31,11 +31,49 @@ Project Renewal {{ request_filter|title }} Requests %}
   {% endif %}
 </p>
 
+<div class="mb-3" id="accordion">
+  <div class="card">
+    <div class="card-header">
+      <a id="expand_button" role="button" class="card-link" data-toggle="collapse" href="#collapseOne">
+        <i class="fas fa-filter" aria-hidden="true"></i> Search
+        <i id="plus_minus" class="fas {{ expand_accordion|get_icon }} float-right"></i>
+      </a>
+    </div>
+    <div id="collapseOne" class="collapse {{ expand_accordion }}" data-parent="#accordion">
+      <div class="card-body">
+        <form id="filter_form" method="GET" action="" autocomplete="off">
+          {{ renewal_search_form|crispy }}
+          <input type="submit" class="btn btn-primary" value="Search">
+          <button id="form_reset_button" type="button" class="btn btn-secondary">Reset</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
 {% if renewal_request_list %}
 <div class="table-responsive">
   {% with queryset=renewal_request_list %}
     {% include 'project/project_renewal/project_renewal_request_list_table.html' %}
   {% endwith %}
+</div>
+{% if is_paginated %} Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+<ul class="pagination float-right mr-3">
+  {% if page_obj.has_previous %}
+  <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}&{{ filter_parameters_with_order_by }}">Previous</a></li>
+  {% else %}
+  <li class="page-item disabled"><a class="page-link" href="#">Previous</a></li>
+  {% endif %}
+  {% if page_obj.has_next %}
+  <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}&{{ filter_parameters_with_order_by }}">Next</a></li>
+  {% else %}
+  <li class="page-item disabled"><a class="page-link" href="#">Next</a></li>
+  {% endif %}
+</ul>
+{% endif %}
+{% elif expand_accordion == 'show' %}
+<div class="alert alert-info">
+  No search results!
 </div>
 {% else %}
 <div class="alert alert-info">
@@ -43,14 +81,19 @@ Project Renewal {{ request_filter|title }} Requests %}
 </div>
 {% endif %}
 
+{% include 'common/selectize.html' %}
 <script>
   $("#navbar-main > ul > li.active").removeClass("active");
   $("#navbar-admin").addClass("active");
 
   $(document).ready(function(){
-      $('[data-toggle="popover"]').popover();
+    $('[data-toggle="popover"]').popover();
+    $('select').selectize({ create: false, sortField: 'text' });
+    $('#form_reset_button').on('click', function() {
+      $('#filter_form')[0].reset();
+      $('#filter_form').submit();
+    });
   });
-
 </script>
 
 {% endblock %}

--- a/coldfront/core/project/templates/project/project_renewal/project_renewal_request_list.html
+++ b/coldfront/core/project/templates/project/project_renewal/project_renewal_request_list.html
@@ -5,32 +5,30 @@
 
 
 {% block title %}
-Project Renewal {{ request_filter|title }} Requests %}
+Project Renewal {{ status|title }} Requests
 {% endblock %}
 
 
 {% block content %}
-<h1>{{ request_filter|title }} Project Renewal Requests</h1>
+<h1>{{ status|title }} Project Renewal Requests</h1>
 <hr>
 
-<p>
-  {% if request_filter == 'completed' %}
-    View completed requests for allocation renewals under projects (including
-    approved requests scheduled for processing). You may also view pending
-    requests
-    <a href="{% url 'pi-allocation-renewal-pending-request-list' %}">
-      <span class="accessibility-link-text">Pending Requests</span>
-      here</a>.
-  {% else %}
-    View pending requests for allocation renewals under projects. You may also
-    view completed requests (including approved requests scheduled for
-    processing)
-    <a href="{% url 'pi-allocation-renewal-completed-request-list' %}">
-      <span class="accessibility-link-text">Completed Requests</span>
-      here</a>.
-  {% endif %}
-</p>
+<ul class="nav nav-pills mb-3">
+  <li class="nav-item">
+    <a class="nav-link {% if status == 'pending' %}active{% endif %}"
+       href="?status=pending&{{ form_filter_parameters }}">Pending</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link {% if status == 'completed' %}active{% endif %}"
+       href="?status=completed&{{ form_filter_parameters }}">Completed</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link {% if status == 'all' %}active{% endif %}"
+       href="?status=all&{{ form_filter_parameters }}">All</a>
+  </li>
+</ul>
 
+{% if show_search %}
 <div class="mb-3" id="accordion">
   <div class="card">
     <div class="card-header">
@@ -42,6 +40,7 @@ Project Renewal {{ request_filter|title }} Requests %}
     <div id="collapseOne" class="collapse {{ expand_accordion }}" data-parent="#accordion">
       <div class="card-body">
         <form id="filter_form" method="GET" action="" autocomplete="off">
+          <input type="hidden" name="status" value="{{ status }}">
           {{ renewal_search_form|crispy }}
           <input type="submit" class="btn btn-primary" value="Search">
           <button id="form_reset_button" type="button" class="btn btn-secondary">Reset</button>
@@ -50,6 +49,7 @@ Project Renewal {{ request_filter|title }} Requests %}
     </div>
   </div>
 </div>
+{% endif %}
 
 {% if renewal_request_list %}
 <div class="table-responsive">
@@ -77,7 +77,7 @@ Project Renewal {{ request_filter|title }} Requests %}
 </div>
 {% else %}
 <div class="alert alert-info">
-  No {{ request_filter }} renewal requests!
+  No {{ status }} renewal requests!
 </div>
 {% endif %}
 

--- a/coldfront/core/project/templates/project/project_renewal/project_renewal_request_list_table.html
+++ b/coldfront/core/project/templates/project/project_renewal/project_renewal_request_list_table.html
@@ -22,19 +22,6 @@
       {% include 'common/table_sorter.html' with table_sorter_field='pi__email' %}
     </th>
     <th scope="col">Status</th>
-    <th scope="col">
-      <a
-          href="#"
-          data-toggle="popover"
-          title="Allocation Period Started?"
-          data-trigger="hover"
-          data-content="Green indicates that the request's Allocation Period has already started. Red indicates that it has not.">
-        <span class="accessibility-link-text">
-          Allocation Period Started?
-        </span>
-        <i class="fas fa-info-circle"></i>
-      </a>
-    </th>
   </tr>
   </thead>
   <tbody>
@@ -69,15 +56,6 @@
             <span class="badge badge-danger">{{ status }}</span>
           {% endif %}
         {% endwith %}
-      </td>
-      <td>
-        {% if not renewal_request.allocation_period_not_started %}
-          <div class="col-1 p-1 badge-success d-inline-block rounded-circle"></div>
-          <span class="accessibility-link-text">Yes</span>
-        {% else %}
-          <div class="col-1 p-1 badge-danger d-inline-block rounded-circle"></div>
-          <span class="accessibility-link-text">No</span>
-        {% endif %}
       </td>
     </tr>
   {% endfor %}

--- a/coldfront/core/project/templates/project/project_renewal/project_renewal_request_list_table.html
+++ b/coldfront/core/project/templates/project/project_renewal/project_renewal_request_list_table.html
@@ -6,14 +6,6 @@
       {% include 'common/table_sorter.html' with table_sorter_field='id' %}
     </th>
     <th scope="col">
-      Requested
-      {% include 'common/table_sorter.html' with table_sorter_field='request_time' %}
-    </th>
-    <th scope="col">
-      Requester
-      {% include 'common/table_sorter.html' with table_sorter_field='requester__email' %}
-    </th>
-    <th scope="col">
       Project
       {% include 'common/table_sorter.html' with table_sorter_field='post_project__name' %}
     </th>
@@ -21,27 +13,29 @@
       PI
       {% include 'common/table_sorter.html' with table_sorter_field='pi__email' %}
     </th>
+    <th scope="col">
+      Requested
+      {% include 'common/table_sorter.html' with table_sorter_field='request_time' %}
+    </th>
+    <th scope="col">
+      Allocation Period
+      {% include 'common/table_sorter.html' with table_sorter_field='allocation_period__start_date' %}
+    </th>
     <th scope="col">Status</th>
   </tr>
   </thead>
   <tbody>
   {% for renewal_request in queryset %}
     <tr>
+      <td>{{ renewal_request.pk }}</td>
       <td>
         <a href="{% url 'pi-allocation-renewal-request-detail' renewal_request.pk %}">
-          <span class="accessibility-link-text">Project {{ renewal_request.pk }}</span>
-          {{ renewal_request.pk }}
-        </a>
-      </td>
-      <td>{{ renewal_request.request_time|date:"M. d, Y" }}</td>
-      <td>{{ renewal_request.requester.email }}</td>
-      <td>
-        <a href="{% url 'project-detail' renewal_request.post_project.pk %}">
-          <span class="accessibility-link-text">{{ renewal_request.post_project.name }}</span>
           {{ renewal_request.post_project.name }}
         </a>
       </td>
       <td>{{ renewal_request.pi.email }}</td>
+      <td>{{ renewal_request.request_time|date:"M. d, Y" }}</td>
+      <td>{{ renewal_request.allocation_period.name }}</td>
       <td>
         {% with status=renewal_request.status.name %}
           {% if status == 'Under Review' %}

--- a/coldfront/core/project/templates/project/project_request/savio/project_request_list.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_list.html
@@ -29,11 +29,49 @@
   {% endif %}
 </p>
 
+<div class="mb-3" id="accordion">
+  <div class="card">
+    <div class="card-header">
+      <a id="expand_button" role="button" class="card-link" data-toggle="collapse" href="#collapseOne">
+        <i class="fas fa-filter" aria-hidden="true"></i> Search
+        <i id="plus_minus" class="fas {{ expand_accordion|get_icon }} float-right"></i>
+      </a>
+    </div>
+    <div id="collapseOne" class="collapse {{ expand_accordion }}" data-parent="#accordion">
+      <div class="card-body">
+        <form id="filter_form" method="GET" action="" autocomplete="off">
+          {{ savio_search_form|crispy }}
+          <input type="submit" class="btn btn-primary" value="Search">
+          <button id="form_reset_button" type="button" class="btn btn-secondary">Reset</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
 {% if savio_project_request_list %}
 <div class="table-responsive">
   {% with queryset=savio_project_request_list %}
     {% include 'project/project_request/savio/project_request_list_table.html' %}
   {% endwith %}
+</div>
+{% if is_paginated %} Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}
+<ul class="pagination float-right mr-3">
+  {% if page_obj.has_previous %}
+  <li class="page-item"><a class="page-link" href="?page={{ page_obj.previous_page_number }}&{{ filter_parameters_with_order_by }}">Previous</a></li>
+  {% else %}
+  <li class="page-item disabled"><a class="page-link" href="#">Previous</a></li>
+  {% endif %}
+  {% if page_obj.has_next %}
+  <li class="page-item"><a class="page-link" href="?page={{ page_obj.next_page_number }}&{{ filter_parameters_with_order_by }}">Next</a></li>
+  {% else %}
+  <li class="page-item disabled"><a class="page-link" href="#">Next</a></li>
+  {% endif %}
+</ul>
+{% endif %}
+{% elif expand_accordion == 'show' %}
+<div class="alert alert-info">
+  No search results!
 </div>
 {% else %}
 <div class="alert alert-info">
@@ -41,15 +79,20 @@
 </div>
 {% endif %}
 
+{% include 'common/selectize.html' %}
 <script>
   $("#navbar-main > ul > li.active").removeClass("active");
   $("#navbar-admin").addClass("active");
   $("#navbar-project-new-project-requests").addClass("active");
 
   $(document).ready(function(){
-      $('[data-toggle="popover"]').popover();
+    $('[data-toggle="popover"]').popover();
+    $('select').selectize({ create: false, sortField: 'text' });
+    $('#form_reset_button').on('click', function() {
+      $('#filter_form')[0].reset();
+      $('#filter_form').submit();
+    });
   });
-
 </script>
 
 {% endblock %}

--- a/coldfront/core/project/templates/project/project_request/savio/project_request_list.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_list.html
@@ -5,30 +5,30 @@
 
 
 {% block title %}
-{{ PRIMARY_CLUSTER_NAME }} Project {{ request_filter|title }} Requests
+{{ PRIMARY_CLUSTER_NAME }} Project {{ status|title }} Requests
 {% endblock %}
 
 
 {% block content %}
-<h1>{{ request_filter|title }} New Project Requests</h1>
+<h1>{{ status|title }} New Project Requests</h1>
 <hr>
 
-<p>
-  {% if request_filter == 'completed' %}
-    Viewing completed requests for new projects (including approved requests
-    scheduled for processing). You may also view pending requests
-    <a href="{% url 'new-project-pending-request-list' %}">
-      <span class="accessibility-link-text">Pending Requests</span>
-      here</a>.
-  {% else %}
-    Viewing pending requests for new projects. You may also view completed
-    requests (including approved requests scheduled for processing)
-    <a href="{% url 'new-project-completed-request-list' %}">
-      <span class="accessibility-link-text">Completed Requests</span>
-      here</a>.
-  {% endif %}
-</p>
+<ul class="nav nav-pills mb-3">
+  <li class="nav-item">
+    <a class="nav-link {% if status == 'pending' %}active{% endif %}"
+       href="?status=pending&{{ form_filter_parameters }}">Pending</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link {% if status == 'completed' %}active{% endif %}"
+       href="?status=completed&{{ form_filter_parameters }}">Completed</a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link {% if status == 'all' %}active{% endif %}"
+       href="?status=all&{{ form_filter_parameters }}">All</a>
+  </li>
+</ul>
 
+{% if show_search %}
 <div class="mb-3" id="accordion">
   <div class="card">
     <div class="card-header">
@@ -40,6 +40,7 @@
     <div id="collapseOne" class="collapse {{ expand_accordion }}" data-parent="#accordion">
       <div class="card-body">
         <form id="filter_form" method="GET" action="" autocomplete="off">
+          <input type="hidden" name="status" value="{{ status }}">
           {{ savio_search_form|crispy }}
           <input type="submit" class="btn btn-primary" value="Search">
           <button id="form_reset_button" type="button" class="btn btn-secondary">Reset</button>
@@ -48,6 +49,7 @@
     </div>
   </div>
 </div>
+{% endif %}
 
 {% if savio_project_request_list %}
 <div class="table-responsive">
@@ -75,7 +77,7 @@
 </div>
 {% else %}
 <div class="alert alert-info">
-  No {{ request_filter }} new project requests!
+  No {{ status }} new project requests!
 </div>
 {% endif %}
 

--- a/coldfront/core/project/templates/project/project_request/savio/project_request_list_table.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_list_table.html
@@ -6,20 +6,16 @@
       {% include 'common/table_sorter.html' with table_sorter_field='id' %}
     </th>
     <th scope="col">
-      Requested
-      {% include 'common/table_sorter.html' with table_sorter_field='request_time' %}
-    </th>
-    <th scope="col">
-      Requester
-      {% include 'common/table_sorter.html' with table_sorter_field='requester__email' %}
-    </th>
-    <th scope="col">
       Project
-      {% include 'common/table_sorter.html' with table_sorter_field='project' %}
+      {% include 'common/table_sorter.html' with table_sorter_field='project__name' %}
     </th>
     <th scope="col">
       PI
       {% include 'common/table_sorter.html' with table_sorter_field='pi__email' %}
+    </th>
+    <th scope="col">
+      Requested
+      {% include 'common/table_sorter.html' with table_sorter_field='request_time' %}
     </th>
     <th scope="col">Status</th>
   </tr>
@@ -27,21 +23,14 @@
   <tbody>
   {% for savio_project_request in queryset %}
     <tr>
+      <td>{{ savio_project_request.pk }}</td>
       <td>
         <a href="{% url 'new-project-request-detail' savio_project_request.pk %}">
-          <span class="accessibility-link-text">Project {{ savio_project_request.pk }}</span>
-          {{ savio_project_request.pk }}
-        </a>
-      </td>
-      <td>{{ savio_project_request.request_time|date:"M. d, Y" }}</td>
-      <td>{{ savio_project_request.requester.email }}</td>
-      <td>
-        <a href="{% url 'project-detail' savio_project_request.project.pk %}">
-          <span class="accessibility-link-text">Project {{ savio_project_request.project.name }}</span>
           {{ savio_project_request.project.name }}
         </a>
       </td>
       <td>{{ savio_project_request.pi.email }}</td>
+      <td>{{ savio_project_request.request_time|date:"M. d, Y" }}</td>
       <td>
         {% with status=savio_project_request.status.name %}
           {% if status == 'Under Review' %}

--- a/coldfront/core/project/templates/project/project_request/savio/project_request_list_table.html
+++ b/coldfront/core/project/templates/project/project_request/savio/project_request_list_table.html
@@ -22,19 +22,6 @@
       {% include 'common/table_sorter.html' with table_sorter_field='pi__email' %}
     </th>
     <th scope="col">Status</th>
-    <th scope="col">
-      <a
-          href="#"
-          data-toggle="popover"
-          title="Allocation Period Started?"
-          data-trigger="hover"
-          data-content="Green indicates that the request's Allocation Period has already started. Red indicates that it has not.">
-        <span class="accessibility-link-text">
-          Allocation Period Started?
-        </span>
-        <i class="fas fa-info-circle"></i>
-      </a>
-    </th>
   </tr>
   </thead>
   <tbody>
@@ -69,15 +56,6 @@
             <span class="badge badge-danger">{{ status }}</span>
           {% endif %}
         {% endwith %}
-      </td>
-      <td>
-        {% if not savio_project_request.allocation_period_not_started %}
-          <div class="col-1 p-1 badge-success d-inline-block rounded-circle"></div>
-          <span class="accessibility-link-text">Yes</span>
-        {% else %}
-          <div class="col-1 p-1 badge-danger d-inline-block rounded-circle"></div>
-          <span class="accessibility-link-text">No</span>
-        {% endif %}
       </td>
     </tr>
   {% endfor %}

--- a/coldfront/core/project/tests/test_views/test_new_project_views/test_savio_project_request_list_view.py
+++ b/coldfront/core/project/tests/test_views/test_new_project_views/test_savio_project_request_list_view.py
@@ -2,6 +2,7 @@ from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
 from coldfront.core.project.tests.utils import create_project_and_request
 from coldfront.core.project.utils_.renewal_utils import get_current_allowance_year_period
 from coldfront.core.utils.tests.test_base import TestBase
+from django.contrib.auth.models import Permission
 from django.contrib.auth.models import User
 from django.urls import reverse
 
@@ -9,8 +10,8 @@ from django.urls import reverse
 class TestViewMixin(object):
     """A mixin for testing SavioProjectRequestListView."""
 
-    completed_url = reverse('new-project-completed-request-list')
-    pending_url = reverse('new-project-pending-request-list')
+    completed_url = reverse('new-project-request-list') + '?status=completed'
+    pending_url = reverse('new-project-request-list') + '?status=pending'
     url = None
 
     def setUp(self):
@@ -95,6 +96,60 @@ class TestViewMixin(object):
         self.assertNotContains(response, self.project_a.name)
         self.assertNotContains(response, self.project_b.name)
         self.assertContains(response, self.project_c.name)
+
+    def test_search_form_visibility(self):
+        """Test that the search form is visible to superusers and users
+        with the view permission (e.g. staff), but hidden from regular
+        users."""
+        self.assertTrue(self.user.is_superuser)
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(self.url)
+        self.assertIs(response.context['show_search'], True)
+        self.assertContains(response, 'id="filter_form"')
+
+        # A user with the view permission also sees the search form.
+        perm = Permission.objects.get(
+            codename='view_savioprojectallocationrequest')
+        self.user_a.user_permissions.add(perm)
+        self.client.login(username=self.user_a.username, password=self.password)
+        response = self.client.get(self.url)
+        self.assertIs(response.context['show_search'], True)
+        self.assertContains(response, 'id="filter_form"')
+        self.user_a.user_permissions.remove(perm)
+
+        self.assertFalse(self.user_b.is_superuser)
+        self.client.login(username=self.user_b.username, password=self.password)
+        response = self.client.get(self.url)
+        self.assertIs(response.context['show_search'], False)
+        self.assertNotContains(response, 'id="filter_form"')
+
+    def test_superuser_can_filter_requests(self):
+        """Test that superusers can filter requests by project and by PI."""
+        self.assertTrue(self.user.is_superuser)
+        self.client.login(username=self.user.username, password=self.password)
+
+        # Filter by project.
+        url = self.url + f'&project={self.project_a.pk}'
+        response = self.client.get(url)
+        request_list = list(response.context['savio_project_request_list'])
+        self.assertEqual(len(request_list), 1)
+        self.assertEqual(request_list[0].project, self.project_a)
+
+        # Filter by PI.
+        url = self.url + f'&pi={self.user_b.pk}'
+        response = self.client.get(url)
+        request_list = list(response.context['savio_project_request_list'])
+        self.assertEqual(len(request_list), 1)
+        self.assertEqual(request_list[0].pi, self.user_b)
+
+    def test_search_params_ignored_for_non_superusers(self):
+        """Test that search query parameters are ignored for non-superusers,
+        preventing them from viewing requests they are not associated with."""
+        self.assertFalse(self.user_a.is_superuser)
+        self.client.login(username=self.user_a.username, password=self.password)
+        url = self.url + f'&project={self.project_b.pk}'
+        response = self.client.get(url)
+        self.assertNotContains(response, self.project_b.name)
 
 
 class TestSavioProjectRequestCompletedListView(TestViewMixin, TestBase):

--- a/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_detail_view.py
+++ b/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_detail_view.py
@@ -331,7 +331,7 @@ class TestAllocationRenewalRequestDetailView(TestBase, TestRenewalViewsMixin):
         self.allocation_renewal_request.save()
         response = self.client.post(url, data)
         redirect_url = reverse('pi-allocation-renewal-pending-request-list')
-        self.assertRedirects(response, redirect_url)
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
         message = f'PI {self.user.username}\'s allocation has been renewed.'
         self.assertEqual(message, self.get_message_strings(response)[0])
 
@@ -385,6 +385,6 @@ class TestAllocationRenewalRequestDetailView(TestBase, TestRenewalViewsMixin):
         new_project_request.save()
         response = self.client.post(url, data)
         redirect_url = reverse('pi-allocation-renewal-pending-request-list')
-        self.assertRedirects(response, redirect_url)
+        self.assertRedirects(response, redirect_url, fetch_redirect_response=False)
         message = f'PI {self.user.username}\'s allocation has been renewed.'
         self.assertEqual(message, self.get_message_strings(response)[0])

--- a/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_list_view.py
+++ b/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_list_view.py
@@ -4,6 +4,7 @@ from coldfront.core.project.tests.test_views.test_renewal_views.utils import Tes
 from coldfront.core.resource.models import Resource
 from coldfront.core.resource.utils_.allowance_utils.constants import BRCAllowances
 from coldfront.core.utils.tests.test_base import TestBase
+from django.contrib.auth.models import Permission
 from django.contrib.auth.models import User
 from django.urls import reverse
 
@@ -11,8 +12,8 @@ from django.urls import reverse
 class TestViewMixin(TestRenewalViewsMixin):
     """A mixin for testing AllocationRenewalRequestListView."""
 
-    completed_url = reverse('pi-allocation-renewal-completed-request-list')
-    pending_url = reverse('pi-allocation-renewal-pending-request-list')
+    completed_url = reverse('pi-allocation-renewal-request-list') + '?status=completed'
+    pending_url = reverse('pi-allocation-renewal-request-list') + '?status=pending'
     url = None
 
     def setUp(self):
@@ -73,6 +74,60 @@ class TestViewMixin(TestRenewalViewsMixin):
         response = self.client.get(self.url)
         self.assertNotContains(response, self.project_a.name)
         self.assertContains(response, self.project_b.name)
+
+    def test_search_form_visibility(self):
+        """Test that the search form is visible to superusers and users
+        with the view permission (e.g. staff), but hidden from regular
+        users."""
+        self.assertTrue(self.user.is_superuser)
+        self.client.login(username=self.user.username, password=self.password)
+        response = self.client.get(self.url)
+        self.assertIs(response.context['show_search'], True)
+        self.assertContains(response, 'id="filter_form"')
+
+        # A user with the view permission also sees the search form.
+        perm = Permission.objects.get(
+            codename='view_allocationrenewalrequest')
+        self.user_a.user_permissions.add(perm)
+        self.client.login(username=self.user_a.username, password=self.password)
+        response = self.client.get(self.url)
+        self.assertIs(response.context['show_search'], True)
+        self.assertContains(response, 'id="filter_form"')
+        self.user_a.user_permissions.remove(perm)
+
+        self.assertFalse(self.user_b.is_superuser)
+        self.client.login(username=self.user_b.username, password=self.password)
+        response = self.client.get(self.url)
+        self.assertIs(response.context['show_search'], False)
+        self.assertNotContains(response, 'id="filter_form"')
+
+    def test_superuser_can_filter_requests(self):
+        """Test that superusers can filter requests by project and by PI."""
+        self.assertTrue(self.user.is_superuser)
+        self.client.login(username=self.user.username, password=self.password)
+
+        # Filter by project.
+        url = self.url + f'&project={self.project_a.pk}'
+        response = self.client.get(url)
+        request_list = list(response.context['renewal_request_list'])
+        self.assertEqual(len(request_list), 1)
+        self.assertEqual(request_list[0].post_project, self.project_a)
+
+        # Filter by PI.
+        url = self.url + f'&pi={self.user_b.pk}'
+        response = self.client.get(url)
+        request_list = list(response.context['renewal_request_list'])
+        self.assertEqual(len(request_list), 1)
+        self.assertEqual(request_list[0].pi, self.user_b)
+
+    def test_search_params_ignored_for_non_superusers(self):
+        """Test that search query parameters are ignored for non-superusers,
+        preventing them from viewing requests they are not associated with."""
+        self.assertFalse(self.user_a.is_superuser)
+        self.client.login(username=self.user_a.username, password=self.password)
+        url = self.url + f'&project={self.project_b.pk}'
+        response = self.client.get(url)
+        self.assertNotContains(response, self.project_b.name)
 
 
 class TestAllocationRenewalRequestCompletedListView(TestViewMixin, TestBase):

--- a/coldfront/core/project/urls.py
+++ b/coldfront/core/project/urls.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.urls import path
-from django.views.generic import TemplateView
+from django.views.generic import RedirectView, TemplateView
 
 from flags.urls import flagged_paths
 
@@ -69,13 +69,18 @@ urlpatterns += [
              condition_dict=new_project_request_views.SavioProjectRequestWizard.condition_dict(),
          ),
          name='new-project-request'),
+    path('new-project-request-list/',
+         new_project_approval_views.SavioProjectRequestListView.as_view(),
+         name='new-project-request-list'),
+    # TODO: Remove these redirects once all internal references have been
+    # updated to use 'new-project-request-list' with a ?status= parameter.
     path('new-project-pending-request-list/',
-         new_project_approval_views.SavioProjectRequestListView.as_view(
-             completed=False),
+         RedirectView.as_view(
+             url='/project/new-project-request-list/?status=pending'),
          name='new-project-pending-request-list'),
     path('new-project-completed-request-list/',
-         new_project_approval_views.SavioProjectRequestListView.as_view(
-             completed=True),
+         RedirectView.as_view(
+             url='/project/new-project-request-list/?status=completed'),
          name='new-project-completed-request-list'),
     path('new-project-request/<int:pk>/',
          new_project_approval_views.SavioProjectRequestDetailView.as_view(),
@@ -190,13 +195,18 @@ urlpatterns += [
              condition_dict=renewal_request_views.AllocationRenewalRequestView.condition_dict(),
          ),
          name='renew-pi-allocation'),
+    path('pi-allocation-renewal-request-list/',
+         renewal_approval_views.AllocationRenewalRequestListView.as_view(),
+         name='pi-allocation-renewal-request-list'),
+    # TODO: Remove these redirects once all internal references have been
+    # updated to use 'pi-allocation-renewal-request-list' with a ?status= parameter.
     path('pi-allocation-renewal-pending-request-list/',
-         renewal_approval_views.AllocationRenewalRequestListView.as_view(
-             completed=False),
+         RedirectView.as_view(
+             url='/project/pi-allocation-renewal-request-list/?status=pending'),
          name='pi-allocation-renewal-pending-request-list'),
     path('pi-allocation-renewal-completed-request-list/',
-         renewal_approval_views.AllocationRenewalRequestListView.as_view(
-             completed=True),
+         RedirectView.as_view(
+             url='/project/pi-allocation-renewal-request-list/?status=completed'),
          name='pi-allocation-renewal-completed-request-list'),
     path('pi-allocation-renewal-request-detail/<int:pk>/',
          renewal_approval_views.AllocationRenewalRequestDetailView.as_view(),

--- a/coldfront/core/project/views_/new_project_views/approval_views.py
+++ b/coldfront/core/project/views_/new_project_views/approval_views.py
@@ -1,11 +1,11 @@
 from coldfront.core.allocation.models import AllocationRenewalRequest
-from coldfront.core.allocation.utils import annotate_queryset_with_allocation_period_not_started_bool
 from coldfront.core.allocation.utils import calculate_service_units_to_allocate
 from coldfront.core.project.forms import MemorandumSignedForm
 from coldfront.core.project.forms import ReviewDenyForm
 from coldfront.core.project.forms import ReviewStatusForm
 from coldfront.core.project.forms_.new_project_forms.request_forms import NewProjectExtraFieldsFormFactory
 from coldfront.core.project.forms_.new_project_forms.request_forms import SavioProjectSurveyForm
+from coldfront.core.project.forms_.new_project_forms.approval_forms import SavioProjectAllocationRequestSearchForm
 from coldfront.core.project.forms_.new_project_forms.approval_forms import SavioProjectReviewSetupForm
 from coldfront.core.project.forms_.new_project_forms.approval_forms import VectorProjectReviewSetupForm
 from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
@@ -43,6 +43,7 @@ from django.views import View
 from django.views.generic import DetailView
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
+from coldfront.core.utils.mixins.views import ListFilterMixin
 from coldfront.core.utils.views.mou_views import MOURequestNotifyPIViewMixIn
 from flags.state import flag_enabled
 
@@ -55,49 +56,61 @@ import logging
 # =============================================================================
 
 
-class SavioProjectRequestListView(LoginRequiredMixin, TemplateView):
+class SavioProjectRequestListView(LoginRequiredMixin, ListFilterMixin,
+                                   TemplateView):
     template_name = 'project/project_request/savio/project_request_list.html'
     # Show completed requests if True; else, show pending requests.
     completed = False
 
     def get_queryset(self):
-        order_by = self.request.GET.get('order_by')
-        if order_by:
-            direction = self.request.GET.get('direction')
-            if direction == 'asc':
-                direction = ''
-            else:
-                direction = '-'
-            order_by = direction + order_by
-        else:
-            order_by = '-request_time'
-
-        return annotate_queryset_with_allocation_period_not_started_bool(
-            SavioProjectAllocationRequest.objects.select_related(
-                'pi', 'project', 'status', 'computing_allowance',
-                'allocation_period', 'requester',
-            ).order_by(order_by))
+        return SavioProjectAllocationRequest.objects.select_related(
+            'pi', 'project', 'status', 'computing_allowance',
+            'allocation_period', 'requester',
+        ).order_by(self.get_order_by(default='-request_time'))
 
     def get_context_data(self, **kwargs):
         """Include either pending or completed requests. If the user is
         a superuser, show all such requests. Otherwise, show only those
         for which the user is a requester or PI."""
         context = super().get_context_data(**kwargs)
-        args, kwargs = [], {}
+        filter_args, filter_kwargs = [], {}
 
         request_list = self.get_queryset()
         user = self.request.user
         permission = 'project.view_savioprojectallocationrequest'
         if not (user.is_superuser or user.has_perm(permission)):
-            args.append(Q(requester=user) | Q(pi=user))
+            filter_args.append(Q(requester=user) | Q(pi=user))
         if self.completed:
-            status__name__in = [
+            filter_kwargs['status__name__in'] = [
                 'Approved - Complete', 'Approved - Scheduled', 'Denied']
         else:
-            status__name__in = ['Under Review', 'Approved - Processing']
-        kwargs['status__name__in'] = status__name__in
-        context['savio_project_request_list'] = request_list.filter(
-            *args, **kwargs)
+            filter_kwargs['status__name__in'] = [
+                'Under Review', 'Approved - Processing']
+        request_list = request_list.filter(*filter_args, **filter_kwargs)
+
+        search_form = SavioProjectAllocationRequestSearchForm(self.request.GET)
+        if search_form.is_valid():
+            data = search_form.cleaned_data
+            if data.get('pi'):
+                request_list = request_list.filter(pi=data['pi'])
+            if data.get('requester'):
+                request_list = request_list.filter(requester=data['requester'])
+            if data.get('allocation_period'):
+                request_list = request_list.filter(
+                    allocation_period=data['allocation_period'])
+
+        filter_parameters = self.build_filter_parameters(
+            search_form.cleaned_data if search_form.is_valid() else {})
+        order_by = self.request.GET.get('order_by', 'request_time')
+        direction = self.request.GET.get('direction', 'des')
+        context['filter_parameters'] = filter_parameters
+        context['filter_parameters_with_order_by'] = (
+            filter_parameters + f'order_by={order_by}&direction={direction}&')
+        context['expand_accordion'] = 'show' if filter_parameters else ''
+        context['savio_search_form'] = search_form
+
+        page_obj = self.paginate(request_list, context)
+        context['savio_project_request_list'] = page_obj.object_list
         context['request_filter'] = (
             'completed' if self.completed else 'pending')
 

--- a/coldfront/core/project/views_/new_project_views/approval_views.py
+++ b/coldfront/core/project/views_/new_project_views/approval_views.py
@@ -99,7 +99,8 @@ class SavioProjectRequestListView(LoginRequiredMixin, ListFilterMixin,
 
         form_filter_parameters = ''
         if show_search:
-            search_form = SavioProjectAllocationRequestSearchForm(self.request.GET)
+            search_form = SavioProjectAllocationRequestSearchForm(
+                self.request.GET, request_queryset=request_list)
             if search_form.is_valid():
                 data = search_form.cleaned_data
                 if data.get('project'):

--- a/coldfront/core/project/views_/new_project_views/approval_views.py
+++ b/coldfront/core/project/views_/new_project_views/approval_views.py
@@ -8,6 +8,7 @@ from coldfront.core.project.forms_.new_project_forms.request_forms import SavioP
 from coldfront.core.project.forms_.new_project_forms.approval_forms import SavioProjectAllocationRequestSearchForm
 from coldfront.core.project.forms_.new_project_forms.approval_forms import SavioProjectReviewSetupForm
 from coldfront.core.project.forms_.new_project_forms.approval_forms import VectorProjectReviewSetupForm
+from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
 from coldfront.core.project.models import SavioProjectAllocationRequest
 from coldfront.core.project.models import VectorProjectAllocationRequest
@@ -31,6 +32,7 @@ from decimal import Decimal
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.models import User
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import transaction
@@ -59,8 +61,9 @@ import logging
 class SavioProjectRequestListView(LoginRequiredMixin, ListFilterMixin,
                                    TemplateView):
     template_name = 'project/project_request/savio/project_request_list.html'
-    # Show completed requests if True; else, show pending requests.
-    completed = False
+
+    PENDING_STATUSES = ['Under Review', 'Approved - Processing']
+    COMPLETED_STATUSES = ['Approved - Complete', 'Approved - Scheduled', 'Denied']
 
     def get_queryset(self):
         return SavioProjectAllocationRequest.objects.select_related(
@@ -69,9 +72,12 @@ class SavioProjectRequestListView(LoginRequiredMixin, ListFilterMixin,
         ).order_by(self.get_order_by(default='-request_time'))
 
     def get_context_data(self, **kwargs):
-        """Include either pending or completed requests. If the user is
-        a superuser, show all such requests. Otherwise, show only those
-        for which the user is a requester or PI."""
+        """Include pending, completed, or all requests depending on the
+        status GET parameter. Superusers and users with the
+        view_savioprojectallocationrequest permission (e.g. staff) see all
+        requests and have access to the search form. All other users see only
+        requests for which they are the requester or PI, with search
+        hidden."""
         context = super().get_context_data(**kwargs)
         filter_args, filter_kwargs = [], {}
 
@@ -80,39 +86,44 @@ class SavioProjectRequestListView(LoginRequiredMixin, ListFilterMixin,
         permission = 'project.view_savioprojectallocationrequest'
         if not (user.is_superuser or user.has_perm(permission)):
             filter_args.append(Q(requester=user) | Q(pi=user))
-        if self.completed:
-            filter_kwargs['status__name__in'] = [
-                'Approved - Complete', 'Approved - Scheduled', 'Denied']
-        else:
-            filter_kwargs['status__name__in'] = [
-                'Under Review', 'Approved - Processing']
+
+        status = self.request.GET.get('status', 'pending')
+        if status == 'pending':
+            filter_kwargs['status__name__in'] = self.PENDING_STATUSES
+        elif status == 'completed':
+            filter_kwargs['status__name__in'] = self.COMPLETED_STATUSES
         request_list = request_list.filter(*filter_args, **filter_kwargs)
 
-        search_form = SavioProjectAllocationRequestSearchForm(self.request.GET)
-        if search_form.is_valid():
-            data = search_form.cleaned_data
-            if data.get('pi'):
-                request_list = request_list.filter(pi=data['pi'])
-            if data.get('requester'):
-                request_list = request_list.filter(requester=data['requester'])
-            if data.get('allocation_period'):
-                request_list = request_list.filter(
-                    allocation_period=data['allocation_period'])
+        show_search = user.is_superuser or user.has_perm(permission)
+        context['show_search'] = show_search
 
-        filter_parameters = self.build_filter_parameters(
-            search_form.cleaned_data if search_form.is_valid() else {})
+        form_filter_parameters = ''
+        if show_search:
+            search_form = SavioProjectAllocationRequestSearchForm(self.request.GET)
+            if search_form.is_valid():
+                data = search_form.cleaned_data
+                if data.get('project'):
+                    request_list = request_list.filter(project=data['project'])
+                if data.get('pi'):
+                    request_list = request_list.filter(pi=data['pi'])
+            form_filter_parameters = self.build_filter_parameters(
+                search_form.cleaned_data if search_form.is_valid() else {})
+            context['savio_search_form'] = search_form
+            context['expand_accordion'] = 'show' if form_filter_parameters else ''
+        else:
+            context['expand_accordion'] = ''
+
+        filter_parameters = form_filter_parameters + f'status={status}&'
         order_by = self.request.GET.get('order_by', 'request_time')
         direction = self.request.GET.get('direction', 'des')
         context['filter_parameters'] = filter_parameters
         context['filter_parameters_with_order_by'] = (
             filter_parameters + f'order_by={order_by}&direction={direction}&')
-        context['expand_accordion'] = 'show' if filter_parameters else ''
-        context['savio_search_form'] = search_form
+        context['form_filter_parameters'] = form_filter_parameters
+        context['status'] = status
 
         page_obj = self.paginate(request_list, context)
         context['savio_project_request_list'] = page_obj.object_list
-        context['request_filter'] = (
-            'completed' if self.completed else 'pending')
 
         return context
 

--- a/coldfront/core/project/views_/renewal_views/approval_views.py
+++ b/coldfront/core/project/views_/renewal_views/approval_views.py
@@ -1,8 +1,9 @@
 from coldfront.core.allocation.models import AllocationRenewalRequest
-from coldfront.core.allocation.utils import annotate_queryset_with_allocation_period_not_started_bool
 from coldfront.core.allocation.utils import calculate_service_units_to_allocate
 from coldfront.core.project.forms import ReviewDenyForm
 from coldfront.core.project.forms import ReviewStatusForm
+from coldfront.core.project.forms_.renewal_forms.approval_forms import AllocationRenewalRequestSearchForm
+from coldfront.core.utils.mixins.views import ListFilterMixin
 from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
 from coldfront.core.project.utils_.renewal_utils import AllocationRenewalApprovalRunner
 from coldfront.core.project.utils_.renewal_utils import AllocationRenewalDenialRunner
@@ -42,24 +43,14 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class AllocationRenewalRequestListView(LoginRequiredMixin, TemplateView):
+class AllocationRenewalRequestListView(LoginRequiredMixin, ListFilterMixin,
+                                       TemplateView):
     template_name = 'project/project_renewal/project_renewal_request_list.html'
     completed = False
 
     def get_queryset(self):
-        order_by = self.request.GET.get('order_by')
-        if order_by:
-            direction = self.request.GET.get('direction')
-            if direction == 'asc':
-                direction = ''
-            else:
-                direction = '-'
-            order_by = direction + order_by
-        else:
-            order_by = '-request_time'
-
-        return annotate_queryset_with_allocation_period_not_started_bool(
-            AllocationRenewalRequest.objects.order_by(order_by))
+        return AllocationRenewalRequest.objects.order_by(
+            self.get_order_by(default='-request_time'))
 
     def get_context_data(self, **kwargs):
         """Include either pending or completed requests. If the user is
@@ -67,19 +58,47 @@ class AllocationRenewalRequestListView(LoginRequiredMixin, TemplateView):
         for which the user is a requester or PI."""
         context = super().get_context_data(**kwargs)
 
-        args, kwargs = [], {}
+        filter_args, filter_kwargs = [], {}
 
         request_list = self.get_queryset()
         user = self.request.user
         permission = 'allocation.view_allocationrenewalrequest'
         if not (user.is_superuser or user.has_perm(permission)):
-            args.append(Q(requester=user) | Q(pi=user))
+            filter_args.append(Q(requester=user) | Q(pi=user))
         if self.completed:
-            status__name__in = ['Approved', 'Complete', 'Denied']
+            filter_kwargs['status__name__in'] = ['Approved', 'Complete', 'Denied']
         else:
-            status__name__in = ['Under Review']
-        kwargs['status__name__in'] = status__name__in
-        context['renewal_request_list'] = request_list.filter(*args, **kwargs)
+            filter_kwargs['status__name__in'] = ['Under Review']
+        request_list = request_list.filter(*filter_args, **filter_kwargs)
+
+        search_form = AllocationRenewalRequestSearchForm(self.request.GET)
+        if search_form.is_valid():
+            data = search_form.cleaned_data
+            if data.get('project'):
+                request_list = request_list.filter(
+                    post_project=data['project'])
+            if data.get('pi'):
+                request_list = request_list.filter(
+                    pi=data['pi'])
+            if data.get('requester'):
+                request_list = request_list.filter(
+                    requester=data['requester'])
+            if data.get('allocation_period'):
+                request_list = request_list.filter(
+                    allocation_period=data['allocation_period'])
+
+        filter_parameters = self.build_filter_parameters(
+            search_form.cleaned_data if search_form.is_valid() else {})
+        order_by = self.request.GET.get('order_by', 'request_time')
+        direction = self.request.GET.get('direction', 'des')
+        context['filter_parameters'] = filter_parameters
+        context['filter_parameters_with_order_by'] = (
+            filter_parameters + f'order_by={order_by}&direction={direction}&')
+        context['expand_accordion'] = 'show' if filter_parameters else ''
+        context['renewal_search_form'] = search_form
+
+        page_obj = self.paginate(request_list, context)
+        context['renewal_request_list'] = page_obj.object_list
         context['request_filter'] = (
             'completed' if self.completed else 'pending')
 

--- a/coldfront/core/project/views_/renewal_views/approval_views.py
+++ b/coldfront/core/project/views_/renewal_views/approval_views.py
@@ -4,6 +4,7 @@ from coldfront.core.project.forms import ReviewDenyForm
 from coldfront.core.project.forms import ReviewStatusForm
 from coldfront.core.project.forms_.renewal_forms.approval_forms import AllocationRenewalRequestSearchForm
 from coldfront.core.utils.mixins.views import ListFilterMixin
+from coldfront.core.project.models import Project
 from coldfront.core.project.models import ProjectAllocationRequestStatusChoice
 from coldfront.core.project.utils_.renewal_utils import AllocationRenewalApprovalRunner
 from coldfront.core.project.utils_.renewal_utils import AllocationRenewalDenialRunner
@@ -22,6 +23,7 @@ from coldfront.core.utils.email.email_strategy import EnqueueEmailStrategy
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth.models import User
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.db import transaction
@@ -46,16 +48,22 @@ logger = logging.getLogger(__name__)
 class AllocationRenewalRequestListView(LoginRequiredMixin, ListFilterMixin,
                                        TemplateView):
     template_name = 'project/project_renewal/project_renewal_request_list.html'
-    completed = False
+
+    PENDING_STATUSES = ['Under Review']
+    COMPLETED_STATUSES = ['Approved', 'Complete', 'Denied']
 
     def get_queryset(self):
-        return AllocationRenewalRequest.objects.order_by(
-            self.get_order_by(default='-request_time'))
+        return AllocationRenewalRequest.objects.select_related(
+            'pi', 'post_project', 'status', 'allocation_period',
+        ).order_by(self.get_order_by(default='-request_time'))
 
     def get_context_data(self, **kwargs):
-        """Include either pending or completed requests. If the user is
-        a superuser, show all such requests. Otherwise, show only those
-        for which the user is a requester or PI."""
+        """Include pending, completed, or all requests depending on the
+        status GET parameter. Superusers and users with the
+        view_allocationrenewalrequest permission (e.g. staff) see all
+        requests and have access to the search form. All other users see only
+        requests for which they are the requester or PI, with search
+        hidden."""
         context = super().get_context_data(**kwargs)
 
         filter_args, filter_kwargs = [], {}
@@ -65,42 +73,47 @@ class AllocationRenewalRequestListView(LoginRequiredMixin, ListFilterMixin,
         permission = 'allocation.view_allocationrenewalrequest'
         if not (user.is_superuser or user.has_perm(permission)):
             filter_args.append(Q(requester=user) | Q(pi=user))
-        if self.completed:
-            filter_kwargs['status__name__in'] = ['Approved', 'Complete', 'Denied']
-        else:
-            filter_kwargs['status__name__in'] = ['Under Review']
+
+        status = self.request.GET.get('status', 'pending')
+        if status == 'pending':
+            filter_kwargs['status__name__in'] = self.PENDING_STATUSES
+        elif status == 'completed':
+            filter_kwargs['status__name__in'] = self.COMPLETED_STATUSES
         request_list = request_list.filter(*filter_args, **filter_kwargs)
 
-        search_form = AllocationRenewalRequestSearchForm(self.request.GET)
-        if search_form.is_valid():
-            data = search_form.cleaned_data
-            if data.get('project'):
-                request_list = request_list.filter(
-                    post_project=data['project'])
-            if data.get('pi'):
-                request_list = request_list.filter(
-                    pi=data['pi'])
-            if data.get('requester'):
-                request_list = request_list.filter(
-                    requester=data['requester'])
-            if data.get('allocation_period'):
-                request_list = request_list.filter(
-                    allocation_period=data['allocation_period'])
+        show_search = user.is_superuser or user.has_perm(permission)
+        context['show_search'] = show_search
 
-        filter_parameters = self.build_filter_parameters(
-            search_form.cleaned_data if search_form.is_valid() else {})
+        form_filter_parameters = ''
+        if show_search:
+            search_form = AllocationRenewalRequestSearchForm(self.request.GET)
+            if search_form.is_valid():
+                data = search_form.cleaned_data
+                if data.get('project'):
+                    request_list = request_list.filter(post_project=data['project'])
+                if data.get('pi'):
+                    request_list = request_list.filter(pi=data['pi'])
+                if data.get('allocation_period'):
+                    request_list = request_list.filter(
+                        allocation_period=data['allocation_period'])
+            form_filter_parameters = self.build_filter_parameters(
+                search_form.cleaned_data if search_form.is_valid() else {})
+            context['renewal_search_form'] = search_form
+            context['expand_accordion'] = 'show' if form_filter_parameters else ''
+        else:
+            context['expand_accordion'] = ''
+
+        filter_parameters = form_filter_parameters + f'status={status}&'
         order_by = self.request.GET.get('order_by', 'request_time')
         direction = self.request.GET.get('direction', 'des')
         context['filter_parameters'] = filter_parameters
         context['filter_parameters_with_order_by'] = (
             filter_parameters + f'order_by={order_by}&direction={direction}&')
-        context['expand_accordion'] = 'show' if filter_parameters else ''
-        context['renewal_search_form'] = search_form
+        context['form_filter_parameters'] = form_filter_parameters
+        context['status'] = status
 
         page_obj = self.paginate(request_list, context)
         context['renewal_request_list'] = page_obj.object_list
-        context['request_filter'] = (
-            'completed' if self.completed else 'pending')
 
         return context
 

--- a/coldfront/core/project/views_/renewal_views/approval_views.py
+++ b/coldfront/core/project/views_/renewal_views/approval_views.py
@@ -86,7 +86,8 @@ class AllocationRenewalRequestListView(LoginRequiredMixin, ListFilterMixin,
 
         form_filter_parameters = ''
         if show_search:
-            search_form = AllocationRenewalRequestSearchForm(self.request.GET)
+            search_form = AllocationRenewalRequestSearchForm(
+                self.request.GET, request_queryset=request_list)
             if search_form.is_valid():
                 data = search_form.cleaned_data
                 if data.get('project'):

--- a/coldfront/core/user/templates/request_hub/request_section.html
+++ b/coldfront/core/user/templates/request_hub/request_section.html
@@ -63,7 +63,7 @@
             </div>
           </div>
         {% endwith %}
-        {% if request_obj.button_path %}
+        {% if admin_staff %}
           <div class="card-body">
             <!-- TODO: Compute the URL in the view itself instead of exposing button_path, button_arg1, button_arg2 and using this if-else. -->
             {% if request_obj.button_arg1 and request_obj.button_arg2 %}

--- a/coldfront/core/user/templates/request_hub/request_section.html
+++ b/coldfront/core/user/templates/request_hub/request_section.html
@@ -63,7 +63,7 @@
             </div>
           </div>
         {% endwith %}
-        {% if admin_staff %}
+        {% if request_obj.button_path %}
           <div class="card-body">
             <!-- TODO: Compute the URL in the view itself instead of exposing button_path, button_arg1, button_arg2 and using this if-else. -->
             {% if request_obj.button_arg1 and request_obj.button_arg2 %}

--- a/coldfront/core/user/tests/test_views/test_request_hub_view.py
+++ b/coldfront/core/user/tests/test_views/test_request_hub_view.py
@@ -348,18 +348,14 @@ class TestRequestHubView(TestBase):
             pending_div = str(
                 soup.find(id=f'{section}_pending'))
             self.assertIn(str(pending_req.pk), pending_div)
-            self.assertIn(pending_req.requester.email, pending_div)
             self.assertIn(pending_req.pi.email, pending_div)
-            self.assertIn(self.format_date(pending_req.modified), pending_div)
             self.assertIn(pending_req.status.name, pending_div)
 
             # completed request is shown
             completed_div = str(
                 soup.find(id=f'{section}_completed'))
             self.assertIn(str(completed_req.pk), completed_div)
-            self.assertIn(completed_req.requester.email, completed_div)
             self.assertIn(completed_req.pi.email, completed_div)
-            self.assertIn(self.format_date(completed_req.modified), completed_div)
             self.assertIn(completed_req.status.name, completed_div)
 
         kwargs = {
@@ -545,20 +541,16 @@ class TestRequestHubView(TestBase):
             pending_div = str(
                 soup.find(id=f'{section}_pending'))
             self.assertIn(str(pending_req.pk), pending_div)
-            self.assertIn(pending_req.requester.email, pending_div)
-            self.assertIn(pending_req.pre_project.name, pending_div)
             self.assertIn(pending_req.post_project.name, pending_div)
-            self.assertIn(self.format_date(pending_req.modified), pending_div)
+            self.assertIn(pending_req.pi.email, pending_div)
             self.assertIn(pending_req.status.name, pending_div)
 
             # completed request is shown
             completed_div = str(
                 soup.find(id=f'{section}_completed'))
             self.assertIn(str(completed_req.pk), completed_div)
-            self.assertIn(completed_req.requester.email, completed_div)
-            self.assertIn(completed_req.pre_project.name, completed_div)
             self.assertIn(completed_req.post_project.name, completed_div)
-            self.assertIn(self.format_date(completed_req.modified), completed_div)
+            self.assertIn(completed_req.pi.email, completed_div)
             self.assertIn(completed_req.status.name, completed_div)
         
         kwargs = {

--- a/coldfront/core/user/views_/request_hub_views.py
+++ b/coldfront/core/user/views_/request_hub_views.py
@@ -315,7 +315,7 @@ class RequestHubView(LoginRequiredMixin,
         savio_proj_request_object.table = \
             'project/project_request/savio/project_request_list_table.html'
         savio_proj_request_object.button_path = \
-            'new-project-pending-request-list'
+            'new-project-request-list'
         savio_proj_request_object.button_text = \
             'Go To New Project Requests Main Page'
         savio_proj_request_object.id = 'new_project_request_section'
@@ -449,7 +449,7 @@ class RequestHubView(LoginRequiredMixin,
         proj_renewal_request_object.table = \
             'project/project_renewal/project_renewal_request_list_table.html'
         proj_renewal_request_object.button_path = \
-            'pi-allocation-renewal-pending-request-list'
+            'pi-allocation-renewal-request-list'
         proj_renewal_request_object.button_text = \
             'Go To Project Renewal Requests Main Page'
         proj_renewal_request_object.id = 'project_renewal_request_section'

--- a/coldfront/core/utils/mixins/views.py
+++ b/coldfront/core/utils/mixins/views.py
@@ -2,11 +2,70 @@ import re
 
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db.models import Model, QuerySet
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 
 from coldfront.core.project.models import Project
+
+
+class ListFilterMixin:
+    """Mixin for list views with server-side sorting, filtering, and pagination.
+
+    Centralizes the three pieces of boilerplate duplicated across every
+    request-queue list view: sort-param parsing, filter_parameters string
+    building, and manual Paginator application.
+    """
+
+    paginate_by = 25
+
+    def get_order_by(self, default='-id'):
+        """Return the queryset order_by string derived from GET params."""
+        order_by = self.request.GET.get('order_by')
+        if order_by:
+            direction = '' if self.request.GET.get('direction') == 'asc' else '-'
+            return direction + order_by
+        return default
+
+    def build_filter_parameters(self, data):
+        """Build a ``key=value&`` query string from a dict of filter values.
+
+        Empty/falsy values are omitted. Model instances (from
+        ``ModelChoiceField``) are serialized as their PK. QuerySets (from
+        ``ModelMultipleChoiceField``) emit one ``key=pk`` pair per element.
+        """
+        result = ''
+        for k, v in data.items():
+            if not v and v != 0:
+                continue
+            if isinstance(v, Model):
+                result += f'{k}={v.pk}&'
+            elif isinstance(v, QuerySet):
+                for ele in v:
+                    result += f'{k}={ele.pk}&'
+            else:
+                result += f'{k}={v}&'
+        return result
+
+    def paginate(self, queryset, context):
+        """Apply pagination to *queryset* and populate *context*.
+
+        Sets ``page_obj`` and ``is_paginated`` on the context dict and
+        returns the current ``Page`` object.
+        """
+        paginator = Paginator(queryset, self.paginate_by)
+        page = self.request.GET.get('page')
+        try:
+            page_obj = paginator.page(page)
+        except PageNotAnInteger:
+            page_obj = paginator.page(1)
+        except EmptyPage:
+            page_obj = paginator.page(paginator.num_pages)
+        context['page_obj'] = page_obj
+        context['is_paginated'] = paginator.num_pages > 1
+        return page_obj
 
 
 class SnakeCaseTemplateNameMixin:

--- a/coldfront/templates/common/navbar_admin.html
+++ b/coldfront/templates/common/navbar_admin.html
@@ -55,7 +55,7 @@
                 </li>
                 {% endif %}
 
-                <li><a id="navbar-project-new-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'new-project-pending-request-list' %}">
+                <li><a id="navbar-project-new-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'new-project-request-list' %}">
                   New Project Requests <span class="badge badge-warning">{{ savio_project_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'BRC_ONLY' as brc_only %}
@@ -70,7 +70,7 @@
                 <li><a id="navbar-project-removal-requests" class="dropdown-item navbar-align-badges" href="{% url 'project-removal-request-list' %}">
                   Project Removal Requests <span class="badge badge-warning">{{ project_removal_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item navbar-align-badges" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
+                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item navbar-align-badges" href="{% url 'pi-allocation-renewal-request-list' %}">
                   Project Renewal Requests <span class="badge badge-warning">{{ project_renewal_req_count }}</span>
                 </a></li>
                 {% if secure_dirs_requestable %}

--- a/coldfront/templates/common/navbar_nonadmin_staff.html
+++ b/coldfront/templates/common/navbar_nonadmin_staff.html
@@ -60,7 +60,7 @@
                 </li>
                 {% endif %}
 
-                <li><a id="navbar-project-new-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'new-project-pending-request-list' %}">
+                <li><a id="navbar-project-new-project-requests" class="dropdown-item navbar-align-badges" href="{% url 'new-project-request-list' %}">
                     New Project Requests <span class="badge badge-warning">{{ savio_project_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'BRC_ONLY' as brc_only %}
@@ -75,7 +75,7 @@
                 <li><a id="navbar-project-removal-requests" class="dropdown-item navbar-align-badges" href="{% url 'project-removal-request-list' %}">
                     Project Removal Requests <span class="badge badge-warning">{{ project_removal_req_count }}</span>
                 </a></li>
-                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item navbar-align-badges" href="{% url 'pi-allocation-renewal-pending-request-list' %}">
+                <li><a id="navbar-pi-allocation-renewal-requests" class="dropdown-item navbar-align-badges" href="{% url 'pi-allocation-renewal-request-list' %}">
                     Project Renewal Requests <span class="badge badge-warning">{{ project_renewal_req_count }}</span>
                 </a></li>
                 {% flag_enabled 'SERVICE_UNITS_PURCHASABLE' as service_units_purchasable %}


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

Addresses #584

- Added search, filtering, and pagination to the project renewal and new project request list views (`AllocationRenewalRequestListView`, `SavioProjectRequestListView`).
    - Added a single list view with a `?status=pending/completed` toggle to replace the separate pending/completed views (old URL names are preserved as redirects).
    - The search form is only visible to and functional for superusers and users with the relevant view permission (staff).

## Type of change

 **** Please delete options that are not relevant. ****

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Exercise the views as various users.
- Ensure that the test suite passes.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
