### PR TITLE
chore(docker): parameterize MailHog UI port for multi-stack support

### DIFF
--- a/bootstrap/development/docker/README.md
+++ b/bootstrap/development/docker/README.md
@@ -54,6 +54,7 @@ Note that these steps must be run from the root directory of the repo.
 
    Notes:
      - `docker-compose.yml` looks for a `.env` file in the same directory it resides in. This script creates `.env` there.
+     - The MailHog web UI port is derived from the web port (e.g., 8880 → 8025, 8881 → 8026). Access it at `http://localhost:MAILHOG_PORT`.
      - There is an optional third argument that configures whether the application expects `env_settings.py` or a legacy pre-generated Python settings file. By default, `env_settings.py` is used, but this can be overridden by providing `false` as a third argument. (Eventually, this will be removed.)
 
 6. Start the application stack. The default project name is `brc-dev`; override with `PROJECT=lrc-dev` for an LRC instance or a second parallel stack.

--- a/bootstrap/development/docker/docker-compose.yml
+++ b/bootstrap/development/docker/docker-compose.yml
@@ -27,8 +27,7 @@ services:
   email-server:
     image: mailhog/mailhog
     ports:
-      - "1025:1025"
-      - "8025:8025"
+      - "${MAILHOG_PORT:-8025}:8025"
 
   db-postgres-shell:
     image: coldfront-db-postgres-shell:${IMAGE_TAG:-latest}

--- a/bootstrap/development/docker/scripts/create_docker_compose_env_file.sh
+++ b/bootstrap/development/docker/scripts/create_docker_compose_env_file.sh
@@ -22,5 +22,8 @@ else
     DB_NAME="cf_lrc_db"
 fi
 
+MAILHOG_PORT=$((8025 + PORT - 8880))
+
 echo "DB_NAME=$DB_NAME" > $ENV_FILE_PATH
 echo "WEB_PORT=$PORT" >> $ENV_FILE_PATH
+echo "MAILHOG_PORT=$MAILHOG_PORT" >> $ENV_FILE_PATH


### PR DESCRIPTION
## Summary

- Replaced hardcoded `8025:8025` port mapping in `docker-compose.yml` with `${MAILHOG_PORT:-8025}:8025`; removed the unused `1025:1025` SMTP host mapping (app containers connect to MailHog via Docker service name, not the host port)
- Added `MAILHOG_PORT` derivation to `create_docker_compose_env_file.sh`, offset from the web port slot (8880→8025, 8881→8026, 8882→8027, 8883→8028), so multiple stacks can run concurrently without port conflicts
- Added a note to the Docker README documenting the MailHog UI URL and port derivation

## Testing

- Run `sh bootstrap/development/docker/scripts/create_docker_compose_env_file.sh BRC 8880` and confirm `MAILHOG_PORT=8025` appears in the generated `.env`
- Run with port 8881 and confirm `MAILHOG_PORT=8026`
- Start two stacks on different ports and confirm both come up without port binding errors
- Access the MailHog UI at `http://localhost:MAILHOG_PORT` for each stack

## Notes

- The `:-8025` default in `docker-compose.yml` means existing `.env` files without `MAILHOG_PORT` continue to work unchanged