### PR TITLE
fix(statistics): scope PI username dropdown to managed projects only

### DIFF
--- a/coldfront/core/statistics/forms.py
+++ b/coldfront/core/statistics/forms.py
@@ -89,8 +89,13 @@ class JobSearchForm(forms.Form):
                     name__in=active_projects)
 
                 if is_pi:
+                    managed_projects = ProjectUser.objects.filter(
+                        user=user,
+                        role__name__in=['Manager', 'Principal Investigator'],
+                        status__name__in=['Active', 'Pending - Remove'],
+                    ).values_list('project', flat=True)
                     pi_project_users = ProjectUser.objects.filter(
-                        project__in=project_queryset,
+                        project__in=managed_projects,
                         status__name='Active',
                     ).values_list('user', flat=True)
                     user_queryset = User.objects.filter(

--- a/coldfront/core/statistics/tests/test_job_views.py
+++ b/coldfront/core/statistics/tests/test_job_views.py
@@ -11,6 +11,7 @@ from coldfront.core.project.models import *
 from coldfront.core.user.models import UserProfile
 from coldfront.core.utils.common import utc_now_offset_aware
 from coldfront.core.utils.tests.test_base import TestBase
+from coldfront.core.statistics.forms import JobSearchForm
 from coldfront.core.statistics.models import Job
 
 
@@ -317,6 +318,32 @@ class TestSlurmJobListView(TestJobBase):
             self.pi, url + '?show_all_jobs=on')
         self.assertContains(response, self.job1.jobslurmid)
         self.assertNotContains(response, self.job2.jobslurmid)
+
+    def test_pi_username_dropdown_scoped_to_managed_projects(self):
+        """Test that the username dropdown for a PI/Manager only includes
+        users from projects they manage, not from projects where they are
+        only a regular member."""
+        # user3 is only a regular member of project3. manager manages
+        # project1 but is only a regular member of project3.
+        user3 = User.objects.create(
+            username='user3', email='user3@email.com')
+        ProjectUser.objects.create(
+            user=user3,
+            project=self.project3,
+            role=ProjectUserRoleChoice.objects.get(name='User'),
+            status=self.active_project_user_status)
+
+        form = JobSearchForm(user=self.manager, is_pi=True)
+        username_choices = [
+            choice[0]
+            for choice in form.fields['username'].widget.choices]
+
+        # Users from project1 (managed by manager) should appear
+        self.assertIn(self.user1.username, username_choices)
+        self.assertIn(self.pi.username, username_choices)
+        # user3 is only in project3 where manager is a regular member,
+        # not PI/Manager — must not appear in the dropdown
+        self.assertNotIn(user3.username, username_choices)
 
     def test_saves_filters_in_session(self):
         """Testing if cleaned form data is saved in session"""


### PR DESCRIPTION
## Summary

- Fixed the username filter dropdown for PI/Manager users to only include members of projects they manage, not members of all projects they belong to
- Previously, the choices queryset used any active project membership (including projects where the PI is only a regular member), leaking usernames from unmanaged projects into the dropdown
- Updated the choices query to match `JobAccessibilityManager`'s logic: filter by `Manager` or `Principal Investigator` role with `Active` or `Pending - Remove` status

## Testing

- Log in as a user who is PI/Manager of project A and a regular member of project B
- Verify the Username dropdown in the job list filter only shows members of project A
- Verify the user's own jobs from project B still appear (submitted_by_user scoping is unaffected)
- Run `python manage.py test coldfront.core.statistics.tests.test_job_views.TestSlurmJobListView`

## Notes

- This was a regression introduced when the username field was converted from a free-text input to a selectize dropdown in #786
- No change to actual job visibility — `JobAccessibilityManager` was never affected; this is a dropdown content fix only