### PR TITLE
feat(user): add DEV_AUTH_ENABLED flag and passwordless dev login

### DIFF
--- a/bootstrap/ansible/.env.tmpl
+++ b/bootstrap/ansible/.env.tmpl
@@ -208,6 +208,7 @@ HPCS__DJANGO_DEBUG_TOOLBAR_INTERNAL_IPS={{ debug_toolbar_ips | join(',') }}
 
 DJANGO_FLAGS__ALLOCATION_RENEWAL_FOR_NEXT_PERIOD_REQUESTABLE_VALUE={{ flag_next_period_renewal_requestable_month }}
 DJANGO_FLAGS__BASIC_AUTH_ENABLED_VALUE={{ flag_basic_auth_enabled | lower }}
+DJANGO_FLAGS__DEV_AUTH_ENABLED_VALUE={{ flag_dev_auth_enabled | default(false) | lower }}
 DJANGO_FLAGS__BRC_ONLY_VALUE={{ flag_brc_enabled | default(false) | lower }}
 DJANGO_FLAGS__LINK_LOGIN_ENABLED_VALUE={{ flag_link_login_enabled | default(false) | lower }}
 DJANGO_FLAGS__LRC_ONLY_VALUE={{ flag_lrc_enabled | default(false) | lower }}

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -175,6 +175,9 @@ cilogon_app_secret: ""
 
 # TODO: For LRC, disable link login.
 flag_basic_auth_enabled: False
+# Whether to enable dev-only passwordless login. Must not be
+# enabled in production.
+flag_dev_auth_enabled: False
 flag_sso_enabled: True
 flag_link_login_enabled: True
 

--- a/bootstrap/development/docker/config/brc_defaults.yml
+++ b/bootstrap/development/docker/config/brc_defaults.yml
@@ -1,4 +1,4 @@
-db_name: cf_brc_db 
+db_name: cf_brc_db
 
 log_path: /var/log/user_portals/cf_mybrc
 portal_log_file: cf_mybrc_portal.log
@@ -7,9 +7,6 @@ logrotate_entry_name: cf_mybrc
 wsgi_conf_file_name: cf_mybrc_wsgi.conf
 wsgi_conf_log_prefix: cf_brc
 
-flag_basic_auth_enabled: False
-flag_sso_enabled: True
-flag_link_login_enabled: True
 flag_brc_enabled: True
 flag_lrc_enabled: False
 flag_next_period_renewal_requestable_month: 5

--- a/bootstrap/development/docker/config/docker_defaults.yml
+++ b/bootstrap/development/docker/config/docker_defaults.yml
@@ -22,3 +22,8 @@ admin_email: developer@localhost
 allocation_period_audit_email_admin_list: ['developer@localhost']
 
 renewal_survey_backend: 'permissive'
+
+flag_basic_auth_enabled: False
+flag_dev_auth_enabled: True
+flag_sso_enabled: False
+flag_link_login_enabled: False

--- a/bootstrap/development/docker/config/lrc_defaults.yml
+++ b/bootstrap/development/docker/config/lrc_defaults.yml
@@ -7,8 +7,6 @@ logrotate_entry_name: cf_mylrc
 wsgi_conf_file_name: cf_mylrc_wsgi.conf
 wsgi_conf_log_prefix: cf_lrc
 
-flag_basic_auth_enabled: False
-flag_sso_enabled: True
 flag_link_login_enabled: False
 flag_brc_enabled: False
 flag_lrc_enabled: True

--- a/coldfront/config/env_settings.py
+++ b/coldfront/config/env_settings.py
@@ -305,6 +305,13 @@ FLAGS = {
                 'DJANGO_FLAGS__BASIC_AUTH_ENABLED_VALUE', default=False),
         },
     ],
+    'DEV_AUTH_ENABLED': [
+        {
+            'condition': 'boolean',
+            'value': env.bool(
+                'DJANGO_FLAGS__DEV_AUTH_ENABLED_VALUE', default=False),
+        },
+    ],
     'BRC_ONLY': [
         {
             'condition': 'boolean',
@@ -392,16 +399,22 @@ FLAGS = {
 if not (FLAGS['BRC_ONLY'][0]['value'] ^ FLAGS['LRC_ONLY'][0]['value']):
     raise ImproperlyConfigured(
         'Exactly one of BRC_ONLY, LRC_ONLY should be enabled.')
-if not (
-        FLAGS['BASIC_AUTH_ENABLED'][0]['value'] ^
-        FLAGS['SSO_ENABLED'][0]['value']):
+if sum([
+        FLAGS['BASIC_AUTH_ENABLED'][0]['value'],
+        FLAGS['SSO_ENABLED'][0]['value'],
+        FLAGS['DEV_AUTH_ENABLED'][0]['value'],
+]) != 1:
     raise ImproperlyConfigured(
-        'Exactly one of BASIC_AUTH_ENABLED, SSO_ENABLED should be enabled.')
+        'Exactly one of BASIC_AUTH_ENABLED, SSO_ENABLED, '
+        'DEV_AUTH_ENABLED must be enabled.')
 if (not FLAGS['SSO_ENABLED'][0]['value'] and
         FLAGS['LINK_LOGIN_ENABLED'][0]['value']):
     raise ImproperlyConfigured(
         'LINK_LOGIN_ENABLED should only be enabled when SSO_ENABLED is '
         'enabled.')
+if FLAGS['DEV_AUTH_ENABLED'][0]['value'] and not DEBUG:
+    raise ImproperlyConfigured(
+        'DEV_AUTH_ENABLED must not be enabled when DEBUG is False.')
 
 #------------------------------------------------------------------------------
 # Plugin: departments

--- a/coldfront/core/user/templates/user/dev_login.html
+++ b/coldfront/core/user/templates/user/dev_login.html
@@ -1,0 +1,66 @@
+{% extends "common/base.html" %}
+
+{% block title %}Dev Login{% endblock %}
+
+{% block head %}
+{{ block.super }}
+{% include "common/selectize.html" %}
+{% endblock %}
+
+{% block content %}
+
+<h1>Dev Login</h1>
+
+<div class="alert alert-warning" role="alert">
+  <strong>Development mode only.</strong> This login page bypasses
+  authentication. It is not available in production.
+</div>
+
+<div class="row mt-3">
+  <div class="col-md-6">
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title">Log in as</h5>
+        <form method="post">
+          {% csrf_token %}
+          {% if next %}
+            <input type="hidden" name="next" value="{{ next }}">
+          {% endif %}
+          <div class="form-group">
+            <select name="user_id" id="dev-user-select"
+                    class="form-control">
+              <option value=""></option>
+              {% for user in users %}
+                <option value="{{ user.pk }}">
+                  {{ user.username }}
+                  {% if user.get_full_name %}
+                    — {{ user.get_full_name }}
+                  {% endif %}
+                </option>
+              {% endfor %}
+            </select>
+          </div>
+          <button type="submit" class="btn btn-primary">
+            <i class="fas fa-sign-in-alt" aria-hidden="true"></i>
+            Log In
+          </button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block javascript %}
+{{ block.super }}
+<script>
+  $("#navbar-main > ul > li.active").removeClass("active");
+  $("#navbar-home").addClass("active");
+  $("#dev-user-select").selectize({
+    create: false,
+    sortField: 'text',
+    placeholder: 'Type to search users\u2026'
+  });
+</script>
+{% endblock %}

--- a/coldfront/core/user/tests/test_views/test_dev_login_views.py
+++ b/coldfront/core/user/tests/test_views/test_dev_login_views.py
@@ -1,0 +1,106 @@
+from copy import deepcopy
+from http import HTTPStatus
+
+from django.conf import settings
+from django.contrib.auth import get_user
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.urls import reverse
+
+from flags.state import flag_enabled
+
+from coldfront.core.utils.tests.test_base import TestBase
+
+
+FLAGS_COPY = deepcopy(settings.FLAGS)
+FLAGS_COPY['DEV_AUTH_ENABLED'] = [{'condition': 'boolean', 'value': True}]
+FLAGS_COPY['SSO_ENABLED'] = [{'condition': 'boolean', 'value': False}]
+
+
+@override_settings(FLAGS=FLAGS_COPY)
+class TestDevLoginView(TestBase):
+    """Tests for DevLoginView: the dev-only passwordless user picker."""
+
+    def setUp(self):
+        super().setUp()
+        self.active_user = User.objects.create_user(
+            username='active_user',
+            email='active@example.com',
+            is_active=True)
+        self.inactive_user = User.objects.create_user(
+            username='inactive_user',
+            email='inactive@example.com',
+            is_active=False)
+
+    @staticmethod
+    def _url():
+        return reverse('dev-login')
+
+    # --- flag state ---
+
+    def test_expected_flags_enabled(self):
+        """DEV_AUTH_ENABLED is on and SSO_ENABLED is off for this test class."""
+        self.assertTrue(flag_enabled('DEV_AUTH_ENABLED'))
+        self.assertFalse(flag_enabled('SSO_ENABLED'))
+
+    # --- GET ---
+
+    def test_get_returns_200(self):
+        """GET returns 200 for an anonymous user."""
+        response = self.client.get(self._url())
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+    def test_get_lists_only_active_users(self):
+        """GET includes active users and excludes inactive users in context."""
+        response = self.client.get(self._url())
+        usernames = [u.username for u in response.context['users']]
+        self.assertIn('active_user', usernames)
+        self.assertNotIn('inactive_user', usernames)
+
+    def test_get_passes_next_to_context(self):
+        """GET with ?next passes the value into the template context."""
+        next_url = '/some/path/'
+        response = self.client.get(f'{self._url()}?next={next_url}')
+        self.assertEqual(response.context['next'], next_url)
+
+    def test_authenticated_user_redirected_to_home_on_get(self):
+        """An authenticated user hitting GET is redirected to home."""
+        self.client.force_login(self.active_user)
+        response = self.client.get(self._url())
+        self.assertRedirects(response, reverse('home'))
+
+    def test_authenticated_user_redirected_to_next_on_get(self):
+        """An authenticated user hitting GET with ?next is redirected to next."""
+        self.client.force_login(self.active_user)
+        next_url = '/some/path/'
+        response = self.client.get(f'{self._url()}?next={next_url}')
+        self.assertRedirects(response, next_url, fetch_redirect_response=False)
+
+    # --- POST ---
+
+    def test_post_logs_in_user_and_redirects_home(self):
+        """POST with a valid user_id logs the user in and redirects to home."""
+        response = self.client.post(self._url(), {'user_id': self.active_user.pk})
+        self.assertRedirects(response, reverse('home'))
+        client_user = get_user(self.client)
+        self.assertTrue(client_user.is_authenticated)
+        self.assertEqual(client_user.pk, self.active_user.pk)
+
+    def test_post_redirects_to_next_after_login(self):
+        """POST with a valid user_id and next param redirects to next."""
+        next_url = '/some/path/'
+        data = {'user_id': self.active_user.pk, 'next': next_url}
+        response = self.client.post(self._url(), data)
+        self.assertRedirects(response, next_url, fetch_redirect_response=False)
+        self.assertTrue(get_user(self.client).is_authenticated)
+
+    # --- flag-disabled guard ---
+
+    def test_url_returns_404_when_flag_disabled(self):
+        """The dev-login URL returns 404 when DEV_AUTH_ENABLED is False."""
+        flags = deepcopy(settings.FLAGS)
+        flags['DEV_AUTH_ENABLED'] = [{'condition': 'boolean', 'value': False}]
+        with override_settings(FLAGS=flags):
+            self.assertFalse(flag_enabled('DEV_AUTH_ENABLED'))
+            response = self.client.get(self._url())
+            self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)

--- a/coldfront/core/user/tests/test_views/test_user_login_view.py
+++ b/coldfront/core/user/tests/test_views/test_user_login_view.py
@@ -1,0 +1,128 @@
+from copy import deepcopy
+
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import override_settings
+from django.urls import reverse
+
+from flags.state import flag_enabled
+
+from coldfront.core.utils.tests.test_base import TestBase
+
+
+_DEV_FLAGS = deepcopy(settings.FLAGS)
+_DEV_FLAGS['DEV_AUTH_ENABLED'] = [{'condition': 'boolean', 'value': True}]
+_DEV_FLAGS['SSO_ENABLED'] = [{'condition': 'boolean', 'value': False}]
+_DEV_FLAGS['BASIC_AUTH_ENABLED'] = [{'condition': 'boolean', 'value': False}]
+
+_BASIC_FLAGS = deepcopy(settings.FLAGS)
+_BASIC_FLAGS['BASIC_AUTH_ENABLED'] = [{'condition': 'boolean', 'value': True}]
+_BASIC_FLAGS['SSO_ENABLED'] = [{'condition': 'boolean', 'value': False}]
+_BASIC_FLAGS['DEV_AUTH_ENABLED'] = [{'condition': 'boolean', 'value': False}]
+
+_SSO_FLAGS = deepcopy(settings.FLAGS)
+_SSO_FLAGS['SSO_ENABLED'] = [{'condition': 'boolean', 'value': True}]
+_SSO_FLAGS['BASIC_AUTH_ENABLED'] = [{'condition': 'boolean', 'value': False}]
+_SSO_FLAGS['DEV_AUTH_ENABLED'] = [{'condition': 'boolean', 'value': False}]
+
+
+class _UserLoginViewBase(TestBase):
+    """Shared helpers for UserLoginView test classes."""
+
+    @staticmethod
+    def _url():
+        return reverse('login')
+
+
+@override_settings(FLAGS=_DEV_FLAGS)
+class TestUserLoginViewDevAuth(_UserLoginViewBase):
+    """UserLoginView routing when DEV_AUTH_ENABLED is True."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(username='user', is_active=True)
+
+    def test_expected_flags(self):
+        """Sanity: correct flag state for this class."""
+        self.assertTrue(flag_enabled('DEV_AUTH_ENABLED'))
+        self.assertFalse(flag_enabled('SSO_ENABLED'))
+        self.assertFalse(flag_enabled('BASIC_AUTH_ENABLED'))
+
+    def test_anonymous_redirected_to_dev_login(self):
+        """Anonymous request is routed to the dev login page."""
+        response = self.client.get(self._url())
+        self.assertRedirects(
+            response, reverse('dev-login'), fetch_redirect_response=False)
+
+    def test_next_forwarded_to_dev_login(self):
+        """A ?next= parameter is preserved in the redirect to dev login."""
+        next_url = '/some/path/'
+        response = self.client.get(f'{self._url()}?next={next_url}')
+        expected = f'{reverse("dev-login")}?next={next_url}'
+        self.assertRedirects(
+            response, expected, fetch_redirect_response=False)
+
+    def test_authenticated_user_redirected_to_home(self):
+        """An authenticated user is redirected to home regardless of flag."""
+        self.client.force_login(self.user)
+        response = self.client.get(self._url())
+        self.assertRedirects(response, reverse('home'))
+
+    def test_authenticated_user_redirected_to_next(self):
+        """An authenticated user with ?next= is redirected to next."""
+        self.client.force_login(self.user)
+        next_url = '/some/path/'
+        response = self.client.get(f'{self._url()}?next={next_url}')
+        self.assertRedirects(
+            response, next_url, fetch_redirect_response=False)
+
+
+@override_settings(FLAGS=_BASIC_FLAGS)
+class TestUserLoginViewBasicAuth(_UserLoginViewBase):
+    """UserLoginView routing when BASIC_AUTH_ENABLED is True."""
+
+    def test_expected_flags(self):
+        """Sanity: correct flag state for this class."""
+        self.assertTrue(flag_enabled('BASIC_AUTH_ENABLED'))
+        self.assertFalse(flag_enabled('SSO_ENABLED'))
+        self.assertFalse(flag_enabled('DEV_AUTH_ENABLED'))
+
+    def test_anonymous_redirected_to_basic_auth_login(self):
+        """Anonymous request is routed to the basic auth login page."""
+        response = self.client.get(self._url())
+        self.assertRedirects(
+            response, reverse('basic-auth-login'),
+            fetch_redirect_response=False)
+
+    def test_next_forwarded_to_basic_auth_login(self):
+        """A ?next= parameter is preserved in the redirect to basic auth."""
+        next_url = '/some/path/'
+        response = self.client.get(f'{self._url()}?next={next_url}')
+        expected = f'{reverse("basic-auth-login")}?next={next_url}'
+        self.assertRedirects(
+            response, expected, fetch_redirect_response=False)
+
+
+@override_settings(FLAGS=_SSO_FLAGS)
+class TestUserLoginViewSSO(_UserLoginViewBase):
+    """UserLoginView routing when SSO_ENABLED is True."""
+
+    def test_expected_flags(self):
+        """Sanity: correct flag state for this class."""
+        self.assertTrue(flag_enabled('SSO_ENABLED'))
+        self.assertFalse(flag_enabled('BASIC_AUTH_ENABLED'))
+        self.assertFalse(flag_enabled('DEV_AUTH_ENABLED'))
+
+    def test_anonymous_redirected_to_sso_login(self):
+        """Anonymous request is routed to the SSO login page."""
+        response = self.client.get(self._url())
+        self.assertRedirects(
+            response, reverse('sso-login'), fetch_redirect_response=False)
+
+    def test_next_forwarded_to_sso_login(self):
+        """A ?next= parameter is preserved in the redirect to SSO login."""
+        next_url = '/some/path/'
+        response = self.client.get(f'{self._url()}?next={next_url}')
+        expected = f'{reverse("sso-login")}?next={next_url}'
+        self.assertRedirects(
+            response, expected, fetch_redirect_response=False)

--- a/coldfront/core/user/urls.py
+++ b/coldfront/core/user/urls.py
@@ -103,6 +103,13 @@ if 'coldfront.plugins.departments' in settings.INSTALLED_APPS:
             include('coldfront.plugins.departments.urls')))
 
 
+with flagged_paths('DEV_AUTH_ENABLED') as f_path:
+    urlpatterns += [
+        f_path('dev_login/',
+               user_views.DevLoginView.as_view(),
+               name='dev-login'),
+    ]
+
 with flagged_paths('SSO_ENABLED') as f_path:
     urlpatterns += [
         f_path('sso_login/',

--- a/coldfront/core/user/views.py
+++ b/coldfront/core/user/views.py
@@ -1,6 +1,7 @@
 import logging
 
 from django.contrib import messages
+from django.contrib.auth import get_user_model, login
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.contrib.auth.models import User
@@ -585,9 +586,9 @@ class CustomPasswordChangeView(PasswordChangeView):
 
 
 class UserLoginView(View):
-    """Redirect to the Basic Auth. login view or the SSO login view
-    based on enabled flags, retaining any provided next URL. If the user
-    is authenticated, redirect to the next URL or the home page."""
+    """Redirect to the appropriate login view based on enabled flags,
+    retaining any provided next URL. If the user is authenticated,
+    redirect to the next URL or the home page."""
 
     def dispatch(self, request, *args, **kwargs):
         next_url = request.GET.get('next')
@@ -595,13 +596,9 @@ class UserLoginView(View):
         if request.user.is_authenticated:
             return redirect(next_url or reverse('home'))
 
-        basic_auth_enabled = flag_enabled('BASIC_AUTH_ENABLED')
-        sso_enabled = flag_enabled('SSO_ENABLED')
-        if not basic_auth_enabled ^ sso_enabled:
-            raise ImproperlyConfigured(
-                'One of the following flags must be enabled: '
-                'BASIC_AUTH_ENABLED, SSO_ENABLED.')
-        if basic_auth_enabled:
+        if flag_enabled('DEV_AUTH_ENABLED'):
+            redirect_url = reverse('dev-login')
+        elif flag_enabled('BASIC_AUTH_ENABLED'):
             redirect_url = reverse('basic-auth-login')
         else:
             redirect_url = reverse('sso-login')
@@ -637,6 +634,33 @@ class SSOLoginView(TemplateView):
             raise ImproperlyConfigured(
                 'One of the following flags must be enabled: BRC_ONLY, '
                 'LRC_ONLY.')
+
+
+class DevLoginView(View):
+    """Dev-only login view. Lists all active users and logs in the
+    selected one without a password. Only reachable when
+    DEV_AUTH_ENABLED is set."""
+
+    template_name = 'user/dev_login.html'
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.user.is_authenticated:
+            return redirect(
+                request.GET.get('next') or reverse('home'))
+        return super().dispatch(request, *args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        users = get_user_model().objects.filter(
+            is_active=True).order_by('username')
+        return render(
+            request, self.template_name,
+            {'users': users, 'next': request.GET.get('next', '')})
+
+    def post(self, request, *args, **kwargs):
+        user = get_user_model().objects.get(pk=request.POST['user_id'])
+        login(request, user,
+              backend='django.contrib.auth.backends.AllowAllUsersModelBackend')
+        return redirect(request.POST.get('next') or reverse('home'))
 
 
 class UserRegistrationView(CreateView):


### PR DESCRIPTION
## Summary
- Added `DEV_AUTH_ENABLED` as a third auth mode: a dev-only login page that lets developers switch to any active user without a password
- Enabled by default in the Docker dev environment; blocked at startup if `DEBUG` is `False`
- Added Ansible variable for production deployments (defaults to `False`)

## Testing
- Run the existing Django test suite for the user app: `python manage.py test coldfront.core.user`
- Start the BRC or LRC Docker dev stack and navigate to `/user/login/` — confirm it redirects to `/user/dev_login/`
- Verify the dev login page shows a searchable selectize dropdown of active users
- Select a user, click Log In, and confirm you are logged in as that user
- Confirm `/user/dev_login/` returns 404 when `DEV_AUTH_ENABLED` is not set

## Notes
- Does not exercise the real OIDC flow; intended as a local development shortcut only