### PR TITLE
chore: bump idna from 3.10 to 3.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ drf-nested-routers==0.95.0
 drf-yasg==1.21.15
 gspread==6.2.1
 humanize==4.15.0
-idna==3.10
+idna==3.15
 iso8601==2.1.0
 ldap3==2.9.1
 mod-wsgi==5.0.2


### PR DESCRIPTION
## Summary

- Bumped `idna` from `3.10` to `3.15` (security: patches CVE-2026-45409, a quadratic-time DoS bypass of the CVE-2024-3651 mitigation)

## Testing

- Rebuild Docker images: `sh bootstrap/development/docker/scripts/build_images.sh`
- Run unit tests: `pytest -m unit`

## Notes

- `idna` is a transitive dependency (pulled in by `requests`/`urllib3`); pinned explicitly due to CVE history