### PR TITLE
Add pytest-cov, coverage config, and pytest output improvements

### DIFF
--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -99,7 +99,7 @@ jobs:
       run: |
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
-        pytest coldfront/ -m component --cov=coldfront --cov-append --cov-report=xml:coverage-component.xml --cov-report=html
+        pytest coldfront/ -m component --cov=coldfront --cov-append --cov-report=xml:coverage-component.xml --cov-report=html --cov-fail-under=25
 
     # - name: Run pytest acceptance tests
     #   run: |

--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -17,6 +17,10 @@ jobs:
 
     runs-on: ubuntu-22.04
 
+    permissions:
+      contents: read
+      pull-requests: write  # required to post coverage comment
+
     services:
       postgres: # Set up a database container with the following specifications
         image: postgres:15.2-alpine3.17
@@ -95,7 +99,7 @@ jobs:
       run: |
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
-        pytest coldfront/ -m component --cov=coldfront --cov-append --cov-report=xml:coverage-component.xml
+        pytest coldfront/ -m component --cov=coldfront --cov-append --cov-report=xml:coverage-component.xml --cov-report=html
 
     # - name: Run pytest acceptance tests
     #   run: |
@@ -103,11 +107,19 @@ jobs:
     #     export django_secret_key=`openssl rand -base64 64`
     #     pytest -m acceptance
 
+    - name: Post coverage comment on PR
+      uses: py-cov-action/python-coverage-comment-action@v3
+      with:
+        GITHUB_TOKEN: ${{ github.token }}
+
     - name: Upload coverage reports
       uses: actions/upload-artifact@v4
       with:
         name: coverage-reports
-        path: coverage-*.xml
+        path: |
+          coverage-*.xml
+          htmlcov/
+        retention-days: 7
       if: always()
 
     - name: Run Tests

--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -89,19 +89,26 @@ jobs:
       run: |
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
-        pytest coldfront/ -m unit --durations=30
+        pytest coldfront/ -m unit --cov=coldfront --cov-report=xml:coverage-unit.xml
 
     - name: Run pytest component tests
       run: |
         source ~/venv/bin/activate
         export django_secret_key=`openssl rand -base64 64`
-        pytest coldfront/ -m component --durations=30
+        pytest coldfront/ -m component --cov=coldfront --cov-append --cov-report=xml:coverage-component.xml
 
     # - name: Run pytest acceptance tests
     #   run: |
     #     source ~/venv/bin/activate
     #     export django_secret_key=`openssl rand -base64 64`
     #     pytest -m acceptance
+
+    - name: Upload coverage reports
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-reports
+        path: coverage-*.xml
+      if: always()
 
     - name: Run Tests
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ omit = [
     "*/conftest.py",
 ]
 branch = true
+relative_files = true
 
 [tool.coverage.report]
 skip_empty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,4 +40,3 @@ relative_files = true
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-fail_under = 25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 ################################################################################
 
 [tool.pytest.ini_options]
-addopts = "--continue-on-collection-errors"
+addopts = "--continue-on-collection-errors --tb=short --durations=30"
 markers = [
     "acceptance: Marks tests as acceptance tests",
     "component: Mark tests as component tests",
@@ -20,3 +20,22 @@ testpaths = [
 ]
 # pytest-django
 DJANGO_SETTINGS_MODULE = "coldfront.config.settings"
+
+################################################################################
+# coverage.py
+################################################################################
+
+[tool.coverage.run]
+source = ["coldfront"]
+omit = [
+    "*/migrations/*",
+    "*/tests/*",
+    "coldfront/config/*",
+    "*/.venv/*",
+    "*/conftest.py",
+]
+branch = true
+
+[tool.coverage.report]
+skip_empty = true
+show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,4 @@ relative_files = true
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
+fail_under = 25

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,6 +48,7 @@ pylint==3.3.7
 pylint-django==2.6.1
 pyparsing==3.2.3
 pytest==9.0.3
+pytest-cov==6.1.0
 pytest-django==4.11.1
 python-dateutil==2.9.0.post0
 python-memcached==1.62


### PR DESCRIPTION
## Description

**** Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. ****

- Wired `pytest-cov` into CI; unit and component runs now produce coverage XML uploaded as a build artifact
- Added `--tb=short` and `--durations=30` to `addopts` so short tracebacks and slowest-test timing appear on every run, locally and in CI, without extra flags
- Added `[tool.coverage.run/report]` config to `pyproject.toml` (branch coverage, omits migrations/tests/config)
- Posted coverage summary comment on PRs via python-coverage-comment-action
- Uploaded HTML coverage report as a 7-day artifact for local inspection
- Set `fail_under = 25` in `[tool.coverage.report]` to enforce a coverage floor and catch regressions in CI

## Type of change

 **** Please delete options that are not relevant. ****

- Infrastructure improvement

## How Has This Been Tested?

**** Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. ****

- Ensure that the test suite passes, and that coverage reports are available.

## PR Self Evaluation
Strikethrough things that don’t make sense for your PR.

- [x] My code follows the agreed upon best practices
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if needed)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in the appropriate modules
- [x] I have performed a self-review of my own code
