### PR TITLE
chore(docker): add Makefile wrapper for docker compose commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+local.mk
 *.py[cod]
 *.swp
 coldfront.egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,44 @@
+# Per-clone overrides (gitignored). Create with: echo "PROJECT := brc-dev" > local.mk
+-include local.mk
+
+# Fallback if local.mk doesn't set PROJECT
+PROJECT ?= brc-dev
+
+COMPOSE_FILE = bootstrap/development/docker/docker-compose.yml
+COMPOSE      = docker compose -f $(COMPOSE_FILE) -p $(PROJECT)
+
+.PHONY: up up-d down restart logs shell db-shell setup build load-db help
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
+	  | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-12s %s\n", $$1, $$2}'
+
+up: ## Start the stack (foreground)
+	$(COMPOSE) up
+
+up-d: ## Start the stack (detached)
+	$(COMPOSE) up -d
+
+down: ## Stop and remove containers
+	$(COMPOSE) down
+
+restart: ## Restart all services
+	$(COMPOSE) restart
+
+logs: ## Tail logs for all services
+	$(COMPOSE) logs -f
+
+shell: ## Shell into the app-shell container
+	$(COMPOSE) exec app-shell bash
+
+db-shell: ## Shell into the db-postgres-shell container
+	$(COMPOSE) exec db-postgres-shell bash
+
+setup: ## Run Django setup scripts (migrate, initial_setup, etc.)
+	sh bootstrap/development/docker/scripts/docker_run_django_scripts.sh $(PROJECT)
+
+build: ## Build Docker images  (optional: make build TAG=my-tag)
+	sh bootstrap/development/docker/scripts/build_images.sh $(TAG)
+
+load-db: ## Load a DB dump  (usage: make load-db DUMP=YYYY_MM_DD-HH-MM.dump)
+	sh bootstrap/development/docker/scripts/docker_load_database_backup.sh $(PROJECT) $(DUMP)

--- a/bootstrap/development/docker/README.md
+++ b/bootstrap/development/docker/README.md
@@ -65,6 +65,7 @@ Note that these steps must be run from the root directory of the repo.
    Notes:
      - Some services (e.g., `web`) are expected to be failing at this point.
      - If the `IMAGE_TAG` environment variable is set, Docker Compose will use images with the specified tag.
+     - To persist the project name across sessions (required for non-BRC deployments), create a gitignored `local.mk` in the repo root: `echo "PROJECT := lrc-dev" > local.mk`.
 
 7. Run Django scripts to set up the database and perform other tasks.
 

--- a/bootstrap/development/docker/README.md
+++ b/bootstrap/development/docker/README.md
@@ -5,11 +5,11 @@ Note that these steps must be run from the root directory of the repo.
 1. Build Docker images.
 
    ```bash
-   sh bootstrap/development/docker/scripts/build_images.sh
+   make build
    ```
 
    Notes:
-      - An optional argument may be specified to build the images with a specific tag. This may be useful for testing updated images (e.g., from different branches) without overriding existing images.
+      - An optional tag may be specified to avoid overriding existing images (e.g., when testing images from a different branch): `make build TAG=my-tag`.
 
 2. Retrieve a `cilogon.yml` file containing CILogon credentials that will be provided for you. Place it in the Docker configuration directory.
 
@@ -56,34 +56,29 @@ Note that these steps must be run from the root directory of the repo.
      - `docker-compose.yml` looks for a `.env` file in the same directory it resides in. This script creates `.env` there.
      - There is an optional third argument that configures whether the application expects `env_settings.py` or a legacy pre-generated Python settings file. By default, `env_settings.py` is used, but this can be overridden by providing `false` as a third argument. (Eventually, this will be removed.)
 
-6. Start the application stack. Specify a unique Docker [project name](https://docs.docker.com/compose/project-name/) so that resources are placed within a Docker namespace. Examples: "brc-dev", "lrc-dev".
+6. Start the application stack. The default project name is `brc-dev`; override with `PROJECT=lrc-dev` for an LRC instance or a second parallel stack.
 
    ```bash
-   export DOCKER_PROJECT_NAME=brc-dev
-   docker compose \
-       -f bootstrap/development/docker/docker-compose.yml \
-       -p $DOCKER_PROJECT_NAME \
-       up
+   make up
    ```
 
    Notes:
      - Some services (e.g., `web`) are expected to be failing at this point.
      - If the `IMAGE_TAG` environment variable is set, Docker Compose will use images with the specified tag.
 
-7. Run Django scripts to set up the database and perform other tasks. You must provide the name of your Docker project.
+7. Run Django scripts to set up the database and perform other tasks.
 
    ```bash
-   sh bootstrap/development/docker/scripts/docker_run_django_scripts.sh $DOCKER_PROJECT_NAME
+   make setup
    ```
 
    Notes:
      - This step may be run multiple times.
 
-8. Retrieve a PostgreSQL database dump file that will be provided for you. Place it in the root directory of the repo. Load it into your instance. You must provide the name of your Docker project.
+8. Retrieve a PostgreSQL database dump file that will be provided for you. Place it in the root directory of the repo. Load it into your instance.
 
    ```bash
-   export RELATIVE_CONTAINER_DUMP_FILE_PATH=YYYY_MM_DD-HH-MM.dump
-   sh bootstrap/development/docker/scripts/docker_load_database_backup.sh $DOCKER_PROJECT_NAME $RELATIVE_CONTAINER_DUMP_FILE_PATH
+   make load-db DUMP=YYYY_MM_DD-HH-MM.dump
    ```
 
    Notes:
@@ -100,7 +95,7 @@ Note that these steps must be run from the root directory of the repo.
     - Enter into the application shell container:
 
          ```bash
-         docker compose -p $DOCKER_PROJECT_NAME exec app-shell bash
+         make shell
          ```
 
     - From within the container, start a Django shell:


### PR DESCRIPTION
## Summary

- Added `Makefile` at repo root wrapping the repetitive `docker compose -f … -p …` flags into short targets (`up`, `down`, `logs`, `shell`, `db-shell`, `setup`, `build`, `load-db`)
- Updated `bootstrap/development/docker/README.md` to use `make` commands throughout
- Added `local.mk` to `.gitignore` to support per-clone project name persistence

## Testing

- N/A — no production code changed; verify manually with `make help` from repo root

## Notes

- `local.mk` (gitignored) persists the Docker project name across sessions: `echo "PROJECT := brc-dev" > local.mk`; defaults to `brc-dev` if absent
- Project name can still be overridden per-invocation: `make up PROJECT=lrc-dev`
- `make build TAG=my-tag` passes a custom image tag through to `build_images.sh`