### PR TITLE
ci: split core.project shard into views and non-views

### DIFF
--- a/.github/workflows/django_testing_ci.yml
+++ b/.github/workflows/django_testing_ci.yml
@@ -20,7 +20,7 @@ jobs:
   # ─── Coverage strategy ───────────────────────────────────────────────────────
   #
   # Each test job writes its coverage data to a unique coverage-<shard> file,
-  # then uploads it as an artifact.  The `report` job downloads all four files,
+  # then uploads it as an artifact.  The `report` job downloads all five files,
   # runs `coverage combine`, and generates the combined HTML + XML report.
   #
   # Shared setup (checkout, Python, venv, settings) lives in the composite
@@ -82,10 +82,10 @@ jobs:
           path: coverage-pytest
         if: always()
 
-  # ─── Django: core.project ────────────────────────────────────────────────────
-  # ~293 test methods — roughly one-third of the full Django suite.
+  # ─── Django: core.project views ──────────────────────────────────────────────
+  # ~143 test methods — view tests only.
 
-  test-django-project:
+  test-django-project-views:
     runs-on: ubuntu-22.04
 
     permissions:
@@ -111,7 +111,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/coldfront-setup
 
-      - name: Run Django tests (core.project)
+      - name: Run Django tests (core.project - views)
         run: |
           source ~/venv/bin/activate
           export django_secret_key=`openssl rand -base64 64`
@@ -119,17 +119,69 @@ jobs:
           coverage run manage.py test \
             --timing \
             --testrunner=coldfront.tests.timing_runner.TimingTestRunner \
-            coldfront.core.project
+            coldfront.core.project.tests.test_views
 
       - name: Rename coverage data
         if: always()
-        run: mv .coverage coverage-django-project || true
+        run: mv .coverage coverage-django-project-views || true
 
-      - name: Upload Django project coverage data
+      - name: Upload Django project views coverage data
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-data-django-project
-          path: coverage-django-project
+          name: coverage-data-django-project-views
+          path: coverage-django-project-views
+        if: always()
+
+  # ─── Django: core.project non-views ──────────────────────────────────────────
+  # ~151 test methods — commands, forms, and utils.
+
+  test-django-project-other:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: read
+
+    services:
+      postgres:
+        image: postgres:15.2-alpine3.17
+        env:
+          POSTGRES_DB: cf_brc_db
+          POSTGRES_PASSWORD: test
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/coldfront-setup
+
+      - name: Run Django tests (core.project - commands, forms, utils)
+        run: |
+          source ~/venv/bin/activate
+          export django_secret_key=`openssl rand -base64 64`
+          python manage.py migrate
+          coverage run manage.py test \
+            --timing \
+            --testrunner=coldfront.tests.timing_runner.TimingTestRunner \
+            coldfront.core.project.tests.test_commands \
+            coldfront.core.project.tests.test_forms \
+            coldfront.core.project.tests.test_utils
+
+      - name: Rename coverage data
+        if: always()
+        run: mv .coverage coverage-django-project-other || true
+
+      - name: Upload Django project other coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-data-django-project-other
+          path: coverage-django-project-other
         if: always()
 
   # ─── Django: api.* ───────────────────────────────────────────────────────────
@@ -243,11 +295,11 @@ jobs:
         if: always()
 
   # ─── Report ──────────────────────────────────────────────────────────────────
-  # Runs after all four test jobs (even if one fails) to combine coverage data,
+  # Runs after all five test jobs (even if one fails) to combine coverage data,
   # post the PR comment, and upload the combined report artifact.
 
   report:
-    needs: [test-pytest, test-django-project, test-django-api, test-django-core]
+    needs: [test-pytest, test-django-project-views, test-django-project-other, test-django-api, test-django-core]
     if: always()
     runs-on: ubuntu-22.04
 

--- a/coldfront/core/project/tests/test_commands/test_add_service_units_to_project.py
+++ b/coldfront/core/project/tests/test_commands/test_add_service_units_to_project.py
@@ -10,6 +10,8 @@ from coldfront.core.project.models import Project, ProjectStatusChoice, \
 from coldfront.core.project.tests.test_commands.test_service_units_base import \
     TestSUBase
 from coldfront.core.resource.models import Resource
+from coldfront.core.resource.utils_.allowance_utils.interface import \
+    get_computing_allowance_interface
 from coldfront.core.utils.common import utc_now_offset_aware
 
 
@@ -29,10 +31,15 @@ class TestAddServiceUnitsToProject(TestSUBase):
         user_role = ProjectUserRoleChoice.objects.get(name='User')
         manager_role = ProjectUserRoleChoice.objects.get(name='Manager')
 
+        computing_allowance_interface = get_computing_allowance_interface()
+        predominant_allowance = self.get_predominant_computing_allowance()
+        project_name_prefix = computing_allowance_interface.code_from_name(
+            predominant_allowance.name)
+
         for i in range(2):
-            # Create an ICA Project and ProjectUsers.
+            # Create a Project and ProjectUsers.
             project = Project.objects.create(
-                name=f'project{i}', status=project_status)
+                name=f'{project_name_prefix}project{i}', status=project_status)
             setattr(self, f'project{i}', project)
             for j in range(2):
                 ProjectUser.objects.create(
@@ -53,41 +60,39 @@ class TestAddServiceUnitsToProject(TestSUBase):
 
     def test_dry_run(self):
         """Testing add_service_units_to_project dry run"""
-        output, error = self.call_command('add_service_units_to_project',
-                                          '--project_name=project0',
-                                          '--amount=1000',
-                                          f'--reason={self.reason}',
-                                          '--dry_run')
-
         dry_run_message = (
-            f'Would add 1000 SUs for Project project0 and its users, '
+            f'Would add 1000 SUs for Project {self.project0.name} and its users, '
             f'increasing its SUs from 1000.00 to 2000.00, with reason '
             f'"{self.reason}".')
 
-        self.assertIn(dry_run_message, output)
-        self.assertEqual(error, '')
+        with self.assertLogs('coldfront.commands', level='INFO') as cm:
+            self.call_command('add_service_units_to_project',
+                              f'--project_name={self.project0.name}',
+                              '--amount=1000',
+                              f'--reason={self.reason}',
+                              '--dry_run')
+        self.assertTrue(any(dry_run_message in r.message for r in cm.records))
 
     def test_creates_and_updates_objects_positive_SU(self):
         """Testing add_service_units_to_project with positive SUs"""
         # test allocation values before command
-        project = Project.objects.get(name='project0')
+        project = self.project0
         pre_time = utc_now_offset_aware()
         pre_length_dict = self.record_historical_objects_len(project)
 
         self.allocation_values_test(project, '1000.00', '500.00')
 
-        # run command
-        output, error = self.call_command('add_service_units_to_project',
-                                          '--project_name=project0',
-                                          '--amount=1000',
-                                          f'--reason={self.reason}')
-
         message = (
-            f'Added 1000 SUs for Project project0 and its users, increasing '
+            f'Added 1000 SUs for Project {project.name} and its users, increasing '
             f'its SUs from 1000.00 to 2000.00, with reason "{self.reason}".')
 
-        self.assertIn(message, output)
-        self.assertEqual(error, '')
+        # run command
+        with self.assertLogs('coldfront.commands', level='INFO') as cm:
+            self.call_command('add_service_units_to_project',
+                              f'--project_name={project.name}',
+                              '--amount=1000',
+                              f'--reason={self.reason}')
+        self.assertTrue(any(message in r.message for r in cm.records))
 
         post_time = utc_now_offset_aware()
 
@@ -105,24 +110,23 @@ class TestAddServiceUnitsToProject(TestSUBase):
     def test_creates_and_updates_objects_negative_SU(self):
         """Testing add_service_units_to_project with negative SUs"""
         # test allocation values before command
-        project = Project.objects.get(name='project0')
+        project = self.project0
         pre_time = utc_now_offset_aware()
         pre_length_dict = self.record_historical_objects_len(project)
 
         self.allocation_values_test(project, '1000.00', '500.00')
 
-        # run command
-        output, error = self.call_command('add_service_units_to_project',
-                                          '--project_name=project0',
-                                          '--amount=-800',
-                                          f'--reason={self.reason}')
-
         message = (
-            f'Added -800 SUs for Project project0 and its users, decreasing '
+            f'Added -800 SUs for Project {project.name} and its users, decreasing '
             f'its SUs from 1000.00 to 200.00, with reason "{self.reason}".')
 
-        self.assertIn(message, output)
-        self.assertEqual(error, '')
+        # run command
+        with self.assertLogs('coldfront.commands', level='INFO') as cm:
+            self.call_command('add_service_units_to_project',
+                              f'--project_name={project.name}',
+                              '--amount=-800',
+                              f'--reason={self.reason}')
+        self.assertTrue(any(message in r.message for r in cm.records))
 
         post_time = utc_now_offset_aware()
 
@@ -141,7 +145,7 @@ class TestAddServiceUnitsToProject(TestSUBase):
         """
         Tests that validate_inputs throws errors in the correct situations
         """
-        project = Project.objects.get(name='project1')
+        project = self.project1
         allocation = Allocation.objects.get(project=project)
 
         # clear resources from allocation
@@ -160,62 +164,44 @@ class TestAddServiceUnitsToProject(TestSUBase):
         # The command should throw a CommandError because the allocation is not
         # to the primary compute Resource.
         with self.assertRaises(CommandError):
-            output, error = \
-                self.call_command('add_service_units_to_project',
-                                  '--project_name=project1',
-                                  '--amount=1000',
-                                  f'--reason={self.reason}')
-            self.assertEqual(output, '')
-            self.assertEqual(error, '')
+            self.call_command('add_service_units_to_project',
+                              f'--project_name={project.name}',
+                              '--amount=1000',
+                              f'--reason={self.reason}')
 
         # testing a project that does not exist
         with self.assertRaises(CommandError):
-            output, error = \
-                self.call_command('add_service_units_to_project',
-                                  '--project_name=project555',
-                                  '--amount=1000',
-                                  f'--reason={self.reason}')
-            self.assertEqual(output, '')
-            self.assertEqual(error, '')
+            self.call_command('add_service_units_to_project',
+                              '--project_name=project555',
+                              '--amount=1000',
+                              f'--reason={self.reason}')
 
         # adding service units that results in allocation having less
         # than settings.ALLOCATION_MIN
         with self.assertRaises(CommandError):
-            output, error = \
-                self.call_command('add_service_units_to_project',
-                                  '--project_name=project0',
-                                  '--amount=-100000',
-                                  f'--reason={self.reason}')
-            self.assertEqual(output, '')
-            self.assertEqual(error, '')
+            self.call_command('add_service_units_to_project',
+                              f'--project_name={self.project0.name}',
+                              '--amount=-100000',
+                              f'--reason={self.reason}')
 
         # adding service units that results in allocation having more
         # than settings.ALLOCATION_MAX
         with self.assertRaises(CommandError):
-            output, error = \
-                self.call_command('add_service_units_to_project',
-                                  '--project_name=project0',
-                                  '--amount=99999500',
-                                  f'--reason={self.reason}')
-            self.assertEqual(output, '')
-            self.assertEqual(error, '')
+            self.call_command('add_service_units_to_project',
+                              f'--project_name={self.project0.name}',
+                              '--amount=99999500',
+                              f'--reason={self.reason}')
 
         # adding service units that are greater than settings.ALLOCATION_MAX
         with self.assertRaises(CommandError):
-            output, error = \
-                self.call_command('add_service_units_to_project',
-                                  '--project_name=project0',
-                                  '--amount=500000000',
-                                  f'--reason={self.reason}')
-            self.assertEqual(output, '')
-            self.assertEqual(error, '')
+            self.call_command('add_service_units_to_project',
+                              f'--project_name={self.project0.name}',
+                              '--amount=500000000',
+                              f'--reason={self.reason}')
 
         # reason is not long enough
         with self.assertRaises(CommandError):
-            output, error = \
-                self.call_command('add_service_units_to_project',
-                                  '--project_name=project0',
-                                  '--amount=1000',
-                                  '--reason=notlong')
-            self.assertEqual(output, '')
-            self.assertEqual(error, '')
+            self.call_command('add_service_units_to_project',
+                              f'--project_name={self.project0.name}',
+                              '--amount=1000',
+                              '--reason=notlong')

--- a/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_deactivate_ica_projects.py
@@ -11,7 +11,8 @@ from coldfront.core.allocation.models import AllocationAttributeUsage, \
 from coldfront.core.project.models import Project, ProjectStatusChoice, \
     ProjectUserStatusChoice, ProjectUserRoleChoice, ProjectUser
 from coldfront.core.allocation.utils import get_project_compute_allocation
-from coldfront.core.utils.common import utc_now_offset_aware
+from coldfront.core.utils.common import display_time_zone_current_date, \
+    utc_now_offset_aware
 from coldfront.core.project.tests.test_commands.test_service_units_base import TestSUBase
 
 
@@ -76,7 +77,7 @@ class TestDeactivateICAProjects(TestSUBase):
         """Tests that the project and allocation were correctly updated"""
         self.assertEqual(project.status.name, 'Inactive')
         self.assertEqual(allocation.status.name, 'Expired')
-        self.assertTrue(pre_time.date() <= allocation.start_date <= post_time.date())
+        self.assertEqual(allocation.start_date, display_time_zone_current_date())
         self.assertTrue(allocation.end_date is None)
 
     def usage_values_updated(self, project, updated_value):
@@ -101,34 +102,32 @@ class TestDeactivateICAProjects(TestSUBase):
 
     def test_dry_run_no_expired_projects(self):
         """Testing a dry run in which no ICA projects are expired"""
-        output, error = self.call_command('deactivate_ica_projects',
-                                          '--dry_run',
-                                          '--send_emails')
-        self.assertIn(output, '')
-        self.assertEqual(error, '')
+        with self.assertNoLogs('coldfront.commands', level='INFO'):
+            self.call_command('deactivate_ica_projects',
+                              '--dry_run',
+                              '--send_emails')
 
     def test_dry_run_with_expired_projects(self):
         """Testing a dry run in which an ICA project is expired"""
         self.create_expired_project('ic_project0')
 
-        output, error = self.call_command('deactivate_ica_projects',
-                                          '--dry_run',
-                                          '--send_emails')
-
         project = Project.objects.get(name='ic_project0')
         allocation = get_project_compute_allocation(project)
 
-        # Messages that should be output to stdout during a dry run
+        # Messages that should be logged during a dry run
         messages = [
             (f'Would deactivate Project {project.name} ({project.pk}), update '
              f'Allocation {allocation.pk}, and update Service Units from '
              f'1000.00 to 0.00.'),
             'Would send a notification email to 1 user.',
         ]
-        for message in messages:
-            self.assertIn(message, output)
 
-        self.assertEqual(error, '')
+        with self.assertLogs('coldfront.commands', level='INFO') as cm:
+            self.call_command('deactivate_ica_projects',
+                              '--dry_run',
+                              '--send_emails')
+        for message in messages:
+            self.assertTrue(any(message in r.message for r in cm.records))
 
     def test_creates_and_updates_objects(self):
         """Testing deactivate_ica_projects WITHOUT send_emails flag"""
@@ -144,16 +143,13 @@ class TestDeactivateICAProjects(TestSUBase):
         self.allocation_values_test(project, '1000.00', '500.00')
 
         # run command
-        output, error = self.call_command('deactivate_ica_projects')
-
-        messages = [
-            (f'Deactivated Project {project.name} ({project.pk}), updated '
-             f'Allocation {allocation.pk}, and updated Service Units from '
-             f'1000.00 to 0.00.'),
-        ]
-        for message in messages:
-            self.assertIn(message, output)
-        self.assertEqual(error, '')
+        message = (
+            f'Deactivated Project {project.name} ({project.pk}), updated '
+            f'Allocation {allocation.pk}, and updated Service Units from '
+            f'1000.00 to 0.00.')
+        with self.assertLogs('coldfront.commands', level='INFO') as cm:
+            self.call_command('deactivate_ica_projects')
+        self.assertTrue(any(message in r.message for r in cm.records))
 
         post_time = utc_now_offset_aware()
         project.refresh_from_db()
@@ -190,19 +186,15 @@ class TestDeactivateICAProjects(TestSUBase):
         allocation = get_project_compute_allocation(project)
         old_end_date = allocation.end_date
 
-        # run command
-        output, error = self.call_command('deactivate_ica_projects',
-                                          '--send_emails')
-
         recipients = project.managers_and_pis_emails()
         num_recipients = len(recipients)
         assert num_recipients == 1
 
-        # Testing that the correct text is output to stdout
+        # run command
         message = f'Sent a notification email to {num_recipients} user.'
-
-        self.assertIn(message, output)
-        self.assertEqual(error, '')
+        with self.assertLogs('coldfront.commands', level='INFO') as cm:
+            self.call_command('deactivate_ica_projects', '--send_emails')
+        self.assertTrue(any(message in r.message for r in cm.records))
 
         # Testing that the correct number of emails were sent
         self.assertEqual(len(mail.outbox), num_recipients)

--- a/coldfront/core/project/tests/test_commands/test_projects.py
+++ b/coldfront/core/project/tests/test_commands/test_projects.py
@@ -156,15 +156,15 @@ class TestProjectsRenew(TestProjectsBase):
         """Test that the request would be successful but the dry run
         ensures that the project is not updated."""
         project = Project.objects.get(name=self.project_name)
-        self.assertEqual(project.status, 
+        self.assertEqual(project.status,
                          ProjectStatusChoice.objects.get(name='Inactive'))
-        output, error = self._command.renew(
-            self.project_name, self.current_ica_period, self.user.username,
-            self.user.username, dry_run=True)
-        
-        self.assertFalse(error)
 
-        self.assertIn('Would renew', output)
+        with self.assertLogs('coldfront.commands', level='INFO') as cm:
+            self._command.renew(
+                self.project_name, self.current_ica_period, self.user.username,
+                self.user.username, dry_run=True)
+        self.assertTrue(any('Would renew' in r.message for r in cm.records))
+
         self.service_units_attribute.refresh_from_db()
         self.assertEqual(
             Decimal(self.service_units_attribute.value),

--- a/coldfront/core/project/tests/test_commands/test_service_units_base.py
+++ b/coldfront/core/project/tests/test_commands/test_service_units_base.py
@@ -133,7 +133,7 @@ class TestSUBase(TestBase):
 
         alloc_attr_hist_reason = \
             allocation_objects.allocation_attribute.history. \
-                latest('id').history_change_reason
+                latest('history_id').history_change_reason
         self.assertEqual(alloc_attr_hist_reason, reason)
 
         for project_user in project.projectuser_set.all():
@@ -145,5 +145,5 @@ class TestSUBase(TestBase):
 
             alloc_attr_hist_reason = \
                 allocation_user_obj.allocation_user_attribute.history.latest(
-                    'id').history_change_reason
+                    'history_id').history_change_reason
             self.assertEqual(alloc_attr_hist_reason, reason)


### PR DESCRIPTION
## Summary

- Split `test-django-project` (18m 45s, the pipeline bottleneck) into two
  concurrent jobs:
  - `test-django-project-views`: `test_views/` (~143 test methods)
  - `test-django-project-other`: `test_commands/`, `test_forms/`,
    `test_utils/` (~151 test methods)
- Added missing `__init__.py` to `coldfront/core/project/tests/test_commands/`
  so Django's test runner can address it as a dotted module path
- Updated `report` job `needs` list to depend on both new jobs
- Fixed the 20 `test_commands` tests that became discoverable for the first
  time after the `__init__.py` was added (4 test files, 4 root causes —
  see commit for details)

## Testing

- Confirm both new jobs appear and run concurrently in the Actions tab
- Confirm the `report` job still runs and posts a combined coverage comment
- Check per-job durations — target is each new shard finishing in ~9–10
  minutes; re-balance if one side dominates