### PR TITLE
Reduce Django test suite runtime via setUpClass optimization

### DIFF
--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -89,13 +89,13 @@ jobs:
       run: |
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
-        pytest coldfront/ -m unit
+        pytest coldfront/ -m unit --durations=30
 
     - name: Run pytest component tests
       run: |
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
-        pytest coldfront/ -m component
+        pytest coldfront/ -m component --durations=30
 
     # - name: Run pytest acceptance tests
     #   run: |
@@ -108,4 +108,6 @@ jobs:
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
         python manage.py migrate
-        python manage.py test
+        python manage.py test \
+          --timing \
+          --testrunner=coldfront.tests.timing_runner.TimingTestRunner

--- a/coldfront/core/billing/tests/test_billing_base.py
+++ b/coldfront/core/billing/tests/test_billing_base.py
@@ -14,10 +14,10 @@ from coldfront.core.project.utils_.renewal_utils import get_current_allowance_ye
 from coldfront.core.resource.utils import get_primary_compute_resource
 from coldfront.core.utils.email.email_strategy import DropEmailStrategy
 from coldfront.core.utils.tests.test_base import enable_deployment
-from coldfront.core.utils.tests.test_base import TestBase
+from coldfront.core.utils.tests.test_base import LRCTestBase
 
 
-class TestBillingBase(TestBase):
+class TestBillingBase(LRCTestBase):
     """A base class for testing Billing-related functionality."""
 
     @enable_deployment('LRC')

--- a/coldfront/core/project/tests/test_utils/test_new_project_user_utils/test_runners.py
+++ b/coldfront/core/project/tests/test_utils/test_new_project_user_utils/test_runners.py
@@ -37,6 +37,7 @@ from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAl
 from coldfront.core.user.models import UserProfile
 from coldfront.core.utils.email.email_strategy import EnqueueEmailStrategy
 from coldfront.core.utils.tests.test_base import enable_deployment
+from coldfront.core.utils.tests.test_base import LRCTestBase
 from coldfront.core.utils.tests.test_base import TestBase
 
 
@@ -58,6 +59,30 @@ class TestNewProjectUserRunner(TestBase):
 
 class TestRunnerBase(TestBase):
     """A base class for testing NewProjectUserRunner classes."""
+
+    def setUp(self):
+        """Set up test data."""
+        super().setUp()
+        self.create_test_user()
+        self.sign_user_access_agreement(self.user)
+
+        computing_allowance_interface = ComputingAllowanceInterface()
+        computing_allowance = self.get_predominant_computing_allowance()
+        prefix = computing_allowance_interface.code_from_name(
+            computing_allowance.name)
+
+        # Create a Project with a computing allowance, along with an 'Active'
+        # ProjectUser.
+        self.project = self.create_active_project_with_pi(
+            f'{prefix}_project', self.user)
+        accounting_allocation_objects = create_project_allocation(
+            self.project, Decimal('0.00'))
+        self.allocation = accounting_allocation_objects.allocation
+        self.project_user = self.project.projectuser_set.get(user=self.user)
+
+
+class LRCTestRunnerBase(LRCTestBase):
+    """A base class for testing LRC NewProjectUserRunner classes."""
 
     def setUp(self):
         """Set up test data."""
@@ -558,7 +583,7 @@ class TestBRCNewProjectUserRunner(TestCommonRunnerMixin, TestRunnerBase):
         },
     }
 )
-class TestLRCNewProjectUserRunner(TestCommonRunnerMixin, TestRunnerBase):
+class TestLRCNewProjectUserRunner(TestCommonRunnerMixin, LRCTestRunnerBase):
     """A class for testing LRCNewProjectUserRunner."""
 
     @enable_deployment('LRC')

--- a/coldfront/core/project/tests/test_utils/test_new_project_utils/test_project_processing_runners.py
+++ b/coldfront/core/project/tests/test_utils/test_new_project_utils/test_project_processing_runners.py
@@ -19,6 +19,7 @@ from coldfront.core.resource.utils_.allowance_utils.constants import LRCAllowanc
 from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
 from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.utils.tests.test_base import enable_deployment
+from coldfront.core.utils.tests.test_base import LRCTestBase
 from coldfront.core.utils.tests.test_base import TestBase
 
 
@@ -131,7 +132,7 @@ class TestBRCProjectProcessingRunner(TestProjectProcessingRunnerMixin,
 
 
 class TestLRCProjectProcessingRunner(TestProjectProcessingRunnerMixin,
-                                     TestBase):
+                                     LRCTestBase):
     """A class for testing SavioProjectProcessingRunner on the LRC
     deployment."""
 

--- a/coldfront/core/project/tests/test_views/test_join_views/test_project_review_join_requests_view.py
+++ b/coldfront/core/project/tests/test_views/test_join_views/test_project_review_join_requests_view.py
@@ -12,6 +12,7 @@ from coldfront.core.billing.models import BillingProject
 from coldfront.core.project.models import ProjectUser, ProjectUserJoinRequest
 from coldfront.core.user.models import UserProfile
 from coldfront.core.utils.tests.test_base import enable_deployment
+from coldfront.core.utils.tests.test_base import LRCTestBase
 from coldfront.core.utils.tests.test_base import TestBase
 
 
@@ -125,7 +126,7 @@ class TestBRCProjectReviewJoinRequestsView(TestViewMixin, TestBase):
         self.assertIsNone(user_profile.billing_activity)
 
 
-class TestLRCProjectReviewJoinRequestsView(TestViewMixin, TestBase):
+class TestLRCProjectReviewJoinRequestsView(TestViewMixin, LRCTestBase):
     """A class for testing ProjectReviewJoinRequestsView on the LRC
     deployment."""
 

--- a/coldfront/core/project/tests/test_views/test_project_add_users_view.py
+++ b/coldfront/core/project/tests/test_views/test_project_add_users_view.py
@@ -11,6 +11,7 @@ from coldfront.core.billing.models import BillingActivity
 from coldfront.core.billing.models import BillingProject
 from coldfront.core.user.models import UserProfile
 from coldfront.core.utils.tests.test_base import enable_deployment
+from coldfront.core.utils.tests.test_base import LRCTestBase
 from coldfront.core.utils.tests.test_base import TestBase
 
 
@@ -56,7 +57,7 @@ class TestBRCProjectAddUsersView(TestProjectAddUsersViewMixin, TestBase):
     # TODO
 
 
-class TestLRCProjectAddUsersView(TestProjectAddUsersViewMixin, TestBase):
+class TestLRCProjectAddUsersView(TestProjectAddUsersViewMixin, LRCTestBase):
     """A class for testing ProjectAddUsersView on the LRC deployment."""
 
     @enable_deployment('LRC')

--- a/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_under_project_view.py
+++ b/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_under_project_view.py
@@ -19,6 +19,7 @@ from coldfront.core.project.utils_.renewal_utils import get_current_allowance_ye
 from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
 from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.utils.tests.test_base import enable_deployment
+from coldfront.core.utils.tests.test_base import LRCTestBase
 from coldfront.core.utils.tests.test_base import TestBase
 
 
@@ -156,7 +157,7 @@ class TestBRCAllocationRenewalRequestUnderProjectView(TestAllocationRenewalReque
 
 
 class TestLRCAllocationRenewalRequestUnderProjectView(TestAllocationRenewalRequestUnderProjectViewMixin,
-                                                      TestBase):
+                                                      LRCTestBase):
     """A class for testing AllocationRenewalRequestUnderProjectView on
     the LRC deployment."""
 

--- a/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_view.py
+++ b/coldfront/core/project/tests/test_views/test_renewal_views/test_allocation_renewal_request_view.py
@@ -20,6 +20,7 @@ from coldfront.core.project.utils_.renewal_utils import get_current_allowance_ye
 from coldfront.core.resource.utils_.allowance_utils.interface import ComputingAllowanceInterface
 from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.utils.tests.test_base import enable_deployment
+from coldfront.core.utils.tests.test_base import LRCTestBase
 from coldfront.core.utils.tests.test_base import TestBase
 
 
@@ -220,7 +221,7 @@ class TestBRCAllocationRenewalRequestView(TestAllocationRenewalRequestViewMixin,
 
 
 class TestLRCAllocationRenewalRequestView(TestAllocationRenewalRequestViewMixin,
-                                          TestBase):
+                                          LRCTestBase):
     """A class for testing AllocationRenewalRequestView on the LRC
     deployment."""
 

--- a/coldfront/core/utils/tests/test_base.py
+++ b/coldfront/core/utils/tests/test_base.py
@@ -42,22 +42,25 @@ class BaseTestMixin(object):
     # A password for convenient reference.
     password = 'password'
 
+    # The deployment whose setup commands are run for this base class.
+    # Subclasses (e.g. LRCTestBase) override this to run a different
+    # deployment's setup commands.
+    _deployment_name = 'BRC'
+
     @classmethod
     def setUpClass(cls):
         """Set up database objects required by all tests in the class.
 
-        Runs call_setup_commands() once per class (for each deployment) rather
-        than once per test method, which is the primary driver of test suite
-        runtime.
+        Runs call_setup_commands() once per class rather than once per test
+        method, which is the primary driver of test suite runtime.
         """
         super().setUpClass()
-        for deployment_name in ('BRC', 'LRC'):
-            deployer = enable_deployment(deployment_name)
-            deployer.enable()
-            try:
-                cls.call_setup_commands()
-            finally:
-                deployer.disable()
+        deployer = enable_deployment(cls._deployment_name)
+        deployer.enable()
+        try:
+            cls.call_setup_commands()
+        finally:
+            deployer.disable()
 
     def setUp(self):
         """Set up per-test state."""
@@ -103,22 +106,7 @@ class BaseTestMixin(object):
     def call_setup_commands():
         """Call the management commands that load required database
         objects."""
-        # Run the setup commands with the BRC_ONLY flag enabled.
-        # TODO: Implement a long-term solution that enables testing of multiple
-        # TODO: types of deployments.
-        # enable_flag('BRC_ONLY', create_boolean_condition=True)
-
-        # Use a savepoint so that a duplicate-key error (when this method is
-        # called more than once per class, e.g. once per deployment in
-        # setUpClass) doesn't corrupt the outer transaction.
-        from django.db import transaction as db_transaction
-        try:
-            with db_transaction.atomic():
-                enable_flag('SERVICE_UNITS_PURCHASABLE', create_boolean_condition=True)
-        except Exception:
-            # Flag DB record already exists; enable_flag already set it in
-            # memory before the save failed, so no further action is needed.
-            pass
+        enable_flag('SERVICE_UNITS_PURCHASABLE', create_boolean_condition=True)
 
         out, err = StringIO(), StringIO()
         commands = [
@@ -216,13 +204,27 @@ class BaseTestMixin(object):
 
 
 class TestBase(BaseTestMixin, TestCase):
-    """A base class for testing the application."""
+    """A base class for testing BRC-deployment functionality."""
     pass
+
+
+class LRCTestBase(BaseTestMixin, TestCase):
+    """A base class for testing LRC-deployment functionality."""
+    _deployment_name = 'LRC'
 
 
 class TransactionTestBase(BaseTestMixin, TransactionTestCase):
     """A base class for testing the application, with real database
     transactions."""
+
+    @classmethod
+    def setUpClass(cls):
+        # TransactionTestCase does not wrap setUpClass in a transaction, so
+        # data created here would be committed and then conflict with setUp's
+        # call_setup_commands() before the first test. Skip
+        # BaseTestMixin.setUpClass entirely; setUp() handles setup for every
+        # test method instead.
+        super(BaseTestMixin, cls).setUpClass()
 
     def setUp(self):
         """Re-run setup commands each test method.
@@ -231,7 +233,12 @@ class TransactionTestBase(BaseTestMixin, TransactionTestCase):
         call_setup_commands() cannot be deferred to setUpClass alone.
         """
         super().setUp()
-        self.call_setup_commands()
+        deployer = enable_deployment(self._deployment_name)
+        deployer.enable()
+        try:
+            self.call_setup_commands()
+        finally:
+            deployer.disable()
 
 
 class enable_deployment(TestContextDecorator):

--- a/coldfront/core/utils/tests/test_base.py
+++ b/coldfront/core/utils/tests/test_base.py
@@ -42,10 +42,26 @@ class BaseTestMixin(object):
     # A password for convenient reference.
     password = 'password'
 
+    @classmethod
+    def setUpClass(cls):
+        """Set up database objects required by all tests in the class.
+
+        Runs call_setup_commands() once per class (for each deployment) rather
+        than once per test method, which is the primary driver of test suite
+        runtime.
+        """
+        super().setUpClass()
+        for deployment_name in ('BRC', 'LRC'):
+            deployer = enable_deployment(deployment_name)
+            deployer.enable()
+            try:
+                cls.call_setup_commands()
+            finally:
+                deployer.disable()
+
     def setUp(self):
-        """Set up test data."""
+        """Set up per-test state."""
         get_computing_allowance_interface.cache_clear()
-        self.call_setup_commands()
         self.client = Client()
 
     def tearDown(self):
@@ -91,7 +107,18 @@ class BaseTestMixin(object):
         # TODO: Implement a long-term solution that enables testing of multiple
         # TODO: types of deployments.
         # enable_flag('BRC_ONLY', create_boolean_condition=True)
-        enable_flag('SERVICE_UNITS_PURCHASABLE', create_boolean_condition=True)
+
+        # Use a savepoint so that a duplicate-key error (when this method is
+        # called more than once per class, e.g. once per deployment in
+        # setUpClass) doesn't corrupt the outer transaction.
+        from django.db import transaction as db_transaction
+        try:
+            with db_transaction.atomic():
+                enable_flag('SERVICE_UNITS_PURCHASABLE', create_boolean_condition=True)
+        except Exception:
+            # Flag DB record already exists; enable_flag already set it in
+            # memory before the save failed, so no further action is needed.
+            pass
 
         out, err = StringIO(), StringIO()
         commands = [
@@ -196,7 +223,15 @@ class TestBase(BaseTestMixin, TestCase):
 class TransactionTestBase(BaseTestMixin, TransactionTestCase):
     """A base class for testing the application, with real database
     transactions."""
-    pass
+
+    def setUp(self):
+        """Re-run setup commands each test method.
+
+        TransactionTestCase flushes the database between test methods, so
+        call_setup_commands() cannot be deferred to setUpClass alone.
+        """
+        super().setUp()
+        self.call_setup_commands()
 
 
 class enable_deployment(TestContextDecorator):

--- a/coldfront/tests/timing_runner.py
+++ b/coldfront/tests/timing_runner.py
@@ -1,0 +1,59 @@
+"""Custom Django test runner that reports per-test timing.
+
+Usage:
+    python manage.py test --testrunner=coldfront.tests.timing_runner.TimingTestRunner
+
+Pair with Django's built-in --timing flag for full breakdown:
+    python manage.py test --timing --testrunner=coldfront.tests.timing_runner.TimingTestRunner
+"""
+import time
+import unittest
+
+from django.test.runner import DiscoverRunner
+
+
+class TimingTestRunner(DiscoverRunner):
+    """A DiscoverRunner that prints a sorted report of the N slowest tests."""
+
+    TOP_N = 50
+
+    def get_resultclass(self):
+        base = super().get_resultclass() or unittest.TextTestResult
+        runner = self
+
+        class TimedResult(base):
+            def startTest(self, test):
+                self._test_start_time = time.monotonic()
+                super().startTest(test)
+
+            def stopTest(self, test):
+                elapsed = time.monotonic() - getattr(
+                    self, '_test_start_time', time.monotonic()
+                )
+                runner._timings.append((elapsed, str(test)))
+                super().stopTest(test)
+
+        return TimedResult
+
+    def run_tests(self, test_labels, **kwargs):
+        self._timings = []
+        failures = super().run_tests(test_labels, **kwargs)
+        self._print_timing_report()
+        return failures
+
+    def _print_timing_report(self):
+        if not self._timings:
+            return
+        timings = sorted(self._timings, reverse=True)
+        n = min(self.TOP_N, len(timings))
+        total = sum(elapsed for elapsed, _ in timings)
+        sep = '=' * 72
+        print(f'\n{sep}')
+        print(
+            f'SLOWEST {n} TESTS '
+            f'(of {len(timings)} total, {total:.1f}s combined)'
+        )
+        print(sep)
+        for elapsed, test_id in timings[:n]:
+            print(f'  {elapsed:7.3f}s  {test_id}')
+        print(sep)


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

- Moved `call_setup_commands()` from `setUp()` (per test method) to `setUpClass()` (once per class), eliminating redundant DB seeding across ~100 test classes. Reduced CI runtime from ~36m to ~29m.
- Introduced `LRCTestBase` to isolate BRC and LRC DB state, preventing silent `Resource` name collisions between deployments. Migrated all LRC-specific test classes.
- Added per-test timing instrumentation to CI (`TimingTestRunner` + `--timing` + `--durations=30`) to surface slow tests on every run.

## Type of change

 **** Please delete options that are not relevant. ****

- Refactor

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Ensure that the test suite passes.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code