### PR TITLE
docs(user): update BRC user agreement data ownership and retention section

### DIFF
--- a/coldfront/core/user/templates/user/deployments/brc/user_access_agreement.html
+++ b/coldfront/core/user/templates/user/deployments/brc/user_access_agreement.html
@@ -68,8 +68,11 @@ User Access Agreement
             </td>
           </tr>
           <tr>
-            <th scope="row">Data Retention</th>
+            <th scope="row">Data Ownership and Retention</th>
             <td>
+              <p>
+                As a representative of the university, the <a href="https://policy.ucop.edu/doc/2500700/ResearchData">PI is responsible for data owned by members of their projects</a>. Given this, Savio staff will provide PIs access to the data owned by members of their project(s) and will remove data at the request of the PI.
+              </p>
               <p>
                 When a PI requests that a user account be deleted, all associated permanent files (in home directories and UC Berkeley cluster systems) are deleted.
               </p>


### PR DESCRIPTION
## Summary

- Renamed "Data Retention" to "Data Ownership and Retention" in the BRC user access agreement
- Added paragraph on PI data responsibility, linked to the UC Research Data Policy