### PR TITLE
chore: make email backend and credentials configurable via env

### DIFF
--- a/bootstrap/ansible/.env.tmpl
+++ b/bootstrap/ansible/.env.tmpl
@@ -41,7 +41,7 @@ DJANGO__EMAIL_HOST_PASSWORD={{ email_host_password | default('') }}
 DJANGO__EMAIL_SUBJECT_PREFIX={{ email_subject_prefix }}
 
 COLDFRONT__EMAIL_SENDER={{ from_email }}
-COLDFRONT__EMAIL_TICKET_SYSTEM_ADDRESS=help@{{ hostname }}
+COLDFRONT__EMAIL_TICKET_SYSTEM_ADDRESS={{ email_ticket_system_address | default('help@' + hostname) }}
 COLDFRONT__EMAIL_DIRECTOR_EMAIL_ADDRESS=director@{{ hostname }}
 COLDFRONT__EMAIL_PROJECT_REVIEW_CONTACT=review@{{ hostname }}
 

--- a/bootstrap/ansible/.env.tmpl
+++ b/bootstrap/ansible/.env.tmpl
@@ -32,8 +32,12 @@ COLDFRONT__CENTER_HELP_EMAIL={{ center_help_email }}
 # Email Configuration
 # -----------------------------------------------------------------------------
 
+DJANGO__EMAIL_BACKEND={{ email_backend }}
 DJANGO__EMAIL_HOST={{ email_host }}
 DJANGO__EMAIL_PORT={{ email_port }}
+DJANGO__EMAIL_USE_TLS={{ email_use_tls | default(false) | lower }}
+DJANGO__EMAIL_HOST_USER={{ email_host_user | default('') }}
+DJANGO__EMAIL_HOST_PASSWORD={{ email_host_password | default('') }}
 DJANGO__EMAIL_SUBJECT_PREFIX={{ email_subject_prefix }}
 
 COLDFRONT__EMAIL_SENDER={{ from_email }}

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -475,9 +475,11 @@ sentry_dsn: ""
 # email_host_user:
 # email_host_password:
 # # TODO: Set these addresses to yours.
-# TODO: For LRC, use mylrc@lbl.gov.
+# # TODO: For LRC, use mylrc@lbl.gov.
 # from_email: brc-mybrc@berkeley.edu
 # admin_email: brc-mybrc@berkeley.edu
+# # TODO: For LRC, use scienceithelp@lbl.gov.
+# email_ticket_system_address: brc-hpc-help@berkeley.edu
 # # TODO: For LRC, use the substring 'MyLRC'.
 # email_subject_prefix: '[MyBRC-User-Portal]'
 
@@ -529,18 +531,20 @@ sentry_dsn: ""
 
 # # Email settings.
 # email_backend: django.core.mail.backends.smtp.EmailBackend
-# For LRC: Use smtp-relay.gmail.com.
+# # For LRC: Use smtp-relay.gmail.com.
 # email_host: smtp.gmail.com
 # email_port: 587
 # email_use_tls: true
 # # Optional: set for authenticated SMTP.
-# TODO: For LRC, leave these blank.
+# # TODO: For LRC, leave these blank.
 # email_host_user: brc-mybrc@berkeley.edu
 # email_host_password:
 # # TODO: Set these addresses to yours.
-# TODO: For LRC, use mylrc@lbl.gov.
+# # TODO: For LRC, use mylrc@lbl.gov.
 # from_email: brc-mybrc@berkeley.edu
 # admin_email: brc-mybrc@berkeley.edu
+# # TODO: For LRC, use scienceithelp@lbl.gov.
+# email_ticket_system_address: brc-hpc-help@berkeley.edu
 # # TODO: For LRC, use the substring 'MyLRC'.
 # email_subject_prefix: '[MyBRC-User-Portal]'
 
@@ -600,6 +604,7 @@ sentry_dsn: ""
 # email_host_password:
 # from_email: placeholder@dev.dev
 # admin_email: placeholder@dev.dev
+# email_ticket_system_address: help@localhost
 # # TODO: For LRC, use the substring 'MyLRC'.
 # email_subject_prefix: '[MyBRC-User-Portal]'
 

--- a/bootstrap/ansible/main.copyme
+++ b/bootstrap/ansible/main.copyme
@@ -446,11 +446,11 @@ sentry_dsn: ""
 # git_prefix: /var/www/coldfront_app
 
 # # Host settings.
-# hostname: scgup-dev.lbl.gov
-# host_ip: 131.243.130.236
+# hostname:
+# host_ip:
 # extra_allowed_hosts: []
-# app_port: 8000
-# full_host_path: http://scgup-dev.lbl.gov:8000
+# app_port:
+# full_host_path:
 
 # # SSL settings.
 # ssl_enabled: false
@@ -467,11 +467,17 @@ sentry_dsn: ""
 # debug_toolbar_ips: ['127.0.0.1']
 
 # # Email settings.
+# email_backend: django.core.mail.backends.dummy.EmailBackend
 # email_host: localhost
 # email_port: 25
+# email_use_tls: false
+# # Optional: set for authenticated SMTP.
+# email_host_user:
+# email_host_password:
 # # TODO: Set these addresses to yours.
-# from_email: brc-hpc-help@berkeley.edu
-# admin_email: brc-hpcs@berkeley.edu
+# TODO: For LRC, use mylrc@lbl.gov.
+# from_email: brc-mybrc@berkeley.edu
+# admin_email: brc-mybrc@berkeley.edu
 # # TODO: For LRC, use the substring 'MyLRC'.
 # email_subject_prefix: '[MyBRC-User-Portal]'
 
@@ -522,11 +528,19 @@ sentry_dsn: ""
 # debug_toolbar_ips: ['127.0.0.1']
 
 # # Email settings.
-# email_host: localhost
-# email_port: 25
+# email_backend: django.core.mail.backends.smtp.EmailBackend
+# For LRC: Use smtp-relay.gmail.com.
+# email_host: smtp.gmail.com
+# email_port: 587
+# email_use_tls: true
+# # Optional: set for authenticated SMTP.
+# TODO: For LRC, leave these blank.
+# email_host_user: brc-mybrc@berkeley.edu
+# email_host_password:
 # # TODO: Set these addresses to yours.
-# from_email: brc-hpc-help@berkeley.edu
-# admin_email: brc-hpcs@berkeley.edu
+# TODO: For LRC, use mylrc@lbl.gov.
+# from_email: brc-mybrc@berkeley.edu
+# admin_email: brc-mybrc@berkeley.edu
 # # TODO: For LRC, use the substring 'MyLRC'.
 # email_subject_prefix: '[MyBRC-User-Portal]'
 
@@ -577,8 +591,13 @@ sentry_dsn: ""
 # debug_toolbar_ips: ['127.0.0.1', '10.0.2.2']  # 10.0.2.2 is the vagrant host.
 
 # # Email settings.
+# email_backend: django.core.mail.backends.smtp.EmailBackend
 # email_host: localhost
 # email_port: 1025
+# email_use_tls: false
+# # Optional: set for authenticated SMTP.
+# email_host_user:
+# email_host_password:
 # from_email: placeholder@dev.dev
 # admin_email: placeholder@dev.dev
 # # TODO: For LRC, use the substring 'MyLRC'.

--- a/bootstrap/ci/config/ci_overrides.yml
+++ b/bootstrap/ci/config/ci_overrides.yml
@@ -4,6 +4,7 @@
 
 # Database and service hosts for CI environment (running on localhost)
 db_host: localhost
+email_backend: django.core.mail.backends.dummy.EmailBackend
 email_host: localhost
 redis_host: localhost
 

--- a/bootstrap/development/docker/config/docker_defaults.yml
+++ b/bootstrap/development/docker/config/docker_defaults.yml
@@ -1,8 +1,10 @@
 debug: True
 
 db_host: db-postgres
+email_backend: django.core.mail.backends.smtp.EmailBackend
 email_host: email-server
 email_port: 1025
+email_use_tls: false
 redis_host: kv
 
 stream_logs_to_stdout: true

--- a/bootstrap/development/docker/config/docker_defaults.yml
+++ b/bootstrap/development/docker/config/docker_defaults.yml
@@ -21,6 +21,7 @@ extra_allowed_hosts:
 
 from_email: developer@localhost
 admin_email: developer@localhost
+email_ticket_system_address: help@localhost
 allocation_period_audit_email_admin_list: ['developer@localhost']
 
 renewal_survey_backend: 'permissive'

--- a/coldfront/config/env_settings.py
+++ b/coldfront/config/env_settings.py
@@ -40,8 +40,21 @@ CENTER_BASE_URL = env('COLDFRONT__CENTER_BASE_URL', default='')
 CENTER_HELP_URL = CENTER_BASE_URL + '/help'
 CENTER_PROJECT_RENEWAL_HELP_URL = CENTER_BASE_URL + '/help'
 
+EMAIL_BACKEND = env(
+    'DJANGO__EMAIL_BACKEND',
+    default='django.core.mail.backends.smtp.EmailBackend')
 EMAIL_HOST = env('DJANGO__EMAIL_HOST')
+_email_host_user = env('DJANGO__EMAIL_HOST_USER', default=None)
+_email_host_password = env('DJANGO__EMAIL_HOST_PASSWORD', default=None)
+if (_email_host_user is None) != (_email_host_password is None):
+    raise ImproperlyConfigured(
+        'DJANGO__EMAIL_HOST_USER and DJANGO__EMAIL_HOST_PASSWORD must '
+        'both be set or both be unset.')
+if _email_host_user is not None:
+    EMAIL_HOST_USER = _email_host_user
+    EMAIL_HOST_PASSWORD = _email_host_password
 EMAIL_PORT = env.int('DJANGO__EMAIL_PORT')
+EMAIL_USE_TLS = env.bool('DJANGO__EMAIL_USE_TLS', default=False)
 EMAIL_SUBJECT_PREFIX = env('DJANGO__EMAIL_SUBJECT_PREFIX')
 # A list of admin email addresses to be notified about new requests and other
 # events.
@@ -67,6 +80,7 @@ EMAIL_OPT_OUT_INSTRUCTION_URL = CENTER_BASE_URL + '/optout'
 EMAIL_SIGNATURE = env('COLDFRONT__EMAIL_SIGNATURE').replace('\\n', '\n')
 
 EMAIL_FROM = env('HPCS__EMAIL_FROM')
+# TODO: EMAIL_ADMIN is not in use. It can be removed.
 EMAIL_ADMIN = env('HPCS__EMAIL_ADMIN')
 DEFAULT_FROM_EMAIL = EMAIL_FROM
 

--- a/coldfront/core/utils/mail.py
+++ b/coldfront/core/utils/mail.py
@@ -14,6 +14,8 @@ if EMAIL_ENABLED:
     EMAIL_SUBJECT_PREFIX = import_from_settings('EMAIL_SUBJECT_PREFIX')
     EMAIL_DEVELOPMENT_EMAIL_LIST = import_from_settings(
         'EMAIL_DEVELOPMENT_EMAIL_LIST')
+    EMAIL_TICKET_SYSTEM_ADDRESS = import_from_settings(
+        'EMAIL_TICKET_SYSTEM_ADDRESS', '')
 
 
 def send_email(subject, body, sender, receiver_list, cc=[], html_body=''):
@@ -40,13 +42,16 @@ def send_email(subject, body, sender, receiver_list, cc=[], html_body=''):
     if cc and settings.DEBUG:
         cc = EMAIL_DEVELOPMENT_EMAIL_LIST
 
+    reply_to = [EMAIL_TICKET_SYSTEM_ADDRESS] if EMAIL_TICKET_SYSTEM_ADDRESS else []
+
     try:
         email = EmailMultiAlternatives(
             subject,
             body,
             sender,
             receiver_list,
-            cc=cc)
+            cc=cc,
+            reply_to=reply_to)
         if html_body:
             email.attach_alternative(html_body, "text/html")
         email.send(fail_silently=False)


### PR DESCRIPTION
## Summary

- Added `DJANGO__EMAIL_BACKEND` environment variable to control the Django email backend; defaults to `smtp.EmailBackend` for backward compatibility with existing deployments
- Added `DJANGO__EMAIL_USE_TLS`, `DJANGO__EMAIL_HOST_USER`, and `DJANGO__EMAIL_HOST_PASSWORD` environment variables to the Ansible template and all deployment config sections
- Enforced that `EMAIL_HOST_USER` and `EMAIL_HOST_PASSWORD` must both be set or both be unset, raising `ImproperlyConfigured` at startup otherwise
- Set dummy email backend for staging (`main.copyme`) and CI (`ci_overrides.yml`) to prevent bounced emails and SMTP connection failures in non-production environments
- Set SMTP backend for Docker dev (pointing at MailHog) and prod
- Added `Reply-To` header pointing to `EMAIL_TICKET_SYSTEM_ADDRESS` on all outgoing application emails via `send_email()`
- Made `email_ticket_system_address` an explicit Ansible variable in `.env.tmpl` (previously hardcoded to `help@<hostname>`), with the hostname-derived value as a fallback for existing deployments

## Testing

- Verify existing deployments that do not set `DJANGO__EMAIL_BACKEND` continue to use SMTP unchanged
- Set only one of `DJANGO__EMAIL_HOST_USER` / `DJANGO__EMAIL_HOST_PASSWORD` and confirm `ImproperlyConfigured` is raised at startup
- Send an email through the application and confirm the `Reply-To` header is set to the configured ticket system address
- Run CI to confirm no email-related failures in the test suite

## Notes

- `EMAIL_ADMIN` in `env_settings.py` is unused; cleanup deferred to a follow-up (TODO comment added)
- The allauth email verification path and Django password reset path bypass `send_email()` and do not include `Reply-To`; this is acceptable since replies to those emails are not expected