### PR TITLE
chore: split dev dependencies and set coverage threshold

### DIFF
--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -121,6 +121,7 @@ jobs:
         source ~/venv/bin/activate
         coverage html
         coverage xml -o coverage-combined.xml
+        coverage report --fail-under=50
 
     - name: Post coverage comment on PR
       uses: py-cov-action/python-coverage-comment-action@v3

--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -56,14 +56,14 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/venv
-        key: ${{ runner.os }}-python-313-packages-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-python-313-packages-${{ hashFiles('requirements.txt', 'requirements-test.txt') }}
 
     - if: ${{ steps.cache-python.outputs.cache-hit != 'true' }} # If a cache is not found
       name: Install Python packages
       run: |
         python3.13 -m venv ~/venv
         source ~/venv/bin/activate
-        pip install -r requirements.txt
+        pip install -r requirements.txt -r requirements-test.txt
 
     - name: Create settings files from samples and other directories needed for testing
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,13 @@ FROM coldfront-os AS coldfront-app-base
 
 WORKDIR /var/www/coldfront_app/coldfront
 
-COPY requirements.txt .
+COPY requirements.txt requirements-test.txt ./
 
 RUN python3 -m venv /var/www/coldfront_app/venv
 
 RUN /var/www/coldfront_app/venv/bin/pip install --upgrade pip wheel && \
     /var/www/coldfront_app/venv/bin/pip install setuptools && \
-    /var/www/coldfront_app/venv/bin/pip install -r requirements.txt
+    /var/www/coldfront_app/venv/bin/pip install -r requirements.txt -r requirements-test.txt
 
 ENV PATH="/var/www/coldfront_app/venv/bin:$PATH"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 ################################################################################
 
 [tool.pytest.ini_options]
-addopts = "--continue-on-collection-errors --tb=short --durations=30"
+addopts = "--continue-on-collection-errors --tb=short --durations=30 --timeout=30"
 markers = [
     "acceptance: Marks tests as acceptance tests",
     "component: Mark tests as component tests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,4 +40,3 @@ relative_files = true
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
-fail_under = 50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,4 @@ relative_files = true
 [tool.coverage.report]
 skip_empty = true
 show_missing = true
+fail_under = 50

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-pre-commit
+pre-commit==4.2.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,10 @@
+coverage==7.13.5
+factory-boy==3.3.3
+Faker==37.5.3
+pylint==3.3.7
+pylint-django==2.6.1
+pytest==9.0.3
+pytest-cov==6.1.0
+pytest-django==4.11.1
+pytest-randomly==4.0.1
+pytest-timeout==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ arrow==1.3.0
 beautifulsoup4==4.13.4
 bibtexparser==1.4.4
 chardet==7.4.3
-coverage==7.13.5
 crispy-bootstrap4==2025.6
 Django==5.2.14
 django-allauth==65.13.0
@@ -32,8 +31,6 @@ djangorestframework==3.17.1
 doi2bib==0.4.0
 drf-nested-routers==0.95.0
 drf-yasg==1.21.15
-factory-boy==3.3.3
-Faker==37.5.3
 gspread==6.2.1
 humanize==4.12.3
 idna==3.10
@@ -44,12 +41,7 @@ oauth2client==4.1.3
 openpyxl==3.1.5
 phonenumbers==9.0.10
 psycopg2-binary==2.9.10
-pylint==3.3.7
-pylint-django==2.6.1
 pyparsing==3.2.3
-pytest==9.0.3
-pytest-cov==6.1.0
-pytest-django==4.11.1
 python-dateutil==2.9.0.post0
 python-memcached==1.62
 pytz==2026.1.post1


### PR DESCRIPTION
## Summary

- Moved `coverage`, `factory-boy`, `Faker`, `pylint`, `pylint-django`, `pytest`, `pytest-cov`, and `pytest-django` out of `requirements.txt`
- Added `requirements-dev.txt` for host-only tooling (`pre-commit==4.2.0`); intentionally minimal so it installs on any Python version pre-commit supports
- Added `requirements-test.txt` for CI/Docker test and lint packages; Docker and CI install both `requirements.txt` and `requirements-test.txt`
- Added `pytest-randomly==4.0.1` and `pytest-timeout==2.4.0` to `requirements-test.txt`
- Updated Dockerfile `coldfront-app-base` to `COPY` and install both requirements files
- Updated CI cache key and install step to reference `requirements-test.txt`
- Added `--timeout=30` to pytest `addopts` for `pytest-timeout`
- Set `fail_under = 50` in `[tool.coverage.report]` based on 54% baseline from first combined coverage run

## Testing

- Run `pip install -r requirements-dev.txt` on host to verify it installs without errors on older Python
- Run `pytest -m unit` inside Docker to confirm test packages are still available after the split
- CI build will validate the full suite and enforce the combined coverage threshold

## Notes

- `fail_under = 50` gives ~4% headroom below the 54% baseline; raise as coverage improves
